### PR TITLE
Hide progress bar when mixer is not running

### DIFF
--- a/ui/page/privacy/account_mixer_page.go
+++ b/ui/page/privacy/account_mixer_page.go
@@ -226,7 +226,7 @@ func (pg *AccountMixerPage) mixerHeaderContent() layout.FlexChild {
 				if !pg.toggleMixer.IsChecked() {
 					return layout.Inset{Top: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
 						return D{}
-					})					
+					})
 				}
 				return layout.UniformInset(values.MarginPadding22).Layout(gtx, func(gtx C) D {
 					return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,

--- a/ui/page/privacy/account_mixer_page.go
+++ b/ui/page/privacy/account_mixer_page.go
@@ -223,6 +223,9 @@ func (pg *AccountMixerPage) mixerHeaderContent() layout.FlexChild {
 				}.Layout(gtx, pg.Theme.Separator().Layout)
 			}),
 			layout.Rigid(func(gtx C) D {
+				if !pg.toggleMixer.IsChecked() {
+					return D{}
+				}
 				return layout.UniformInset(values.MarginPadding22).Layout(gtx, func(gtx C) D {
 					return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,
 						layout.Rigid(func(gtx C) D {

--- a/ui/page/privacy/account_mixer_page.go
+++ b/ui/page/privacy/account_mixer_page.go
@@ -223,7 +223,7 @@ func (pg *AccountMixerPage) mixerHeaderContent() layout.FlexChild {
 				}.Layout(gtx, pg.Theme.Separator().Layout)
 			}),
 			layout.Rigid(func(gtx C) D {
-				if !pg.toggleMixer.IsChecked() {
+				if !pg.dcrImpl.IsAccountMixerActive() {
 					return layout.Inset{Top: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
 						return D{}
 					})

--- a/ui/page/privacy/account_mixer_page.go
+++ b/ui/page/privacy/account_mixer_page.go
@@ -224,7 +224,9 @@ func (pg *AccountMixerPage) mixerHeaderContent() layout.FlexChild {
 			}),
 			layout.Rigid(func(gtx C) D {
 				if !pg.toggleMixer.IsChecked() {
-					return D{}
+					return layout.Inset{Top: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
+						return D{}
+					})					
 				}
 				return layout.UniformInset(values.MarginPadding22).Layout(gtx, func(gtx C) D {
 					return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,


### PR DESCRIPTION
Closes #51.
Hides mixer status bar when the mixer is not activated
![remove mixer bar](https://github.com/crypto-power/cryptopower/assets/54014025/959e9541-3bfa-440d-9804-d519eeb10c49)
