### PR TITLE
config: use app private directory for android builds

### DIFF
--- a/os.go
+++ b/os.go
@@ -1,0 +1,8 @@
+//go:build !android
+// +build !android
+
+package main
+
+// OS-specific variables for non-android OS.
+
+var isAndroidOS = false

--- a/os_android.go
+++ b/os_android.go
@@ -1,0 +1,8 @@
+//go:build android
+// +build android
+
+package main
+
+// OS-specific variables for android OS.
+
+var isAndroidOS = true


### PR DESCRIPTION
closes #37 

Android 11+ only allows creating files in public directories or the app private directory. Using the generic `$HOME/.cryptopower` directory produces a `permission denied` error in android 11+ and prevents the app from initializing.

As an added advantage, using a private directory for the android app ensures the app files are not publicly accessible to other apps.