### PR TITLE
Show loader when loading VSP

### DIFF
--- a/ui/page/components/vsp_selector.go
+++ b/ui/page/components/vsp_selector.go
@@ -247,10 +247,10 @@ func (v *vspSelectorModal) Layout(gtx layout.Context) layout.Dimensions {
 				layout.Rigid(func(gtx C) D {
 					// if VSP(s) are being loaded, show loading UI.
 					if v.isLoadingVSP {
-						return layout.Inset{Top: values.MarginPadding120,
-							Right:  values.MarginPadding120,
-							Bottom: values.MarginPadding120,
-							Left:   values.MarginPadding120}.Layout(gtx, v.materialLoader.Layout)
+						return layout.Inset{Top: values.MarginPadding140,
+							Right:  values.MarginPadding140,
+							Bottom: values.MarginPadding140,
+							Left:   values.MarginPadding140}.Layout(gtx, v.materialLoader.Layout)
 					}
 
 					// if no vsp loaded, display a no vsp text

--- a/ui/page/components/vsp_selector.go
+++ b/ui/page/components/vsp_selector.go
@@ -247,10 +247,10 @@ func (v *vspSelectorModal) Layout(gtx layout.Context) layout.Dimensions {
 				layout.Rigid(func(gtx C) D {
 					// if VSP(s) are being loaded, show loading UI.
 					if v.isLoadingVSP {
-						return layout.Inset{Top: values.MarginPadding100,
-							Right:  values.MarginPadding100,
-							Bottom: values.MarginPadding100,
-							Left:   values.MarginPadding100}.Layout(gtx, v.materialLoader.Layout)
+						return layout.Inset{Top: values.MarginPadding120,
+							Right:  values.MarginPadding120,
+							Bottom: values.MarginPadding120,
+							Left:   values.MarginPadding120}.Layout(gtx, v.materialLoader.Layout)
 					}
 
 					// if no vsp loaded, display a no vsp text
@@ -262,6 +262,8 @@ func (v *vspSelectorModal) Layout(gtx layout.Context) layout.Dimensions {
 					}
 
 					return v.vspList.Layout(gtx, len(vsps), func(gtx C, i int) D {
+						// Show scrollbar on VSP selector modal
+						v.Modal.ShowScrollbar(true)
 						return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
 							layout.Flexed(0.8, func(gtx C) D {
 								return layout.Inset{Top: values.MarginPadding12, Bottom: values.MarginPadding12}.Layout(gtx, func(gtx C) D {

--- a/ui/values/localizable/en.go
+++ b/ui/values/localizable/en.go
@@ -308,6 +308,7 @@ const EN = `
 "liveTickets" = "Live Tickets"
 "loading" = "Loading..."
 "loadingPrice" = "Loading price"
+"loadingVSP" = "Loading voting service provider"
 "locked" = "Locked"
 "lockedByTickets" = "Locked By Tickets"
 "lockedin" = "Locked In"

--- a/ui/values/strings.go
+++ b/ui/values/strings.go
@@ -416,6 +416,7 @@ const (
 	StrLiveTickets                     = "liveTickets"
 	StrLoading                         = "loading"
 	StrLoadingPrice                    = "loadingPrice"
+	StrLoadingVSP                      = "loadingVSP"
 	StrLocked                          = "locked"
 	StrLockedByTickets                 = "lockedByTickets"
 	StrLockedIn                        = "lockedin"


### PR DESCRIPTION
This PR shows the loader UI when loading voting service providers.
Closes #22 

![Screenshot from 2023-09-22 16-34-20](https://github.com/crypto-power/cryptopower/assets/4796738/e7cc760e-199a-4ec0-aea4-cdffc8cf0d01)

