### PR TITLE
ui: fix the recent trade display section on overview page

### DIFF
--- a/ui/page/components/order_list.go
+++ b/ui/page/components/order_list.go
@@ -22,6 +22,10 @@ func OrderItemWidget(gtx C, l *load.Load, orderItem *instantswap.Order) D {
 		Background: l.Theme.Color.Surface,
 		Alignment:  layout.Middle,
 		Border:     cryptomaterial.Border{Radius: cryptomaterial.Radius(14)},
+		Margin: layout.Inset{
+			Top:    values.MarginPadding8,
+			Bottom: values.MarginPadding10,
+		},
 	}.Layout(gtx,
 		layout.Rigid(func(gtx C) D {
 			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
@@ -68,12 +72,23 @@ func OrderItemWidget(gtx C, l *load.Load, orderItem *instantswap.Order) D {
 					return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
 						layout.Rigid(func(gtx C) D {
 							return layout.Inset{
-								Right: values.MarginPadding10,
+								Right: values.MarginPadding50,
 							}.Layout(gtx, func(gtx C) D {
 								return D{}
 							})
 						}),
-						layout.Rigid(l.Theme.Label(values.TextSize16, orderItem.Status.String()).Layout),
+						layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+							return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,
+								layout.Rigid(l.Theme.Label(values.TextSize16, orderItem.Status.String()).Layout),
+								layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+									statusLayout := statusIcon(l, orderItem.Status)
+									if statusLayout == nil {
+										return layout.Dimensions{}
+									}
+									return layout.Inset{Left: values.MarginPadding6}.Layout(gtx, statusLayout)
+								}),
+							)
+						}),
 						layout.Flexed(1, func(gtx C) D {
 							return layout.E.Layout(gtx, func(gtx C) D {
 								return layout.Flex{
@@ -96,6 +111,16 @@ func OrderItemWidget(gtx C, l *load.Load, orderItem *instantswap.Order) D {
 			)
 		}),
 	)
+}
+
+func statusIcon(l *load.Load, status api.Status) func(gtx C) layout.Dimensions {
+	switch status {
+	case api.OrderStatusCompleted:
+		return l.Theme.Icons.ConfirmIcon.Layout16dp
+	case api.OrderStatusCanceled, api.OrderStatusExpired, api.OrderStatusFailed:
+		return l.Theme.Icons.FailedIcon.Layout16dp
+	}
+	return nil
 }
 
 func LayoutNoOrderHistory(gtx C, l *load.Load, syncing bool) D {

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -77,6 +77,10 @@ func NewOverviewPage(l *load.Load) *OverviewPage {
 			Axis:      layout.Vertical,
 			Alignment: layout.Middle,
 		},
+		recentTradeList: layout.List{
+			Axis:      layout.Vertical,
+			Alignment: layout.Middle,
+		},
 		recentProposalList: layout.List{
 			Axis:      layout.Vertical,
 			Alignment: layout.Middle,
@@ -585,11 +589,15 @@ func (pg *OverviewPage) recentTrades(gtx C) D {
 					return components.OrderItemWidget(gtx, pg.Load, pg.orders[i])
 				}),
 				layout.Rigid(func(gtx C) D {
-					// No divider for last row
+					// Show bottom divider for all rows except the last row.
 					if i == len(pg.orders)-1 {
 						return layout.Dimensions{}
 					}
-					return pg.Theme.Separator().Layout(gtx)
+
+					gtx.Constraints.Min.X = gtx.Constraints.Max.X
+					return layout.E.Layout(gtx, func(gtx C) D {
+						return layout.Inset{Left: values.MarginPadding50}.Layout(gtx, pg.Theme.Separator().Layout)
+					})
 				}),
 			)
 		})


### PR DESCRIPTION
Closes #85 

<img width="745" alt="Screenshot 2023-09-26 at 10 28 03 PM" src="https://github.com/crypto-power/cryptopower/assets/57448127/75475cc1-7627-4736-9e3e-35a60a3e8f42">
