### PR TITLE
Use live data for overview Sliders

### DIFF
--- a/ui/cryptomaterial/slider.go
+++ b/ui/cryptomaterial/slider.go
@@ -18,8 +18,8 @@ type Slider struct {
 	card       Card
 	items      []layout.Widget
 
-	selected int
-
+	selected         int
+	isSliderItemsSet bool
 	// colors of the indicator and navigation button
 	ButtonBackgroundColor    color.NRGBA
 	IndicatorBackgroundColor color.NRGBA
@@ -47,7 +47,11 @@ func (t *Theme) Slider() *Slider {
 }
 
 func (s *Slider) Layout(gtx C, items []layout.Widget) D {
-	s.items = items
+	// set slider items once since layout is drawn multiple times per sec.
+	if !s.isSliderItemsSet {
+		s.items = items
+		s.isSliderItemsSet = true
+	}
 	s.handleClickEvent()
 
 	gtx.Constraints.Max = s.items[s.selected](gtx).Size

--- a/ui/cryptomaterial/slider.go
+++ b/ui/cryptomaterial/slider.go
@@ -137,6 +137,10 @@ func (s *Slider) centerLayout(gtx C, content layout.Widget) D {
 	return layout.Center.Layout(gtx, content)
 }
 
+func (s *Slider) RefreshItems() {
+	s.isSliderItemsSet = false
+}
+
 func (s *Slider) handleClickEvent() {
 	l := len(s.items) - 1 // index starts at 0
 	if s.nextButton.Clicked() {

--- a/ui/cryptomaterial/tab.go
+++ b/ui/cryptomaterial/tab.go
@@ -100,3 +100,11 @@ func (tn *Tab) Changed() bool {
 	tn.changed = false
 	return changed
 }
+
+func (tn *Tab) SetSelectedTab(tab string) {
+	for i, item := range tn.tabItems {
+		if item == tab {
+			tn.selectedIndex = i
+		}
+	}
+}

--- a/ui/page/root/home_page.go
+++ b/ui/page/root/home_page.go
@@ -147,6 +147,14 @@ func (hp *HomePage) HandleUserInteractions() {
 		hp.Display(pg)
 	}
 
+	// set the page to the active nav, especially when navigating from over pages
+	// like the overview page slider.
+	if hp.CurrentPageID() == WalletSelectorPageID && hp.navigationTab.SelectedTab() != values.String(values.StrWallets) {
+		hp.navigationTab.SetSelectedTab(values.String(values.StrWallets))
+	} else if hp.CurrentPageID() == TradePageID && hp.navigationTab.SelectedTab() != values.String(values.StrTrade) {
+		hp.navigationTab.SetSelectedTab(values.String(values.StrTrade))
+	}
+
 	for _, item := range hp.drawerNav.AppNavBarItems {
 		for item.Clickable.Clicked() {
 			// TODO: Implement click functionality

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -216,19 +216,19 @@ func (pg *OverviewPage) supportedCoinSliderLayout(gtx C) D {
 	var sliderWidget []layout.Widget
 
 	if pg.dcr != nil {
-		sliderWidget = append(sliderWidget, pg.supportedCoinItemLayout(gtx, *pg.dcr))
+		sliderWidget = append(sliderWidget, pg.supportedCoinItemLayout(*pg.dcr))
 	}
 	if pg.btc != nil {
-		sliderWidget = append(sliderWidget, pg.supportedCoinItemLayout(gtx, *pg.btc))
+		sliderWidget = append(sliderWidget, pg.supportedCoinItemLayout(*pg.btc))
 	}
 	if pg.ltc != nil {
-		sliderWidget = append(sliderWidget, pg.supportedCoinItemLayout(gtx, *pg.ltc))
+		sliderWidget = append(sliderWidget, pg.supportedCoinItemLayout(*pg.ltc))
 	}
 
 	return pg.coinSlider.Layout(gtx, sliderWidget)
 }
 
-func (pg *OverviewPage) supportedCoinItemLayout(gtx C, item supportedCoinSliderItem) layout.Widget {
+func (pg *OverviewPage) supportedCoinItemLayout(item supportedCoinSliderItem) layout.Widget {
 	return func(gtx C) D {
 		return layout.Stack{}.Layout(gtx,
 			layout.Stacked(func(gtx C) D {
@@ -671,6 +671,7 @@ func (pg *OverviewPage) fetchExchangeRate() {
 			}
 		}
 
+		pg.coinSlider.RefreshItems()
 		pg.ParentWindow().Reload()
 	}
 }

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -46,18 +46,19 @@ type OverviewPage struct {
 	mixerSlider               *cryptomaterial.Slider
 	proposalItems             []*components.ProposalItem
 	orders                    []*instantswap.Order
+	sliderRedirectBtn         *cryptomaterial.Clickable
 
 	card cryptomaterial.Card
 
-	dcr *supportedCoinSliderItem
-	btc *supportedCoinSliderItem
-	ltc *supportedCoinSliderItem
+	dcr *assetSliderItem
+	btc *assetSliderItem
+	ltc *assetSliderItem
 
 	assetsTotalBalance map[libutils.AssetType]sharedW.AssetAmount
 	usdExchangeRate    float64
 }
 
-type supportedCoinSliderItem struct {
+type assetSliderItem struct {
 	assetType       string
 	totalBalance    sharedW.AssetAmount
 	totalBalanceUSD string
@@ -97,8 +98,9 @@ func NewOverviewPage(l *load.Load) *OverviewPage {
 				Alignment: layout.Middle,
 			},
 		},
-		coinSlider: l.Theme.Slider(),
-		card:       l.Theme.Card(),
+		coinSlider:        l.Theme.Slider(),
+		card:              l.Theme.Card(),
+		sliderRedirectBtn: l.Theme.NewClickable(false),
 	}
 
 	pg.mixerSlider = l.Theme.Slider()
@@ -142,7 +144,9 @@ func (pg *OverviewPage) OnNavigatedTo() {
 // displayed.
 // Part of the load.Page interface.
 func (pg *OverviewPage) HandleUserInteractions() {
-
+	for pg.sliderRedirectBtn.Clicked() {
+		pg.ParentNavigator().Display(NewWalletSelectorPage(pg.Load))
+	}
 }
 
 // OnNavigatedFrom is called when the page is about to be removed from
@@ -228,55 +232,57 @@ func (pg *OverviewPage) supportedCoinSliderLayout(gtx C) D {
 	return pg.coinSlider.Layout(gtx, sliderWidget)
 }
 
-func (pg *OverviewPage) supportedCoinItemLayout(item supportedCoinSliderItem) layout.Widget {
+func (pg *OverviewPage) supportedCoinItemLayout(item assetSliderItem) layout.Widget {
 	return func(gtx C) D {
-		return layout.Stack{}.Layout(gtx,
-			layout.Stacked(func(gtx C) D {
-				return item.backgroundImage.LayoutSize2(gtx, unit.Dp(gtx.Constraints.Max.X), values.MarginPadding221)
-			}),
-			layout.Expanded(func(gtx C) D {
-				col := pg.Theme.Color.InvText
-				return layout.Flex{
-					Axis:      layout.Vertical,
-					Alignment: layout.Middle,
-				}.Layout(gtx,
-					layout.Rigid(func(gtx C) D {
-						lbl := pg.Theme.Body1(item.assetType)
-						lbl.Color = col
-						return pg.centerLayout(gtx, values.MarginPadding15, values.MarginPadding10, lbl.Layout)
-					}),
-					layout.Rigid(func(gtx C) D {
-						return pg.centerLayout(gtx, values.MarginPadding0, values.MarginPadding10, func(gtx C) D {
-							return item.image.LayoutSize(gtx, values.MarginPadding65)
-						})
-					}),
-					layout.Rigid(func(gtx C) D {
-						return pg.centerLayout(gtx, values.MarginPadding0, values.MarginPadding10, func(gtx C) D {
-							return components.LayoutBalanceColor(gtx, pg.Load, item.totalBalance.String(), col)
-						})
-					}),
-					layout.Rigid(func(gtx C) D {
-						card := pg.Theme.Card()
-						card.Radius = cryptomaterial.Radius(12)
-						card.Color = values.TransparentColor(values.TransparentBlack, 0.2)
-						return pg.centerLayout(gtx, values.MarginPadding0, values.MarginPadding0, func(gtx C) D {
-							return card.Layout(gtx, func(gtx C) D {
-								return layout.Inset{
-									Top:    values.MarginPadding4,
-									Bottom: values.MarginPadding4,
-									Right:  values.MarginPadding8,
-									Left:   values.MarginPadding8,
-								}.Layout(gtx, func(gtx C) D {
-									lbl := pg.Theme.Body2(item.totalBalanceUSD)
-									lbl.Color = col
-									return lbl.Layout(gtx)
+		return pg.sliderRedirectBtn.Layout(gtx, func(gtx C) D {
+			return layout.Stack{}.Layout(gtx,
+				layout.Stacked(func(gtx C) D {
+					return item.backgroundImage.LayoutSize2(gtx, unit.Dp(gtx.Constraints.Max.X), values.MarginPadding221)
+				}),
+				layout.Expanded(func(gtx C) D {
+					col := pg.Theme.Color.InvText
+					return layout.Flex{
+						Axis:      layout.Vertical,
+						Alignment: layout.Middle,
+					}.Layout(gtx,
+						layout.Rigid(func(gtx C) D {
+							lbl := pg.Theme.Body1(item.assetType)
+							lbl.Color = col
+							return pg.centerLayout(gtx, values.MarginPadding15, values.MarginPadding10, lbl.Layout)
+						}),
+						layout.Rigid(func(gtx C) D {
+							return pg.centerLayout(gtx, values.MarginPadding0, values.MarginPadding10, func(gtx C) D {
+								return item.image.LayoutSize(gtx, values.MarginPadding65)
+							})
+						}),
+						layout.Rigid(func(gtx C) D {
+							return pg.centerLayout(gtx, values.MarginPadding0, values.MarginPadding10, func(gtx C) D {
+								return components.LayoutBalanceColor(gtx, pg.Load, item.totalBalance.String(), col)
+							})
+						}),
+						layout.Rigid(func(gtx C) D {
+							card := pg.Theme.Card()
+							card.Radius = cryptomaterial.Radius(12)
+							card.Color = values.TransparentColor(values.TransparentBlack, 0.2)
+							return pg.centerLayout(gtx, values.MarginPadding0, values.MarginPadding0, func(gtx C) D {
+								return card.Layout(gtx, func(gtx C) D {
+									return layout.Inset{
+										Top:    values.MarginPadding4,
+										Bottom: values.MarginPadding4,
+										Right:  values.MarginPadding8,
+										Left:   values.MarginPadding8,
+									}.Layout(gtx, func(gtx C) D {
+										lbl := pg.Theme.Body2(item.totalBalanceUSD)
+										lbl.Color = col
+										return lbl.Layout(gtx)
+									})
 								})
 							})
-						})
-					}),
-				)
-			}),
-		)
+						}),
+					)
+				}),
+			)
+		})
 	}
 }
 
@@ -650,7 +656,7 @@ func (pg *OverviewPage) fetchExchangeRate() {
 			rate, err := pg.WL.AssetsManager.ExternalService.GetTicker(preferredExchange, market)
 			if err != nil {
 				log.Error(err)
-				return "$----"
+				return "$--"
 			}
 
 			balanceInUSD := bal.MulF64(rate.LastTradePrice).ToCoin()
@@ -683,11 +689,11 @@ func (pg *OverviewPage) updateSliders() {
 		return
 	}
 
-	sliderItem := func(totalBalance sharedW.AssetAmount, assetFullName string, icon, bkgImage *cryptomaterial.Image) *supportedCoinSliderItem {
-		return &supportedCoinSliderItem{
+	sliderItem := func(totalBalance sharedW.AssetAmount, assetFullName string, icon, bkgImage *cryptomaterial.Image) *assetSliderItem {
+		return &assetSliderItem{
 			assetType:       assetFullName,
 			totalBalance:    totalBalance,
-			totalBalanceUSD: "$----",
+			totalBalanceUSD: "$--",
 			image:           icon,
 			backgroundImage: bkgImage,
 		}

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -42,7 +42,7 @@ type OverviewPage struct {
 	scrollContainer *widget.List
 
 	infoButton, forwardButton cryptomaterial.IconButton // TOD0: use *cryptomaterial.Clickable
-	coinSlider                *cryptomaterial.Slider
+	assetBalanceSlider        *cryptomaterial.Slider
 	mixerSlider               *cryptomaterial.Slider
 	proposalItems             []*components.ProposalItem
 	orders                    []*instantswap.Order
@@ -50,15 +50,15 @@ type OverviewPage struct {
 
 	card cryptomaterial.Card
 
-	dcr *assetSliderItem
-	btc *assetSliderItem
-	ltc *assetSliderItem
+	dcr *assetBalanceSliderItem
+	btc *assetBalanceSliderItem
+	ltc *assetBalanceSliderItem
 
 	assetsTotalBalance map[libutils.AssetType]sharedW.AssetAmount
 	usdExchangeRate    float64
 }
 
-type assetSliderItem struct {
+type assetBalanceSliderItem struct {
 	assetType       string
 	totalBalance    sharedW.AssetAmount
 	totalBalanceUSD string
@@ -98,9 +98,9 @@ func NewOverviewPage(l *load.Load) *OverviewPage {
 				Alignment: layout.Middle,
 			},
 		},
-		coinSlider:        l.Theme.Slider(),
-		card:              l.Theme.Card(),
-		sliderRedirectBtn: l.Theme.NewClickable(false),
+		assetBalanceSlider: l.Theme.Slider(),
+		card:               l.Theme.Card(),
+		sliderRedirectBtn:  l.Theme.NewClickable(false),
 	}
 
 	pg.mixerSlider = l.Theme.Slider()
@@ -209,30 +209,30 @@ func (pg *OverviewPage) sliderLayout(gtx C) D {
 		Direction:   layout.Center,
 		Margin:      layout.Inset{Bottom: values.MarginPadding20},
 	}.Layout(gtx,
-		layout.Flexed(.5, pg.supportedCoinSliderLayout),
+		layout.Flexed(.5, pg.assetBalanceSliderLayout),
 		layout.Flexed(.5, func(gtx C) D {
 			return layout.Inset{Left: values.MarginPadding10}.Layout(gtx, pg.mixerSliderLayout)
 		}),
 	)
 }
 
-func (pg *OverviewPage) supportedCoinSliderLayout(gtx C) D {
+func (pg *OverviewPage) assetBalanceSliderLayout(gtx C) D {
 	var sliderWidget []layout.Widget
 
 	if pg.dcr != nil {
-		sliderWidget = append(sliderWidget, pg.supportedCoinItemLayout(*pg.dcr))
+		sliderWidget = append(sliderWidget, pg.assetBalanceItemLayout(*pg.dcr))
 	}
 	if pg.btc != nil {
-		sliderWidget = append(sliderWidget, pg.supportedCoinItemLayout(*pg.btc))
+		sliderWidget = append(sliderWidget, pg.assetBalanceItemLayout(*pg.btc))
 	}
 	if pg.ltc != nil {
-		sliderWidget = append(sliderWidget, pg.supportedCoinItemLayout(*pg.ltc))
+		sliderWidget = append(sliderWidget, pg.assetBalanceItemLayout(*pg.ltc))
 	}
 
-	return pg.coinSlider.Layout(gtx, sliderWidget)
+	return pg.assetBalanceSlider.Layout(gtx, sliderWidget)
 }
 
-func (pg *OverviewPage) supportedCoinItemLayout(item assetSliderItem) layout.Widget {
+func (pg *OverviewPage) assetBalanceItemLayout(item assetBalanceSliderItem) layout.Widget {
 	return func(gtx C) D {
 		return pg.sliderRedirectBtn.Layout(gtx, func(gtx C) D {
 			return layout.Stack{}.Layout(gtx,
@@ -677,7 +677,7 @@ func (pg *OverviewPage) fetchExchangeRate() {
 			}
 		}
 
-		pg.coinSlider.RefreshItems()
+		pg.assetBalanceSlider.RefreshItems()
 		pg.ParentWindow().Reload()
 	}
 }
@@ -689,8 +689,8 @@ func (pg *OverviewPage) updateSliders() {
 		return
 	}
 
-	sliderItem := func(totalBalance sharedW.AssetAmount, assetFullName string, icon, bkgImage *cryptomaterial.Image) *assetSliderItem {
-		return &assetSliderItem{
+	sliderItem := func(totalBalance sharedW.AssetAmount, assetFullName string, icon, bkgImage *cryptomaterial.Image) *assetBalanceSliderItem {
+		return &assetBalanceSliderItem{
 			assetType:       assetFullName,
 			totalBalance:    totalBalance,
 			totalBalanceUSD: "$--",

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -3,6 +3,7 @@ package root
 import (
 	"context"
 	"image/color"
+	"strings"
 
 	"gioui.org/font"
 	"gioui.org/layout"
@@ -17,6 +18,9 @@ import (
 	"github.com/crypto-power/cryptopower/ui/load"
 	"github.com/crypto-power/cryptopower/ui/page/components"
 	"github.com/crypto-power/cryptopower/ui/values"
+	sharedW "github.com/crypto-power/cryptopower/libwallet/assets/wallet"
+	libutils "github.com/crypto-power/cryptopower/libwallet/utils"
+	"github.com/crypto-power/cryptopower/ui/utils"
 )
 
 const (
@@ -40,21 +44,28 @@ type OverviewPage struct {
 	infoButton, forwardButton cryptomaterial.IconButton // TOD0: use *cryptomaterial.Clickable
 	coinSlider                *cryptomaterial.Slider
 	mixerSlider               *cryptomaterial.Slider
-
 	proposalItems []*components.ProposalItem
 	orders        []*instantswap.Order
 
 	card cryptomaterial.Card
+
+	dcr *supportedCoinSliderItem
+	btc *supportedCoinSliderItem
+	ltc *supportedCoinSliderItem
+
+	usdExchangeRate       float64
 }
 
 type supportedCoinSliderItem struct {
-	Title    string
-	MainText string
-	SubText  string
+	assetType    string
+	totalBalance sharedW.AssetAmount
+	totalBalanceUSD  string
 
-	Image           *cryptomaterial.Image
-	BackgroundImage *cryptomaterial.Image
+	image           *cryptomaterial.Image
+	backgroundImage *cryptomaterial.Image
 }
+
+
 
 type assetMarketData struct {
 	title            string
@@ -117,9 +128,10 @@ func (pg *OverviewPage) ID() string {
 func (pg *OverviewPage) OnNavigatedTo() {
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
 
+	pg.updateSliders()
+
 	pg.proposalItems = components.LoadProposals(pg.Load, libwallet.ProposalCategoryAll, 0, 3, true)
 	pg.orders = components.LoadOrders(pg.Load, 0, 3, true)
-
 }
 
 // HandleUserInteractions is called just before Layout() to determine
@@ -195,47 +207,26 @@ func (pg *OverviewPage) sliderLayout(gtx C) D {
 }
 
 func (pg *OverviewPage) supportedCoinSliderLayout(gtx C) D {
-	// TODO use real data
-	dcr := supportedCoinSliderItem{
-		Title:           "DECRED",
-		MainText:        "20000.199 DCR",
-		SubText:         "$1000",
-		Image:           pg.Theme.Icons.DCRGroupIcon,
-		BackgroundImage: pg.Theme.Icons.DCRBackground,
+	var sliderWidget []layout.Widget
+
+	if pg.dcr != nil {
+		sliderWidget = append(sliderWidget,  pg.supportedCoinItemLayout(gtx, *pg.dcr))
 	}
-	ltc := supportedCoinSliderItem{
-		Title:           "Litecoin",
-		MainText:        "50000.199 LTC",
-		SubText:         "$9000",
-		Image:           pg.Theme.Icons.LTCGroupIcon,
-		BackgroundImage: pg.Theme.Icons.LTCBackground,
+	if pg.btc != nil {
+		sliderWidget = append(sliderWidget,  pg.supportedCoinItemLayout(gtx, *pg.btc))
 	}
-	btc := supportedCoinSliderItem{
-		Title:           "Bitcoin",
-		MainText:        "100000.199 BTC",
-		SubText:         "$89000",
-		Image:           pg.Theme.Icons.BTCGroupIcon,
-		BackgroundImage: pg.Theme.Icons.BTCBackground,
+	if pg.ltc != nil {
+		sliderWidget = append(sliderWidget,   pg.supportedCoinItemLayout(gtx, *pg.ltc))
 	}
 
-	sliderWidget := []layout.Widget{
-		func(gtx C) D {
-			return pg.supportedCoinItemLayout(gtx, dcr)
-		},
-		func(gtx C) D {
-			return pg.supportedCoinItemLayout(gtx, ltc)
-		},
-		func(gtx C) D {
-			return pg.supportedCoinItemLayout(gtx, btc)
-		},
-	}
 	return pg.coinSlider.Layout(gtx, sliderWidget)
 }
 
-func (pg *OverviewPage) supportedCoinItemLayout(gtx C, item supportedCoinSliderItem) D {
+func (pg *OverviewPage) supportedCoinItemLayout(gtx C, item supportedCoinSliderItem) layout.Widget {
+	return func(gtx C)D{
 	return layout.Stack{}.Layout(gtx,
 		layout.Stacked(func(gtx C) D {
-			return item.BackgroundImage.LayoutSize2(gtx, unit.Dp(gtx.Constraints.Max.X), values.MarginPadding221)
+			return item.backgroundImage.LayoutSize2(gtx, unit.Dp(gtx.Constraints.Max.X), values.MarginPadding221)
 		}),
 		layout.Expanded(func(gtx C) D {
 			col := pg.Theme.Color.InvText
@@ -244,18 +235,18 @@ func (pg *OverviewPage) supportedCoinItemLayout(gtx C, item supportedCoinSliderI
 				Alignment: layout.Middle,
 			}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
-					lbl := pg.Theme.Body1(item.Title)
+					lbl := pg.Theme.Body1(item.assetType)
 					lbl.Color = col
 					return pg.centerLayout(gtx, values.MarginPadding15, values.MarginPadding10, lbl.Layout)
 				}),
 				layout.Rigid(func(gtx C) D {
 					return pg.centerLayout(gtx, values.MarginPadding0, values.MarginPadding10, func(gtx C) D {
-						return item.Image.LayoutSize(gtx, values.MarginPadding65)
+						return item.image.LayoutSize(gtx, values.MarginPadding65)
 					})
 				}),
 				layout.Rigid(func(gtx C) D {
 					return pg.centerLayout(gtx, values.MarginPadding0, values.MarginPadding10, func(gtx C) D {
-						return components.LayoutBalanceColor(gtx, pg.Load, item.MainText, col)
+						return components.LayoutBalanceColor(gtx, pg.Load, item.totalBalance.String(), col)
 					})
 				}),
 				layout.Rigid(func(gtx C) D {
@@ -270,7 +261,7 @@ func (pg *OverviewPage) supportedCoinItemLayout(gtx C, item supportedCoinSliderI
 								Right:  values.MarginPadding8,
 								Left:   values.MarginPadding8,
 							}.Layout(gtx, func(gtx C) D {
-								lbl := pg.Theme.Body2(item.SubText)
+								lbl := pg.Theme.Body2(item.totalBalanceUSD)
 								lbl.Color = col
 								return lbl.Layout(gtx)
 							})
@@ -280,6 +271,7 @@ func (pg *OverviewPage) supportedCoinItemLayout(gtx C, item supportedCoinSliderI
 			)
 		}),
 	)
+}
 }
 
 func (pg *OverviewPage) mixerSliderLayout(gtx C) D {
@@ -621,6 +613,118 @@ func (pg *OverviewPage) recentProposal(gtx C) D {
 		})
 	})
 }
+
+func (pg *OverviewPage) calculateTotalAssetBalance() (map[libutils.AssetType]int64, error){
+		wallets := pg.WL.AssetsManager.AllWallets()
+	assetsTotalBalance := make(map[libutils.AssetType]int64)
+
+	for _, wal := range wallets {
+		if wal.IsWatchingOnlyWallet() { 
+			continue
+		}
+
+		accountsResult, err := wal.GetAccountsRaw()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, account := range accountsResult.Accounts {
+			assetsTotalBalance[wal.GetAssetType()] += account.Balance.Total.ToInt()
+		}
+	}
+
+	return assetsTotalBalance, nil
+}
+
+// func (pg *OverviewPage) updateExchangeSetting() {
+// 	pg.usdExchangeSet = false
+// 	if components.IsFetchExchangeRateAPIAllowed(pg.WL) {
+// 		pg.currencyExchangeValue = pg.WL.AssetsManager.GetCurrencyConversionExchange()
+// 		go pg.fetchExchangeRate()
+// 	}
+// }
+
+// func (pg *OverviewPage) fetchExchangeRate(assetType utils.AssetType) {
+// 	if components.IsFetchExchangeRateAPIAllowed(pg.WL) {
+// 		preferredExchange := pg.WL.AssetsManager.GetCurrencyConversionExchange()
+// 	// if pg.isFetchingExchangeRate {
+// 	// 	return
+// 	// }
+
+// 	// pg.isFetchingExchangeRate = true
+// 	var market string
+// 	switch assetType {
+// 	case libutils.DCRWalletAsset:
+// 		market = values.DCRUSDTMarket
+// 	case libutils.BTCWalletAsset:
+// 		market = values.BTCUSDTMarket
+// 	case libutils.LTCWalletAsset:
+// 		market = values.LTCUSDTMarket
+// 	default:
+// 		log.Errorf("Unsupported asset type: %s", assetType)
+// 		// pg.isFetchingExchangeRate = false
+// 		return
+// 	}
+
+// 	rate, err := pg.WL.AssetsManager.ExternalService.GetTicker(preferredExchange, market)
+// 	if err != nil {
+// 		log.Error(err)
+// 		// pg.isFetchingExchangeRate = false
+// 		return
+// 	}
+
+// 	pg.usdExchangeRate = rate.LastTradePrice
+// 	pg.updateBalance()
+// 	pg.usdExchangeSet = true
+// 	pg.ParentWindow().Reload()
+// 	pg.isFetchingExchangeRate = false
+// }
+// }
+
+func (pg *OverviewPage) updateSliders() {
+	assetItem, err := pg.calculateTotalAssetBalance()
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	sliderItem := func(totalBalance sharedW.AssetAmount, totalBalanceUSD, assetFullName string,
+	 icon, bkgImage *cryptomaterial.Image) *supportedCoinSliderItem {
+	  	return  &supportedCoinSliderItem{
+				assetType:           assetFullName,
+				totalBalance:        totalBalance,
+				totalBalanceUSD: totalBalanceUSD,
+				image:           icon,
+				backgroundImage: bkgImage,
+			}
+	  }
+
+	  usdBalance := func(bal sharedW.AssetAmount) string{
+	  	balanceInUSD := bal.MulF64(pg.usdExchangeRate).ToCoin()
+		return utils.FormatUSDBalance(pg.Printer, balanceInUSD)
+	  }
+
+	for assetType, totalBalance := range assetItem {
+		
+		
+		assetFullName:=  strings.ToUpper(assetType.ToFull())
+
+		switch assetType {
+		case libutils.BTCWalletAsset:
+			balance := pg.WL.AssetsManager.AllBTCWallets()[0].ToAmount(totalBalance)
+			pg.btc = sliderItem(balance, usdBalance(balance), assetFullName, pg.Theme.Icons.BTCGroupIcon, pg.Theme.Icons.BTCBackground)
+		case libutils.DCRWalletAsset:
+			balance := pg.WL.AssetsManager.AllDCRWallets()[0].ToAmount(totalBalance)
+			pg.dcr = sliderItem(balance, usdBalance(balance), assetFullName, pg.Theme.Icons.DCRGroupIcon, pg.Theme.Icons.DCRBackground)
+		case libutils.LTCWalletAsset:
+			balance := pg.WL.AssetsManager.AllLTCWallets()[0].ToAmount(totalBalance)
+			pg.ltc = sliderItem(balance, usdBalance(balance), assetFullName, pg.Theme.Icons.LTCGroupIcon, pg.Theme.Icons.LTCBackground)
+		default:
+
+	}
+	}
+}
+
 
 func (pg *OverviewPage) pageContentWrapper(gtx C, sectionTitle string, body layout.Widget) D {
 	return layout.Flex{Axis: layout.Vertical}.Layout(gtx,


### PR DESCRIPTION
Fix #82
This PR implement using live data for the overview sliders.
It also adds a condition to prevent slider widget from adding items repeatedly since Layout() is drawn multiple times per sec.

<img width="801" alt="image" src="https://github.com/crypto-power/cryptopower/assets/27733432/ceb34a52-2eb9-42a4-84c6-ae3c83577167">

Testnet is failing when trying to fetch exchange with this error 
```
 [ERR] UI: Get "/markets/DCR-USDT/ticker": unsupported protocol scheme ""
2023-09-27 10:02:03.110 [ERR] UI: Get "/markets/DCR-USDT/ticker": unsupported protocol scheme ""
```
Mainnet
<img width="798" alt="image" src="https://github.com/crypto-power/cryptopower/assets/27733432/a46f572d-61ff-4802-87a3-4d013135a538">
