### PR TITLE
image: Fix layout width.

### DIFF
--- a/ui/cryptomaterial/image.go
+++ b/ui/cryptomaterial/image.go
@@ -57,7 +57,7 @@ func (img *Image) LayoutSize(gtx C, size unit.Dp) D {
 }
 
 func (img *Image) LayoutSize2(gtx C, width, height unit.Dp) D {
-	dst := image.NewRGBA(image.Rectangle{Max: image.Point{X: int(width), Y: int(height * 2)}})
+	dst := image.NewRGBA(image.Rectangle{Max: image.Point{X: int(width * 2), Y: int(height * 2)}})
 	draw.BiLinear.Scale(dst, dst.Bounds(), img, img.Bounds(), draw.Src, nil)
 
 	i := widget.Image{Src: paint.NewImageOp(dst)}


### PR DESCRIPTION
closes #94

Unsure of the logic why this is correct, but seems to stretch it out correctly.

![image](https://github.com/crypto-power/cryptopower/assets/34998433/492c7331-54d0-4a28-baa8-6bc2ae835b0b)
