### PR TITLE
Add txs and stakes to the overview page

### DIFF
--- a/ui/page/components/coinformat.go
+++ b/ui/page/components/coinformat.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"gioui.org/font"
 	"gioui.org/layout"
 	"gioui.org/unit"
 	"github.com/crypto-power/cryptopower/libwallet/utils"
@@ -20,7 +21,7 @@ var (
 	noDecimal                 = regexp.MustCompile(`([0-9]{1,3},*)+`)
 )
 
-func formatBalance(gtx layout.Context, l *load.Load, amount string, mainTextSize unit.Sp, scale float32, col color.NRGBA, displayUnitText bool) D {
+func formatBalance(gtx layout.Context, l *load.Load, amount string, mainTextSize unit.Sp, scale float32, col color.NRGBA, displayUnitText bool, fontweight font.Weight) D {
 
 	startIndex := 0
 	stopIndex := 0
@@ -50,19 +51,25 @@ func formatBalance(gtx layout.Context, l *load.Load, amount string, mainTextSize
 		layout.Rigid(func(gtx C) D {
 			txt := l.Theme.Label(mainTextSize, mainText)
 			txt.Color = col
+			txt.Font.Weight = fontweight
 			return txt.Layout(gtx)
 		}),
 		layout.Rigid(func(gtx C) D {
 			txt := l.Theme.Label(subTextSize, subText)
 			txt.Color = col
+			txt.Font.Weight = fontweight
 			return txt.Layout(gtx)
 		}),
 		layout.Rigid(func(gtx C) D {
 			if displayUnitText {
-				return l.Theme.Label(mainTextSize, unitText).Layout(gtx)
+				txt := l.Theme.Label(mainTextSize, unitText)
+				txt.Font.Weight = fontweight
+				return txt.Layout(gtx)
 			}
 
-			return l.Theme.Label(subTextSize, unitText).Layout(gtx)
+			txt := l.Theme.Label(subTextSize, unitText)
+			txt.Font.Weight = fontweight
+			return txt.Layout(gtx)
 		}),
 	)
 }
@@ -84,25 +91,29 @@ func getIndexUnit(amount string) int {
 // LayoutBalance aligns the main and sub DCR balances horizontally, putting the sub
 // balance at the baseline of the row.
 func LayoutBalance(gtx layout.Context, l *load.Load, amount string) layout.Dimensions {
-	return formatBalance(gtx, l, amount, values.TextSize20, defaultScale, l.Theme.Color.Text, false)
+	return formatBalance(gtx, l, amount, values.TextSize20, defaultScale, l.Theme.Color.Text, false, font.Normal)
 }
 
 func LayoutBalanceWithUnit(gtx layout.Context, l *load.Load, amount string) layout.Dimensions {
-	return formatBalance(gtx, l, amount, values.TextSize20, defaultScale, l.Theme.Color.PageNavText, true)
+	return formatBalance(gtx, l, amount, values.TextSize20, defaultScale, l.Theme.Color.PageNavText, true, font.Normal)
 }
 
 func LayoutBalanceWithUnitSize(gtx layout.Context, l *load.Load, amount string, mainTextSize unit.Sp) layout.Dimensions {
-	return formatBalance(gtx, l, amount, mainTextSize, defaultScale, l.Theme.Color.PageNavText, true)
+	return formatBalance(gtx, l, amount, mainTextSize, defaultScale, l.Theme.Color.PageNavText, true, font.Normal)
 }
 
 func LayoutBalanceSize(gtx layout.Context, l *load.Load, amount string, mainTextSize unit.Sp) layout.Dimensions {
-	return formatBalance(gtx, l, amount, mainTextSize, defaultScale, l.Theme.Color.Text, false)
+	return formatBalance(gtx, l, amount, mainTextSize, defaultScale, l.Theme.Color.Text, false, font.Normal)
+}
+
+func LayoutBalanceSizeWeight(gtx layout.Context, l *load.Load, amount string, mainTextSize unit.Sp, weight font.Weight) layout.Dimensions {
+	return formatBalance(gtx, l, amount, mainTextSize, defaultScale, l.Theme.Color.Text, false, weight)
 }
 
 func LayoutBalanceSizeScale(gtx layout.Context, l *load.Load, amount string, mainTextSize unit.Sp, scale float32) layout.Dimensions {
-	return formatBalance(gtx, l, amount, mainTextSize, scale, l.Theme.Color.Text, false)
+	return formatBalance(gtx, l, amount, mainTextSize, scale, l.Theme.Color.Text, false, font.Normal)
 }
 
 func LayoutBalanceColor(gtx layout.Context, l *load.Load, amount string, color color.NRGBA) layout.Dimensions {
-	return formatBalance(gtx, l, amount, values.TextSize20, defaultScale, color, false)
+	return formatBalance(gtx, l, amount, values.TextSize20, defaultScale, color, false, font.Normal)
 }

--- a/ui/page/components/coinformat.go
+++ b/ui/page/components/coinformat.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strings"
 
-	"gioui.org/font"
 	"gioui.org/layout"
 	"gioui.org/unit"
 	"github.com/crypto-power/cryptopower/libwallet/utils"
@@ -21,7 +20,7 @@ var (
 	noDecimal                 = regexp.MustCompile(`([0-9]{1,3},*)+`)
 )
 
-func formatBalance(gtx layout.Context, l *load.Load, amount string, mainTextSize unit.Sp, scale float32, col color.NRGBA, displayUnitText bool, fontweight font.Weight) D {
+func formatBalance(gtx layout.Context, l *load.Load, amount string, mainTextSize unit.Sp, scale float32, col color.NRGBA, displayUnitText bool) D {
 
 	startIndex := 0
 	stopIndex := 0
@@ -51,25 +50,18 @@ func formatBalance(gtx layout.Context, l *load.Load, amount string, mainTextSize
 		layout.Rigid(func(gtx C) D {
 			txt := l.Theme.Label(mainTextSize, mainText)
 			txt.Color = col
-			txt.Font.Weight = fontweight
 			return txt.Layout(gtx)
 		}),
 		layout.Rigid(func(gtx C) D {
 			txt := l.Theme.Label(subTextSize, subText)
 			txt.Color = col
-			txt.Font.Weight = fontweight
 			return txt.Layout(gtx)
 		}),
 		layout.Rigid(func(gtx C) D {
 			if displayUnitText {
-				txt := l.Theme.Label(mainTextSize, unitText)
-				txt.Font.Weight = fontweight
-				return txt.Layout(gtx)
+				return l.Theme.Label(mainTextSize, unitText).Layout(gtx)
 			}
-
-			txt := l.Theme.Label(subTextSize, unitText)
-			txt.Font.Weight = fontweight
-			return txt.Layout(gtx)
+			return l.Theme.Label(subTextSize, unitText).Layout(gtx)
 		}),
 	)
 }
@@ -91,25 +83,25 @@ func getIndexUnit(amount string) int {
 // LayoutBalance aligns the main and sub DCR balances horizontally, putting the sub
 // balance at the baseline of the row.
 func LayoutBalance(gtx layout.Context, l *load.Load, amount string) layout.Dimensions {
-	return formatBalance(gtx, l, amount, values.TextSize20, defaultScale, l.Theme.Color.Text, false, font.Normal)
+	return formatBalance(gtx, l, amount, values.TextSize20, defaultScale, l.Theme.Color.Text, false)
 }
 
 func LayoutBalanceWithUnit(gtx layout.Context, l *load.Load, amount string) layout.Dimensions {
-	return formatBalance(gtx, l, amount, values.TextSize20, defaultScale, l.Theme.Color.PageNavText, true, font.Normal)
+	return formatBalance(gtx, l, amount, values.TextSize20, defaultScale, l.Theme.Color.PageNavText, true)
 }
 
 func LayoutBalanceWithUnitSize(gtx layout.Context, l *load.Load, amount string, mainTextSize unit.Sp) layout.Dimensions {
-	return formatBalance(gtx, l, amount, mainTextSize, defaultScale, l.Theme.Color.PageNavText, true, font.Normal)
+	return formatBalance(gtx, l, amount, mainTextSize, defaultScale, l.Theme.Color.PageNavText, true)
 }
 
 func LayoutBalanceSize(gtx layout.Context, l *load.Load, amount string, mainTextSize unit.Sp) layout.Dimensions {
-	return formatBalance(gtx, l, amount, mainTextSize, defaultScale, l.Theme.Color.Text, false, font.Normal)
+	return formatBalance(gtx, l, amount, mainTextSize, defaultScale, l.Theme.Color.Text, false)
 }
 
 func LayoutBalanceSizeScale(gtx layout.Context, l *load.Load, amount string, mainTextSize unit.Sp, scale float32) layout.Dimensions {
-	return formatBalance(gtx, l, amount, mainTextSize, scale, l.Theme.Color.Text, false, font.Normal)
+	return formatBalance(gtx, l, amount, mainTextSize, scale, l.Theme.Color.Text, false)
 }
 
 func LayoutBalanceColor(gtx layout.Context, l *load.Load, amount string, color color.NRGBA) layout.Dimensions {
-	return formatBalance(gtx, l, amount, values.TextSize20, defaultScale, color, false, font.Normal)
+	return formatBalance(gtx, l, amount, values.TextSize20, defaultScale, color, false)
 }

--- a/ui/page/components/coinformat.go
+++ b/ui/page/components/coinformat.go
@@ -106,10 +106,6 @@ func LayoutBalanceSize(gtx layout.Context, l *load.Load, amount string, mainText
 	return formatBalance(gtx, l, amount, mainTextSize, defaultScale, l.Theme.Color.Text, false, font.Normal)
 }
 
-func LayoutBalanceSizeWeight(gtx layout.Context, l *load.Load, amount string, mainTextSize unit.Sp, weight font.Weight) layout.Dimensions {
-	return formatBalance(gtx, l, amount, mainTextSize, defaultScale, l.Theme.Color.Text, false, weight)
-}
-
 func LayoutBalanceSizeScale(gtx layout.Context, l *load.Load, amount string, mainTextSize unit.Sp, scale float32) layout.Dimensions {
 	return formatBalance(gtx, l, amount, mainTextSize, scale, l.Theme.Color.Text, false, font.Normal)
 }

--- a/ui/page/components/components.go
+++ b/ui/page/components/components.go
@@ -436,6 +436,33 @@ func LayoutTransactionRow2(gtx layout.Context, l *load.Load, row TransactionRow)
 						Alignment:   layout.Middle,
 					}.Layout(gtx,
 						layout.Rigid(func(gtx C) D {
+							if row.Transaction.Type == txhelper.TxTypeMixed {
+								return cryptomaterial.LinearLayout{
+									Width:       cryptomaterial.WrapContent,
+									Height:      cryptomaterial.WrapContent,
+									Orientation: layout.Horizontal,
+									Direction:   layout.W,
+									Alignment:   layout.Middle,
+								}.Layout(gtx,
+									layout.Rigid(func(gtx C) D {
+										// mix denomination
+										mixedDenom := wal.ToAmount(row.Transaction.MixDenomination).String()
+										txt := l.Theme.Label(values.TextSize12, mixedDenom)
+										txt.Color = l.Theme.Color.GrayText2
+										return txt.Layout(gtx)
+									}),
+									layout.Rigid(func(gtx C) D {
+										// Mixed outputs count
+										if row.Transaction.MixCount > 1 {
+											label := l.Theme.Label(values.TextSize12, fmt.Sprintf("x%d", row.Transaction.MixCount))
+											label.Color = l.Theme.Color.GrayText2
+											return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, label.Layout)
+										}
+										return D{}
+									}),
+								)
+							}
+
 							walBalTxt := l.Theme.Label(values.TextSize12, amount)
 							walBalTxt.Color = l.Theme.Color.GrayText2
 							return walBalTxt.Layout(gtx)
@@ -535,7 +562,7 @@ func LayoutTransactionRow2(gtx layout.Context, l *load.Load, row TransactionRow)
 					}),
 
 					layout.Rigid(func(gtx C) D {
-						if row.Transaction.Type == txhelper.TxTypeRegular {
+						if row.Transaction.Type == txhelper.TxTypeRegular || row.Transaction.Type == txhelper.TxTypeMixed {
 							statusIcon := l.Theme.Icons.ConfirmIcon
 							if TxConfirmations(l, row.Transaction) < wal.RequiredConfirmations() {
 								statusIcon = l.Theme.Icons.PendingIcon

--- a/ui/page/components/components.go
+++ b/ui/page/components/components.go
@@ -277,21 +277,27 @@ func LayoutTransactionRow(gtx layout.Context, l *load.Load, row TransactionRow, 
 						Width:       cryptomaterial.WrapContent,
 						Height:      cryptomaterial.WrapContent,
 						Orientation: layout.Horizontal,
+						Direction:   layout.W,
 						Alignment:   layout.Baseline,
-						Direction:   layout.Center,
 					}.Layout(gtx,
 						layout.Rigid(l.Theme.Label(values.TextSize18, txStatus.Title).Layout),
 						layout.Rigid(func(gtx C) D {
-							if isTxPage {
-								return D{}
-							}
-							return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, assetIcon.Layout12dp)
-						}),
-						layout.Rigid(func(gtx C) D {
-							if isTxPage {
-								return D{}
-							}
-							return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, walName.Layout)
+							return layout.E.Layout(gtx, func(gtx C) D {
+								return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+									layout.Rigid(func(gtx C) D {
+										if isTxPage {
+											return D{}
+										}
+										return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, assetIcon.Layout12dp)
+									}),
+									layout.Rigid(func(gtx C) D {
+										if isTxPage {
+											return D{}
+										}
+										return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, walName.Layout)
+									}),
+								)
+							})
 						}),
 					)
 				}),

--- a/ui/page/components/components.go
+++ b/ui/page/components/components.go
@@ -367,6 +367,9 @@ func LayoutTransactionRow2(gtx layout.Context, l *load.Load, row TransactionRow)
 
 	wal := l.WL.AssetsManager.WalletWithID(row.Transaction.WalletID)
 	txStatus := TransactionTitleIcon(l, wal, &row.Transaction)
+	amount := wal.ToAmount(row.Transaction.Amount).String()
+	assetIcon := CoinImageBySymbol(l, wal.GetAssetType(), wal.IsWatchingOnlyWallet())
+	walName := l.Theme.Label(values.TextSize12, wal.GetWalletName())
 
 	return cryptomaterial.LinearLayout{
 		Orientation: layout.Horizontal,
@@ -386,7 +389,6 @@ func LayoutTransactionRow2(gtx layout.Context, l *load.Load, row TransactionRow)
 			}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
 					if row.Transaction.Type == txhelper.TxTypeRegular {
-						amount := wal.ToAmount(row.Transaction.Amount).String()
 						if row.Transaction.Direction == txhelper.TxDirectionSent && !strings.Contains(amount, "-") {
 							amount = "-" + amount
 						}
@@ -399,15 +401,11 @@ func LayoutTransactionRow2(gtx layout.Context, l *load.Load, row TransactionRow)
 						Orientation: layout.Horizontal,
 						Alignment:   layout.Baseline,
 					}.Layout(gtx,
+						layout.Rigid(l.Theme.Label(values.TextSize18, txStatus.Title).Layout),
 						layout.Rigid(func(gtx C) D {
-							return l.Theme.Label(values.TextSize18, txStatus.Title).Layout(gtx)
-						}),
-						layout.Rigid(func(gtx C) D {
-							assetIcon := CoinImageBySymbol(l, wal.GetAssetType(), wal.IsWatchingOnlyWallet())
 							return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, assetIcon.Layout12dp)
 						}),
 						layout.Rigid(func(gtx C) D {
-							walName := l.Theme.Label(values.TextSize12, wal.GetWalletName())
 							return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, walName.Layout)
 						}),
 					)
@@ -423,11 +421,9 @@ func LayoutTransactionRow2(gtx layout.Context, l *load.Load, row TransactionRow)
 							Alignment:   layout.Middle,
 						}.Layout(gtx,
 							layout.Rigid(func(gtx C) D {
-								assetIcon := CoinImageBySymbol(l, wal.GetAssetType(), wal.IsWatchingOnlyWallet())
 								return assetIcon.Layout12dp(gtx)
 							}),
 							layout.Rigid(func(gtx C) D {
-								walName := l.Theme.Label(values.TextSize12, wal.GetWalletName())
 								return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, walName.Layout)
 							}),
 						)
@@ -440,14 +436,12 @@ func LayoutTransactionRow2(gtx layout.Context, l *load.Load, row TransactionRow)
 						Alignment:   layout.Middle,
 					}.Layout(gtx,
 						layout.Rigid(func(gtx C) D {
-							walBal := wal.ToAmount(row.Transaction.Amount).String()
-							walBalTxt := l.Theme.Label(values.TextSize12, walBal)
+							walBalTxt := l.Theme.Label(values.TextSize12, amount)
 							walBalTxt.Color = l.Theme.Color.GrayText2
 							return walBalTxt.Layout(gtx)
 						}),
 						layout.Rigid(func(gtx C) D {
-							wall := l.WL.AssetsManager.WalletWithID(row.Transaction.WalletID)
-							if dcrAsset, ok := wall.(*dcr.Asset); ok {
+							if dcrAsset, ok := wal.(*dcr.Asset); ok {
 								if ok, _ := dcrAsset.TicketHasVotedOrRevoked(row.Transaction.Hash); ok {
 									return layout.Inset{
 										Left: values.MarginPadding4,
@@ -461,9 +455,8 @@ func LayoutTransactionRow2(gtx layout.Context, l *load.Load, row TransactionRow)
 							return D{}
 						}),
 						layout.Rigid(func(gtx C) D {
-							wall := l.WL.AssetsManager.WalletWithID(row.Transaction.WalletID)
 							var ticketSpender *sharedW.Transaction
-							if dcrAsset, ok := wall.(*dcr.Asset); ok {
+							if dcrAsset, ok := wal.(*dcr.Asset); ok {
 								ticketSpender, _ = dcrAsset.TicketSpender(row.Transaction.Hash)
 							}
 
@@ -500,7 +493,6 @@ func LayoutTransactionRow2(gtx layout.Context, l *load.Load, row TransactionRow)
 
 			return layout.E.Layout(gtx, func(gtx C) D {
 				return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
-					//layout.Rigid(status.Layout),
 					layout.Rigid(func(gtx C) D {
 						return cryptomaterial.LinearLayout{
 							Width:       cryptomaterial.WrapContent,

--- a/ui/page/components/components.go
+++ b/ui/page/components/components.go
@@ -248,279 +248,272 @@ func LayoutTransactionRow(gtx layout.Context, l *load.Load, row TransactionRow, 
 		insetRight = values.MarginPadding8
 	}
 
-	return layout.E.Layout(gtx, func(gtx C) D {
-		return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
-			layout.Rigid(func(gtx C) D {
-				return layout.Inset{Left: insetLeft}.Layout(gtx, txStatus.Icon.Layout24dp)
-			}),
-			layout.Rigid(func(gtx C) D {
-				return cryptomaterial.LinearLayout{
-					Orientation: layout.Horizontal,
-					Width:       cryptomaterial.MatchParent,
-					Height:      gtx.Dp(values.MarginPadding56),
-					Alignment:   layout.Baseline,
-					Padding:     layout.Inset{Right: insetRight},
-				}.Layout(gtx,
-					layout.Rigid(func(gtx C) D {
+	return cryptomaterial.LinearLayout{
+		Orientation: layout.Horizontal,
+		Width:       cryptomaterial.MatchParent,
+		Height:      gtx.Dp(values.MarginPadding56),
+		Alignment:   layout.Middle,
+		Padding:     layout.Inset{Right: insetRight, Left: insetLeft},
+	}.Layout(gtx,
+		layout.Rigid(txStatus.Icon.Layout24dp),
+		layout.Rigid(func(gtx C) D {
+			return cryptomaterial.LinearLayout{
+				Width:       cryptomaterial.WrapContent,
+				Height:      cryptomaterial.MatchParent,
+				Orientation: layout.Vertical,
+				Padding:     layout.Inset{Left: insetLeft},
+				Direction:   layout.Center,
+			}.Layout(gtx,
+				layout.Rigid(func(gtx C) D {
+					if row.Transaction.Type == txhelper.TxTypeRegular {
+						amount := wal.ToAmount(row.Transaction.Amount).String()
+						if row.Transaction.Direction == txhelper.TxDirectionSent && !strings.Contains(amount, "-") {
+							amount = "-" + amount
+						}
+						return LayoutBalanceSize(gtx, l, amount, values.TextSize18)
+					}
+
+					return cryptomaterial.LinearLayout{
+						Width:       cryptomaterial.WrapContent,
+						Height:      cryptomaterial.WrapContent,
+						Orientation: layout.Horizontal,
+						Direction:   layout.W,
+						Alignment:   layout.Baseline,
+					}.Layout(gtx,
+						layout.Rigid(l.Theme.Label(values.TextSize18, txStatus.Title).Layout),
+						layout.Rigid(func(gtx C) D {
+							if isTxPage {
+								return D{}
+							}
+							return layout.E.Layout(gtx, func(gtx C) D {
+								return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+									layout.Rigid(func(gtx C) D {
+										return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, assetIcon.Layout12dp)
+									}),
+									layout.Rigid(func(gtx C) D {
+										return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, walName.Layout)
+									}),
+								)
+							})
+						}),
+					)
+				}),
+				layout.Rigid(func(gtx C) D {
+					if !isTxPage && row.Transaction.Type == txhelper.TxTypeRegular {
 						return cryptomaterial.LinearLayout{
 							Width:       cryptomaterial.WrapContent,
-							Height:      cryptomaterial.MatchParent,
-							Orientation: layout.Vertical,
-							Padding:     layout.Inset{Left: insetLeft},
-							Direction:   layout.Center,
+							Height:      cryptomaterial.WrapContent,
+							Orientation: layout.Horizontal,
+							Direction:   layout.W,
+							Alignment:   layout.Middle,
 						}.Layout(gtx,
+							layout.Rigid(assetIcon.Layout12dp),
 							layout.Rigid(func(gtx C) D {
-								if row.Transaction.Type == txhelper.TxTypeRegular {
-									amount := wal.ToAmount(row.Transaction.Amount).String()
-									if row.Transaction.Direction == txhelper.TxDirectionSent && !strings.Contains(amount, "-") {
-										amount = "-" + amount
-									}
-									return LayoutBalanceSize(gtx, l, amount, values.TextSize18)
-								}
+								return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, walName.Layout)
+							}),
+						)
+					}
 
+					return cryptomaterial.LinearLayout{
+						Width:       cryptomaterial.WrapContent,
+						Height:      cryptomaterial.WrapContent,
+						Orientation: layout.Horizontal,
+						Alignment:   layout.Middle,
+					}.Layout(gtx,
+						layout.Rigid(func(gtx C) D {
+							if row.Transaction.Type == txhelper.TxTypeMixed {
 								return cryptomaterial.LinearLayout{
 									Width:       cryptomaterial.WrapContent,
 									Height:      cryptomaterial.WrapContent,
 									Orientation: layout.Horizontal,
 									Direction:   layout.W,
-									Alignment:   layout.Baseline,
-								}.Layout(gtx,
-									layout.Rigid(l.Theme.Label(values.TextSize18, txStatus.Title).Layout),
-									layout.Rigid(func(gtx C) D {
-										if isTxPage {
-											return D{}
-										}
-										return layout.E.Layout(gtx, func(gtx C) D {
-											return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
-												layout.Rigid(func(gtx C) D {
-													return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, assetIcon.Layout12dp)
-												}),
-												layout.Rigid(func(gtx C) D {
-													return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, walName.Layout)
-												}),
-											)
-										})
-									}),
-								)
-							}),
-							layout.Rigid(func(gtx C) D {
-								if !isTxPage && row.Transaction.Type == txhelper.TxTypeRegular {
-									return cryptomaterial.LinearLayout{
-										Width:       cryptomaterial.WrapContent,
-										Height:      cryptomaterial.WrapContent,
-										Orientation: layout.Horizontal,
-										Direction:   layout.W,
-										Alignment:   layout.Middle,
-									}.Layout(gtx,
-										layout.Rigid(assetIcon.Layout12dp),
-										layout.Rigid(func(gtx C) D {
-											return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, walName.Layout)
-										}),
-									)
-								}
-
-								return cryptomaterial.LinearLayout{
-									Width:       cryptomaterial.WrapContent,
-									Height:      cryptomaterial.WrapContent,
-									Orientation: layout.Horizontal,
 									Alignment:   layout.Middle,
 								}.Layout(gtx,
 									layout.Rigid(func(gtx C) D {
-										if row.Transaction.Type == txhelper.TxTypeMixed {
-											return cryptomaterial.LinearLayout{
-												Width:       cryptomaterial.WrapContent,
-												Height:      cryptomaterial.WrapContent,
-												Orientation: layout.Horizontal,
-												Direction:   layout.W,
-												Alignment:   layout.Middle,
-											}.Layout(gtx,
-												layout.Rigid(func(gtx C) D {
-													// mix denomination
-													mixedDenom := wal.ToAmount(row.Transaction.MixDenomination).String()
-													txt := l.Theme.Label(values.TextSize12, mixedDenom)
-													txt.Color = l.Theme.Color.GrayText2
-													return txt.Layout(gtx)
-												}),
-												layout.Rigid(func(gtx C) D {
-													// Mixed outputs count
-													if row.Transaction.MixCount > 1 {
-														label := l.Theme.Label(values.TextSize12, fmt.Sprintf("x%d", row.Transaction.MixCount))
-														label.Color = l.Theme.Color.GrayText2
-														return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, label.Layout)
-													}
-													return D{}
-												}),
-											)
-										}
-
-										if isTxPage {
-											return D{}
-										}
-
-										walBalTxt := l.Theme.Label(values.TextSize12, amount)
-										walBalTxt.Color = l.Theme.Color.GrayText2
-										return walBalTxt.Layout(gtx)
+										// mix denomination
+										mixedDenom := wal.ToAmount(row.Transaction.MixDenomination).String()
+										txt := l.Theme.Label(values.TextSize12, mixedDenom)
+										txt.Color = l.Theme.Color.GrayText2
+										return txt.Layout(gtx)
 									}),
 									layout.Rigid(func(gtx C) D {
-										if dcrAsset, ok := wal.(*dcr.Asset); ok && !isTxPage {
-											if ok, _ := dcrAsset.TicketHasVotedOrRevoked(row.Transaction.Hash); ok {
-												return layout.Inset{
-													Left: values.MarginPadding4,
-												}.Layout(gtx, func(gtx C) D {
-													ic := cryptomaterial.NewIcon(l.Theme.Icons.ImageBrightness1)
-													ic.Color = l.Theme.Color.GrayText2
-													return ic.Layout(gtx, values.MarginPadding6)
-												})
-											}
+										// Mixed outputs count
+										if row.Transaction.MixCount > 1 {
+											label := l.Theme.Label(values.TextSize12, fmt.Sprintf("x%d", row.Transaction.MixCount))
+											label.Color = l.Theme.Color.GrayText2
+											return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, label.Layout)
 										}
 										return D{}
-									}),
-									layout.Rigid(func(gtx C) D {
-										var ticketSpender *sharedW.Transaction
-										if dcrAsset, ok := wal.(*dcr.Asset); ok {
-											ticketSpender, _ = dcrAsset.TicketSpender(row.Transaction.Hash)
-										}
-
-										if ticketSpender == nil || isTxPage {
-											return D{}
-										}
-										amnt := wal.ToAmount(ticketSpender.VoteReward).ToCoin()
-										lbl := l.Theme.Label(values.TextSize12, fmt.Sprintf("%.2f", amnt))
-										if amnt > 0 {
-											lbl = l.Theme.Label(values.TextSize12, fmt.Sprintf("+%.2f", amnt))
-										}
-										return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, lbl.Layout)
 									}),
 								)
-							}),
-						)
-					}),
-					layout.Flexed(1, func(gtx C) D {
-						txSize := values.TextSize16
-						if !isTxPage {
-							txSize = values.TextSize12
-						}
-						status := l.Theme.Label(txSize, values.String(values.StrUnknown))
-						txConfirmations := TxConfirmations(l, row.Transaction)
-						reqConf := wal.RequiredConfirmations()
-						if txConfirmations < 1 {
-							status = l.Theme.Label(txSize, values.String(values.StrUnconfirmedTx))
-							status.Color = l.Theme.Color.GrayText1
-						} else if txConfirmations >= reqConf {
-							status.Color = l.Theme.Color.GrayText2
-							date := time.Unix(row.Transaction.Timestamp, 0).Format("Jan 2, 2006")
-							timeSplit := time.Unix(row.Transaction.Timestamp, 0).Format("03:04:05 PM")
-							status.Text = fmt.Sprintf("%v at %v", date, timeSplit)
-						} else {
-							status = l.Theme.Label(txSize, values.StringF(values.StrTxStatusPending, txConfirmations, reqConf))
-							status.Color = l.Theme.Color.GrayText1
-						}
+							}
 
-						return layout.E.Layout(gtx, func(gtx C) D {
-							return layout.Flex{Alignment: layout.Baseline}.Layout(gtx,
-								layout.Rigid(func(gtx C) D {
-									voteOrRevocationTx := row.Transaction.Type == txhelper.TxTypeVote || row.Transaction.Type == txhelper.TxTypeRevocation
-									if isTxPage && voteOrRevocationTx {
-										title := values.String(values.StrRevoke)
-										if row.Transaction.Type == txhelper.TxTypeVote {
-											title = values.String(values.StrVote)
-										}
+							if isTxPage {
+								return D{}
+							}
 
-										return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
-											layout.Rigid(func(gtx C) D {
-												lbl := l.Theme.Label(values.TextSize16, fmt.Sprintf("%dd to %s", row.Transaction.DaysToVoteOrRevoke, title))
-												lbl.Color = l.Theme.Color.GrayText2
-												return lbl.Layout(gtx)
-											}),
-											layout.Rigid(func(gtx C) D {
-												return layout.Inset{
-													Right: values.MarginPadding5,
-													Left:  values.MarginPadding5,
-												}.Layout(gtx, func(gtx C) D {
-													ic := cryptomaterial.NewIcon(l.Theme.Icons.ImageBrightness1)
-													ic.Color = l.Theme.Color.GrayText2
-													return ic.Layout(gtx, values.MarginPadding6)
-												})
-											}),
-										)
-									}
-
-									return D{}
-								}),
-								layout.Rigid(func(gtx C) D {
-									if !isTxPage {
-										return cryptomaterial.LinearLayout{
-											Width:       cryptomaterial.WrapContent,
-											Height:      cryptomaterial.MatchParent,
-											Orientation: layout.Vertical,
-											Alignment:   layout.End,
-											Direction:   layout.Center,
-										}.Layout(gtx,
-											layout.Rigid(func(gtx C) D {
-												tx := &row.Transaction
-												if wal.TxMatchesFilter(tx, libutils.TxFilterStaking) {
-													durationPrefix := values.String(values.StrVoted)
-													if tx.Type == txhelper.TxTypeTicketPurchase {
-														if wal.TxMatchesFilter(tx, libutils.TxFilterUnmined) {
-															durationPrefix = values.String(values.StrUmined)
-														} else if wal.TxMatchesFilter(tx, libutils.TxFilterImmature) {
-															durationPrefix = values.String(values.StrImmature)
-														} else if wal.TxMatchesFilter(tx, libutils.TxFilterLive) {
-															durationPrefix = values.String(values.StrLive)
-														} else if wal.TxMatchesFilter(tx, libutils.TxFilterExpired) {
-															durationPrefix = values.String(values.StrExpired)
-														}
-													} else if tx.Type == txhelper.TxTypeRevocation {
-														durationPrefix = values.String(values.StrRevoked)
-													}
-
-													durationTxt := TimeAgo(row.Transaction.Timestamp)
-													durationTxt = fmt.Sprintf("%s %s", durationPrefix, durationTxt)
-
-													lbl := l.Theme.Label(values.TextSize12, durationTxt)
-													return lbl.Layout(gtx)
-												}
-												return D{}
-											}),
-											layout.Rigid(status.Layout),
-										)
-									}
-									return D{}
-								}),
-								layout.Rigid(func(gtx C) D {
-									if isTxPage {
-										return status.Layout(gtx)
-									}
-									return D{}
-								}),
-								layout.Rigid(func(gtx C) D {
-									isMixedOrRegular := row.Transaction.Type == txhelper.TxTypeMixed || row.Transaction.Type == txhelper.TxTypeRegular
-									if !isTxPage && !isMixedOrRegular {
-										return D{}
-									}
-									statusIcon := l.Theme.Icons.ConfirmIcon
-									if TxConfirmations(l, row.Transaction) < wal.RequiredConfirmations() {
-										statusIcon = l.Theme.Icons.PendingIcon
-									}
-
-									if isTxPage {
-										return layout.Inset{
-											Left: values.MarginPadding15,
-											Top:  values.MarginPadding5,
-										}.Layout(gtx, statusIcon.Layout12dp)
-									}
-
+							walBalTxt := l.Theme.Label(values.TextSize12, amount)
+							walBalTxt.Color = l.Theme.Color.GrayText2
+							return walBalTxt.Layout(gtx)
+						}),
+						layout.Rigid(func(gtx C) D {
+							if dcrAsset, ok := wal.(*dcr.Asset); ok && !isTxPage {
+								if ok, _ := dcrAsset.TicketHasVotedOrRevoked(row.Transaction.Hash); ok {
 									return layout.Inset{
-										Left: values.MarginPadding2,
-									}.Layout(gtx, statusIcon.Layout12dp)
+										Left: values.MarginPadding4,
+									}.Layout(gtx, func(gtx C) D {
+										ic := cryptomaterial.NewIcon(l.Theme.Icons.ImageBrightness1)
+										ic.Color = l.Theme.Color.GrayText2
+										return ic.Layout(gtx, values.MarginPadding6)
+									})
+								}
+							}
+							return D{}
+						}),
+						layout.Rigid(func(gtx C) D {
+							var ticketSpender *sharedW.Transaction
+							if dcrAsset, ok := wal.(*dcr.Asset); ok {
+								ticketSpender, _ = dcrAsset.TicketSpender(row.Transaction.Hash)
+							}
+
+							if ticketSpender == nil || isTxPage {
+								return D{}
+							}
+							amnt := wal.ToAmount(ticketSpender.VoteReward).ToCoin()
+							lbl := l.Theme.Label(values.TextSize12, fmt.Sprintf("%.2f", amnt))
+							if amnt > 0 {
+								lbl = l.Theme.Label(values.TextSize12, fmt.Sprintf("+%.2f", amnt))
+							}
+							return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, lbl.Layout)
+						}),
+					)
+				}),
+			)
+		}),
+		layout.Flexed(1, func(gtx C) D {
+			txSize := values.TextSize16
+			if !isTxPage {
+				txSize = values.TextSize12
+			}
+			status := l.Theme.Label(txSize, values.String(values.StrUnknown))
+			txConfirmations := TxConfirmations(l, row.Transaction)
+			reqConf := wal.RequiredConfirmations()
+			if txConfirmations < 1 {
+				status = l.Theme.Label(txSize, values.String(values.StrUnconfirmedTx))
+				status.Color = l.Theme.Color.GrayText1
+			} else if txConfirmations >= reqConf {
+				status.Color = l.Theme.Color.GrayText2
+				date := time.Unix(row.Transaction.Timestamp, 0).Format("Jan 2, 2006")
+				timeSplit := time.Unix(row.Transaction.Timestamp, 0).Format("03:04:05 PM")
+				status.Text = fmt.Sprintf("%v at %v", date, timeSplit)
+			} else {
+				status = l.Theme.Label(txSize, values.StringF(values.StrTxStatusPending, txConfirmations, reqConf))
+				status.Color = l.Theme.Color.GrayText1
+			}
+
+			return layout.E.Layout(gtx, func(gtx C) D {
+				return layout.Flex{Alignment: layout.Baseline}.Layout(gtx,
+					layout.Rigid(func(gtx C) D {
+						voteOrRevocationTx := row.Transaction.Type == txhelper.TxTypeVote || row.Transaction.Type == txhelper.TxTypeRevocation
+						if isTxPage && voteOrRevocationTx {
+							title := values.String(values.StrRevoke)
+							if row.Transaction.Type == txhelper.TxTypeVote {
+								title = values.String(values.StrVote)
+							}
+
+							return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+								layout.Rigid(func(gtx C) D {
+									lbl := l.Theme.Label(values.TextSize16, fmt.Sprintf("%dd to %s", row.Transaction.DaysToVoteOrRevoke, title))
+									lbl.Color = l.Theme.Color.GrayText2
+									return lbl.Layout(gtx)
+								}),
+								layout.Rigid(func(gtx C) D {
+									return layout.Inset{
+										Right: values.MarginPadding5,
+										Left:  values.MarginPadding5,
+									}.Layout(gtx, func(gtx C) D {
+										ic := cryptomaterial.NewIcon(l.Theme.Icons.ImageBrightness1)
+										ic.Color = l.Theme.Color.GrayText2
+										return ic.Layout(gtx, values.MarginPadding6)
+									})
 								}),
 							)
-						})
+						}
+
+						return D{}
+					}),
+					layout.Rigid(func(gtx C) D {
+						if !isTxPage {
+							return cryptomaterial.LinearLayout{
+								Width:       cryptomaterial.WrapContent,
+								Height:      cryptomaterial.MatchParent,
+								Orientation: layout.Vertical,
+								Alignment:   layout.End,
+								Direction:   layout.Center,
+							}.Layout(gtx,
+								layout.Rigid(func(gtx C) D {
+									tx := &row.Transaction
+									if wal.TxMatchesFilter(tx, libutils.TxFilterStaking) {
+										durationPrefix := values.String(values.StrVoted)
+										if tx.Type == txhelper.TxTypeTicketPurchase {
+											if wal.TxMatchesFilter(tx, libutils.TxFilterUnmined) {
+												durationPrefix = values.String(values.StrUmined)
+											} else if wal.TxMatchesFilter(tx, libutils.TxFilterImmature) {
+												durationPrefix = values.String(values.StrImmature)
+											} else if wal.TxMatchesFilter(tx, libutils.TxFilterLive) {
+												durationPrefix = values.String(values.StrLive)
+											} else if wal.TxMatchesFilter(tx, libutils.TxFilterExpired) {
+												durationPrefix = values.String(values.StrExpired)
+											}
+										} else if tx.Type == txhelper.TxTypeRevocation {
+											durationPrefix = values.String(values.StrRevoked)
+										}
+
+										durationTxt := TimeAgo(row.Transaction.Timestamp)
+										durationTxt = fmt.Sprintf("%s %s", durationPrefix, durationTxt)
+
+										lbl := l.Theme.Label(values.TextSize12, durationTxt)
+										return lbl.Layout(gtx)
+									}
+									return D{}
+								}),
+								layout.Rigid(status.Layout),
+							)
+						}
+						return D{}
+					}),
+					layout.Rigid(func(gtx C) D {
+						if isTxPage {
+							return status.Layout(gtx)
+						}
+						return D{}
+					}),
+					layout.Rigid(func(gtx C) D {
+						isMixedOrRegular := row.Transaction.Type == txhelper.TxTypeMixed || row.Transaction.Type == txhelper.TxTypeRegular
+						if !isTxPage && !isMixedOrRegular {
+							return D{}
+						}
+						statusIcon := l.Theme.Icons.ConfirmIcon
+						if TxConfirmations(l, row.Transaction) < wal.RequiredConfirmations() {
+							statusIcon = l.Theme.Icons.PendingIcon
+						}
+
+						if isTxPage {
+							return layout.Inset{
+								Left: values.MarginPadding15,
+								Top:  values.MarginPadding5,
+							}.Layout(gtx, statusIcon.Layout12dp)
+						}
+
+						return layout.Inset{
+							Left: values.MarginPadding2,
+						}.Layout(gtx, statusIcon.Layout12dp)
 					}),
 				)
-			}),
-		)
-	})
+			})
+		}),
+	)
+
 }
 
 func TxConfirmations(l *load.Load, transaction sharedW.Transaction) int32 {

--- a/ui/page/components/components.go
+++ b/ui/page/components/components.go
@@ -321,6 +321,9 @@ func LayoutTransactionRow(gtx layout.Context, l *load.Load, row TransactionRow, 
 						Alignment:   layout.Middle,
 					}.Layout(gtx,
 						layout.Rigid(func(gtx C) D {
+							if isTxPage {
+								return D{}
+							}
 							if row.Transaction.Type == txhelper.TxTypeMixed {
 								return cryptomaterial.LinearLayout{
 									Width:       cryptomaterial.WrapContent,
@@ -380,11 +383,11 @@ func LayoutTransactionRow(gtx layout.Context, l *load.Load, row TransactionRow, 
 								return D{}
 							}
 							amnt := wal.ToAmount(ticketSpender.VoteReward).ToCoin()
-							lbl := l.Theme.Label(values.TextSize12, fmt.Sprintf("%.2f", amnt))
+							txt := fmt.Sprintf("%.2f", amnt)
 							if amnt > 0 {
-								lbl = l.Theme.Label(values.TextSize12, fmt.Sprintf("+%.2f", amnt))
+								txt = fmt.Sprintf("+%.2f", amnt)
 							}
-							return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, lbl.Layout)
+							return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, l.Theme.Label(values.TextSize12, txt).Layout)
 						}),
 					)
 				}),
@@ -471,9 +474,7 @@ func LayoutTransactionRow(gtx layout.Context, l *load.Load, row TransactionRow, 
 
 										durationTxt := TimeAgo(row.Transaction.Timestamp)
 										durationTxt = fmt.Sprintf("%s %s", durationPrefix, durationTxt)
-
-										lbl := l.Theme.Label(values.TextSize12, durationTxt)
-										return lbl.Layout(gtx)
+										return l.Theme.Label(values.TextSize12, durationTxt).Layout(gtx)
 									}
 									return D{}
 								}),

--- a/ui/page/components/components.go
+++ b/ui/page/components/components.go
@@ -248,280 +248,279 @@ func LayoutTransactionRow(gtx layout.Context, l *load.Load, row TransactionRow, 
 		insetRight = values.MarginPadding8
 	}
 
-	return cryptomaterial.LinearLayout{
-		Orientation: layout.Horizontal,
-		Width:       cryptomaterial.MatchParent,
-		Height:      gtx.Dp(values.MarginPadding56),
-		Alignment:   layout.Middle,
-		Padding:     layout.Inset{Left: insetLeft, Right: insetRight},
-	}.Layout(gtx,
-		layout.Rigid(txStatus.Icon.Layout24dp),
-		layout.Rigid(func(gtx C) D {
-			return cryptomaterial.LinearLayout{
-				Width:       cryptomaterial.WrapContent,
-				Height:      cryptomaterial.MatchParent,
-				Orientation: layout.Vertical,
-				Padding:     layout.Inset{Left: insetLeft},
-				Direction:   layout.Center,
-			}.Layout(gtx,
-				layout.Rigid(func(gtx C) D {
-					if row.Transaction.Type == txhelper.TxTypeRegular {
-						amount := wal.ToAmount(row.Transaction.Amount).String()
-						if row.Transaction.Direction == txhelper.TxDirectionSent && !strings.Contains(amount, "-") {
-							amount = "-" + amount
-						}
-						return LayoutBalanceSize(gtx, l, amount, values.TextSize18)
-					}
-
-					return cryptomaterial.LinearLayout{
-						Width:       cryptomaterial.WrapContent,
-						Height:      cryptomaterial.WrapContent,
-						Orientation: layout.Horizontal,
-						Direction:   layout.W,
-						Alignment:   layout.Baseline,
-					}.Layout(gtx,
-						layout.Rigid(l.Theme.Label(values.TextSize18, txStatus.Title).Layout),
-						layout.Rigid(func(gtx C) D {
-							return layout.E.Layout(gtx, func(gtx C) D {
-								return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
-									layout.Rigid(func(gtx C) D {
-										if isTxPage {
-											return D{}
-										}
-										return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, assetIcon.Layout12dp)
-									}),
-									layout.Rigid(func(gtx C) D {
-										if isTxPage {
-											return D{}
-										}
-										return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, walName.Layout)
-									}),
-								)
-							})
-						}),
-					)
-				}),
-				layout.Rigid(func(gtx C) D {
-					if !isTxPage && row.Transaction.Type == txhelper.TxTypeRegular {
+	return layout.E.Layout(gtx, func(gtx C) D {
+		return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+			layout.Rigid(func(gtx C) D {
+				return layout.Inset{Left: insetLeft}.Layout(gtx, txStatus.Icon.Layout24dp)
+			}),
+			layout.Rigid(func(gtx C) D {
+				return cryptomaterial.LinearLayout{
+					Orientation: layout.Horizontal,
+					Width:       cryptomaterial.MatchParent,
+					Height:      gtx.Dp(values.MarginPadding56),
+					Alignment:   layout.Baseline,
+					Padding:     layout.Inset{Right: insetRight},
+				}.Layout(gtx,
+					layout.Rigid(func(gtx C) D {
 						return cryptomaterial.LinearLayout{
 							Width:       cryptomaterial.WrapContent,
-							Height:      cryptomaterial.WrapContent,
-							Orientation: layout.Horizontal,
-							Direction:   layout.W,
-							Alignment:   layout.Middle,
+							Height:      cryptomaterial.MatchParent,
+							Orientation: layout.Vertical,
+							Padding:     layout.Inset{Left: insetLeft},
+							Direction:   layout.Center,
 						}.Layout(gtx,
-							layout.Rigid(assetIcon.Layout12dp),
 							layout.Rigid(func(gtx C) D {
-								return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, walName.Layout)
-							}),
-						)
-					}
+								if row.Transaction.Type == txhelper.TxTypeRegular {
+									amount := wal.ToAmount(row.Transaction.Amount).String()
+									if row.Transaction.Direction == txhelper.TxDirectionSent && !strings.Contains(amount, "-") {
+										amount = "-" + amount
+									}
+									return LayoutBalanceSize(gtx, l, amount, values.TextSize18)
+								}
 
-					return cryptomaterial.LinearLayout{
-						Width:       cryptomaterial.WrapContent,
-						Height:      cryptomaterial.WrapContent,
-						Orientation: layout.Horizontal,
-						Alignment:   layout.Middle,
-					}.Layout(gtx,
-						layout.Rigid(func(gtx C) D {
-							if row.Transaction.Type == txhelper.TxTypeMixed {
 								return cryptomaterial.LinearLayout{
 									Width:       cryptomaterial.WrapContent,
 									Height:      cryptomaterial.WrapContent,
 									Orientation: layout.Horizontal,
 									Direction:   layout.W,
+									Alignment:   layout.Baseline,
+								}.Layout(gtx,
+									layout.Rigid(l.Theme.Label(values.TextSize18, txStatus.Title).Layout),
+									layout.Rigid(func(gtx C) D {
+										if isTxPage {
+											return D{}
+										}
+										return layout.E.Layout(gtx, func(gtx C) D {
+											return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+												layout.Rigid(func(gtx C) D {
+													return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, assetIcon.Layout12dp)
+												}),
+												layout.Rigid(func(gtx C) D {
+													return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, walName.Layout)
+												}),
+											)
+										})
+									}),
+								)
+							}),
+							layout.Rigid(func(gtx C) D {
+								if !isTxPage && row.Transaction.Type == txhelper.TxTypeRegular {
+									return cryptomaterial.LinearLayout{
+										Width:       cryptomaterial.WrapContent,
+										Height:      cryptomaterial.WrapContent,
+										Orientation: layout.Horizontal,
+										Direction:   layout.W,
+										Alignment:   layout.Middle,
+									}.Layout(gtx,
+										layout.Rigid(assetIcon.Layout12dp),
+										layout.Rigid(func(gtx C) D {
+											return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, walName.Layout)
+										}),
+									)
+								}
+
+								return cryptomaterial.LinearLayout{
+									Width:       cryptomaterial.WrapContent,
+									Height:      cryptomaterial.WrapContent,
+									Orientation: layout.Horizontal,
 									Alignment:   layout.Middle,
 								}.Layout(gtx,
 									layout.Rigid(func(gtx C) D {
-										// mix denomination
-										mixedDenom := wal.ToAmount(row.Transaction.MixDenomination).String()
-										txt := l.Theme.Label(values.TextSize12, mixedDenom)
-										txt.Color = l.Theme.Color.GrayText2
-										return txt.Layout(gtx)
+										if row.Transaction.Type == txhelper.TxTypeMixed {
+											return cryptomaterial.LinearLayout{
+												Width:       cryptomaterial.WrapContent,
+												Height:      cryptomaterial.WrapContent,
+												Orientation: layout.Horizontal,
+												Direction:   layout.W,
+												Alignment:   layout.Middle,
+											}.Layout(gtx,
+												layout.Rigid(func(gtx C) D {
+													// mix denomination
+													mixedDenom := wal.ToAmount(row.Transaction.MixDenomination).String()
+													txt := l.Theme.Label(values.TextSize12, mixedDenom)
+													txt.Color = l.Theme.Color.GrayText2
+													return txt.Layout(gtx)
+												}),
+												layout.Rigid(func(gtx C) D {
+													// Mixed outputs count
+													if row.Transaction.MixCount > 1 {
+														label := l.Theme.Label(values.TextSize12, fmt.Sprintf("x%d", row.Transaction.MixCount))
+														label.Color = l.Theme.Color.GrayText2
+														return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, label.Layout)
+													}
+													return D{}
+												}),
+											)
+										}
+
+										if isTxPage {
+											return D{}
+										}
+
+										walBalTxt := l.Theme.Label(values.TextSize12, amount)
+										walBalTxt.Color = l.Theme.Color.GrayText2
+										return walBalTxt.Layout(gtx)
 									}),
 									layout.Rigid(func(gtx C) D {
-										// Mixed outputs count
-										if row.Transaction.MixCount > 1 {
-											label := l.Theme.Label(values.TextSize12, fmt.Sprintf("x%d", row.Transaction.MixCount))
-											label.Color = l.Theme.Color.GrayText2
-											return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, label.Layout)
+										if dcrAsset, ok := wal.(*dcr.Asset); ok && !isTxPage {
+											if ok, _ := dcrAsset.TicketHasVotedOrRevoked(row.Transaction.Hash); ok {
+												return layout.Inset{
+													Left: values.MarginPadding4,
+												}.Layout(gtx, func(gtx C) D {
+													ic := cryptomaterial.NewIcon(l.Theme.Icons.ImageBrightness1)
+													ic.Color = l.Theme.Color.GrayText2
+													return ic.Layout(gtx, values.MarginPadding6)
+												})
+											}
 										}
 										return D{}
 									}),
+									layout.Rigid(func(gtx C) D {
+										var ticketSpender *sharedW.Transaction
+										if dcrAsset, ok := wal.(*dcr.Asset); ok {
+											ticketSpender, _ = dcrAsset.TicketSpender(row.Transaction.Hash)
+										}
+
+										if ticketSpender == nil || isTxPage {
+											return D{}
+										}
+										amnt := wal.ToAmount(ticketSpender.VoteReward).ToCoin()
+										lbl := l.Theme.Label(values.TextSize12, fmt.Sprintf("%.2f", amnt))
+										if amnt > 0 {
+											lbl = l.Theme.Label(values.TextSize12, fmt.Sprintf("+%.2f", amnt))
+										}
+										return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, lbl.Layout)
+									}),
 								)
-							}
-
-							if isTxPage {
-								return D{}
-							}
-
-							walBalTxt := l.Theme.Label(values.TextSize12, amount)
-							walBalTxt.Color = l.Theme.Color.GrayText2
-							return walBalTxt.Layout(gtx)
-						}),
-						layout.Rigid(func(gtx C) D {
-							if dcrAsset, ok := wal.(*dcr.Asset); ok && !isTxPage {
-								if ok, _ := dcrAsset.TicketHasVotedOrRevoked(row.Transaction.Hash); ok {
-									return layout.Inset{
-										Left: values.MarginPadding4,
-									}.Layout(gtx, func(gtx C) D {
-										ic := cryptomaterial.NewIcon(l.Theme.Icons.ImageBrightness1)
-										ic.Color = l.Theme.Color.GrayText2
-										return ic.Layout(gtx, values.MarginPadding6)
-									})
-								}
-							}
-							return D{}
-						}),
-						layout.Rigid(func(gtx C) D {
-							var ticketSpender *sharedW.Transaction
-							if dcrAsset, ok := wal.(*dcr.Asset); ok {
-								ticketSpender, _ = dcrAsset.TicketSpender(row.Transaction.Hash)
-							}
-
-							if ticketSpender == nil || isTxPage {
-								return D{}
-							}
-							amnt := wal.ToAmount(ticketSpender.VoteReward).ToCoin()
-							lbl := l.Theme.Label(values.TextSize12, fmt.Sprintf("%.2f", amnt))
-							if amnt > 0 {
-								lbl = l.Theme.Label(values.TextSize12, fmt.Sprintf("+%.2f", amnt))
-							}
-							return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, lbl.Layout)
-						}),
-					)
-				}),
-			)
-		}),
-		layout.Flexed(1, func(gtx C) D {
-			status := l.Theme.Label(values.TextSize16, values.String(values.StrUnknown))
-			if !isTxPage {
-				status = l.Theme.Label(values.TextSize12, values.String(values.StrUnknown))
-			}
-			txConfirmations := TxConfirmations(l, row.Transaction)
-			reqConf := wal.RequiredConfirmations()
-			if txConfirmations < 1 {
-				status = l.Theme.Label(values.TextSize16, values.String(values.StrUnconfirmedTx))
-				status.Color = l.Theme.Color.GrayText1
-			} else if txConfirmations >= reqConf {
-				status.Color = l.Theme.Color.GrayText2
-				date := time.Unix(row.Transaction.Timestamp, 0).Format("Jan 2, 2006")
-				timeSplit := time.Unix(row.Transaction.Timestamp, 0).Format("03:04:05 PM")
-				status.Text = fmt.Sprintf("%v at %v", date, timeSplit)
-			} else {
-				status = l.Theme.Label(values.TextSize16, values.StringF(values.StrTxStatusPending, txConfirmations, reqConf))
-				status.Color = l.Theme.Color.GrayText1
-			}
-
-			return layout.E.Layout(gtx, func(gtx C) D {
-				alignment := layout.Baseline
-				if !isTxPage {
-					alignment = layout.Middle
-				}
-				return layout.Flex{Alignment: alignment}.Layout(gtx,
-					layout.Rigid(func(gtx C) D {
-						if isTxPage && row.Transaction.Type == txhelper.TxTypeVote || row.Transaction.Type == txhelper.TxTypeRevocation {
-							title := values.String(values.StrRevoke)
-							if row.Transaction.Type == txhelper.TxTypeVote {
-								title = values.String(values.StrVote)
-							}
-
-							return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
-								layout.Rigid(func(gtx C) D {
-									lbl := l.Theme.Label(values.TextSize16, fmt.Sprintf("%dd to %s", row.Transaction.DaysToVoteOrRevoke, title))
-									lbl.Color = l.Theme.Color.GrayText2
-									return lbl.Layout(gtx)
-								}),
-								layout.Rigid(func(gtx C) D {
-									return layout.Inset{
-										Right: values.MarginPadding5,
-										Left:  values.MarginPadding5,
-									}.Layout(gtx, func(gtx C) D {
-										ic := cryptomaterial.NewIcon(l.Theme.Icons.ImageBrightness1)
-										ic.Color = l.Theme.Color.GrayText2
-										return ic.Layout(gtx, values.MarginPadding6)
-									})
-								}),
-							)
+							}),
+						)
+					}),
+					layout.Flexed(1, func(gtx C) D {
+						txSize := values.TextSize16
+						if !isTxPage {
+							txSize = values.TextSize12
+						}
+						status := l.Theme.Label(txSize, values.String(values.StrUnknown))
+						txConfirmations := TxConfirmations(l, row.Transaction)
+						reqConf := wal.RequiredConfirmations()
+						if txConfirmations < 1 {
+							status = l.Theme.Label(txSize, values.String(values.StrUnconfirmedTx))
+							status.Color = l.Theme.Color.GrayText1
+						} else if txConfirmations >= reqConf {
+							status.Color = l.Theme.Color.GrayText2
+							date := time.Unix(row.Transaction.Timestamp, 0).Format("Jan 2, 2006")
+							timeSplit := time.Unix(row.Transaction.Timestamp, 0).Format("03:04:05 PM")
+							status.Text = fmt.Sprintf("%v at %v", date, timeSplit)
+						} else {
+							status = l.Theme.Label(txSize, values.StringF(values.StrTxStatusPending, txConfirmations, reqConf))
+							status.Color = l.Theme.Color.GrayText1
 						}
 
-						return D{}
-					}),
-					layout.Rigid(func(gtx C) D {
-						if !isTxPage {
-							return cryptomaterial.LinearLayout{
-								Width:       cryptomaterial.WrapContent,
-								Height:      cryptomaterial.MatchParent,
-								Orientation: layout.Vertical,
-								Alignment:   layout.End,
-								Direction:   layout.Center,
-							}.Layout(gtx,
+						return layout.E.Layout(gtx, func(gtx C) D {
+							return layout.Flex{Alignment: layout.Baseline}.Layout(gtx,
 								layout.Rigid(func(gtx C) D {
-									tx := &row.Transaction
-									if tx.Type == txhelper.TxTypeTicketPurchase {
-										durationPrefix := values.String(values.StrVoted)
-										if wal.TxMatchesFilter(tx, libutils.TxFilterUnmined) {
-											durationPrefix = values.String(values.StrUmined)
-										} else if wal.TxMatchesFilter(tx, libutils.TxFilterImmature) {
-											durationPrefix = values.String(values.StrImmature)
-										} else if wal.TxMatchesFilter(tx, libutils.TxFilterLive) {
-											durationPrefix = values.String(values.StrLive)
-										} else if wal.TxMatchesFilter(tx, libutils.TxFilterExpired) {
-											durationPrefix = values.String(values.StrExpired)
-										} else {
-											ticketSpender, _ := wal.(*dcr.Asset).TicketSpender(tx.Hash)
-											if ticketSpender != nil {
-												// if this is not a vote tx, then it must be a revoked tx.
-												if ticketSpender.Type != txhelper.TxTypeVote {
-													durationPrefix = values.String(values.StrRevoke)
-												}
-											}
+									voteOrRevocationTx := row.Transaction.Type == txhelper.TxTypeVote || row.Transaction.Type == txhelper.TxTypeRevocation
+									if isTxPage && voteOrRevocationTx {
+										title := values.String(values.StrRevoke)
+										if row.Transaction.Type == txhelper.TxTypeVote {
+											title = values.String(values.StrVote)
 										}
-										durationTxt := TimeAgo(row.Transaction.Timestamp)
-										durationTxt = fmt.Sprintf("%s %s", durationPrefix, durationTxt)
 
-										lbl := l.Theme.Label(values.TextSize12, durationTxt)
-										return lbl.Layout(gtx)
+										return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+											layout.Rigid(func(gtx C) D {
+												lbl := l.Theme.Label(values.TextSize16, fmt.Sprintf("%dd to %s", row.Transaction.DaysToVoteOrRevoke, title))
+												lbl.Color = l.Theme.Color.GrayText2
+												return lbl.Layout(gtx)
+											}),
+											layout.Rigid(func(gtx C) D {
+												return layout.Inset{
+													Right: values.MarginPadding5,
+													Left:  values.MarginPadding5,
+												}.Layout(gtx, func(gtx C) D {
+													ic := cryptomaterial.NewIcon(l.Theme.Icons.ImageBrightness1)
+													ic.Color = l.Theme.Color.GrayText2
+													return ic.Layout(gtx, values.MarginPadding6)
+												})
+											}),
+										)
+									}
 
+									return D{}
+								}),
+								layout.Rigid(func(gtx C) D {
+									if !isTxPage {
+										return cryptomaterial.LinearLayout{
+											Width:       cryptomaterial.WrapContent,
+											Height:      cryptomaterial.MatchParent,
+											Orientation: layout.Vertical,
+											Alignment:   layout.End,
+											Direction:   layout.Center,
+										}.Layout(gtx,
+											layout.Rigid(func(gtx C) D {
+												tx := &row.Transaction
+												if wal.TxMatchesFilter(tx, libutils.TxFilterStaking) {
+													durationPrefix := values.String(values.StrVoted)
+													if tx.Type == txhelper.TxTypeTicketPurchase {
+														if wal.TxMatchesFilter(tx, libutils.TxFilterUnmined) {
+															durationPrefix = values.String(values.StrUmined)
+														} else if wal.TxMatchesFilter(tx, libutils.TxFilterImmature) {
+															durationPrefix = values.String(values.StrImmature)
+														} else if wal.TxMatchesFilter(tx, libutils.TxFilterLive) {
+															durationPrefix = values.String(values.StrLive)
+														} else if wal.TxMatchesFilter(tx, libutils.TxFilterExpired) {
+															durationPrefix = values.String(values.StrExpired)
+														}
+													} else if tx.Type == txhelper.TxTypeRevocation {
+														durationPrefix = values.String(values.StrRevoked)
+													}
+
+													durationTxt := TimeAgo(row.Transaction.Timestamp)
+													durationTxt = fmt.Sprintf("%s %s", durationPrefix, durationTxt)
+
+													lbl := l.Theme.Label(values.TextSize12, durationTxt)
+													return lbl.Layout(gtx)
+												}
+												return D{}
+											}),
+											layout.Rigid(status.Layout),
+										)
 									}
 									return D{}
 								}),
-								layout.Rigid(status.Layout),
+								layout.Rigid(func(gtx C) D {
+									if isTxPage {
+										return status.Layout(gtx)
+									}
+									return D{}
+								}),
+								layout.Rigid(func(gtx C) D {
+									isMixedOrRegular := row.Transaction.Type == txhelper.TxTypeMixed || row.Transaction.Type == txhelper.TxTypeRegular
+									if !isTxPage && !isMixedOrRegular {
+										return D{}
+									}
+									statusIcon := l.Theme.Icons.ConfirmIcon
+									if TxConfirmations(l, row.Transaction) < wal.RequiredConfirmations() {
+										statusIcon = l.Theme.Icons.PendingIcon
+									}
+
+									if isTxPage {
+										return layout.Inset{
+											Left: values.MarginPadding15,
+											Top:  values.MarginPadding5,
+										}.Layout(gtx, statusIcon.Layout12dp)
+									}
+
+									return layout.Inset{
+										Left: values.MarginPadding2,
+									}.Layout(gtx, statusIcon.Layout12dp)
+								}),
 							)
-						}
-						return D{}
-					}),
-					layout.Rigid(func(gtx C) D {
-						if isTxPage {
-							return status.Layout(gtx)
-						}
-						return D{}
-					}),
-					layout.Rigid(func(gtx C) D {
-						isMixedOrRegular := row.Transaction.Type == txhelper.TxTypeMixed || row.Transaction.Type == txhelper.TxTypeRegular
-						if !isTxPage && !isMixedOrRegular {
-							return D{}
-						}
-						statusIcon := l.Theme.Icons.ConfirmIcon
-						if TxConfirmations(l, row.Transaction) < wal.RequiredConfirmations() {
-							statusIcon = l.Theme.Icons.PendingIcon
-						}
-
-						if isTxPage {
-							return layout.Inset{
-								Left: values.MarginPadding15,
-								Top:  values.MarginPadding5,
-							}.Layout(gtx, statusIcon.Layout12dp)
-						}
-
-						return layout.Inset{
-							Left: values.MarginPadding2,
-						}.Layout(gtx, statusIcon.Layout12dp)
+						})
 					}),
 				)
-			})
-		}),
-	)
+			}),
+		)
+	})
 }
 
 func TxConfirmations(l *load.Load, transaction sharedW.Transaction) int32 {

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -945,7 +945,7 @@ func (pg *OverviewPage) txStakingSection(gtx C) D {
 
 								return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 									layout.Rigid(func(gtx C) D {
-										return components.LayoutTransactionRow2(gtx, pg.Load, row)
+										return components.LayoutTransactionRow(gtx, pg.Load, row, false)
 									}),
 									layout.Rigid(func(gtx C) D {
 										// No divider for last row
@@ -983,7 +983,7 @@ func (pg *OverviewPage) txStakingSection(gtx C) D {
 
 							return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 								layout.Rigid(func(gtx C) D {
-									return components.LayoutTransactionRow2(gtx, pg.Load, row)
+									return components.LayoutTransactionRow(gtx, pg.Load, row, false)
 								}),
 								layout.Rigid(func(gtx C) D {
 									// No divider for last row

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -48,6 +48,8 @@ type OverviewPage struct {
 	mobileMarketOverviewList layout.List
 	recentProposalList       layout.List
 	recentTradeList          layout.List
+	recentTransactions       layout.List
+	recentStakes             layout.List
 
 	scrollContainer               *widget.List
 	mobileMarketOverviewContainer *widget.List
@@ -57,6 +59,8 @@ type OverviewPage struct {
 	mixerSlider               *cryptomaterial.Slider
 	proposalItems             []*components.ProposalItem
 	orders                    []*instantswap.Order
+	transactions              []sharedW.Transaction
+	stakes                    []sharedW.Transaction
 	sliderRedirectBtn         *cryptomaterial.Clickable
 	mktValues                 []assetMarketData
 
@@ -152,6 +156,15 @@ func NewOverviewPage(l *load.Load) *OverviewPage {
 				image:     l.Theme.Icons.LTC,
 			},
 		},
+		recentTransactions: layout.List{
+			Axis:      layout.Vertical,
+			Alignment: layout.Middle,
+		},
+		recentStakes: layout.List{
+			Axis:      layout.Vertical,
+			Alignment: layout.Middle,
+		},
+
 		assetBalanceSlider: l.Theme.Slider(),
 		card:               l.Theme.Card(),
 		sliderRedirectBtn:  l.Theme.NewClickable(false),
@@ -169,6 +182,9 @@ func NewOverviewPage(l *load.Load) *OverviewPage {
 	pg.forwardButton.Size = values.MarginPadding20
 
 	pg.assetsTotalBalance = make(map[libutils.AssetType]sharedW.AssetAmount)
+
+	pg.stakes = make([]sharedW.Transaction, 0)
+	pg.transactions = make([]sharedW.Transaction, 0)
 
 	return pg
 }
@@ -189,6 +205,7 @@ func (pg *OverviewPage) OnNavigatedTo() {
 
 	pg.updateAssetsSliders()
 	go pg.updateAssetsUSDBalance()
+	go pg.loadTransactions()
 
 	pg.proposalItems = components.LoadProposals(pg.Load, libwallet.ProposalCategoryAll, 0, 3, true)
 	pg.orders = components.LoadOrders(pg.Load, 0, 3, true)
@@ -913,19 +930,75 @@ func (pg *OverviewPage) txStakingSection(gtx C) D {
 				layout.Flexed(.5, func(gtx C) D {
 					return layout.Inset{Right: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
 						return pg.pageContentWrapper(gtx, "Recent Transactions", nil, func(gtx C) D {
-							return pg.centerLayout(gtx, values.MarginPadding10, values.MarginPadding10, func(gtx C) D {
-								gtx.Constraints.Min.X = gtx.Constraints.Max.X
-								return pg.Theme.Body1("No recent transaction").Layout(gtx)
+							if len(pg.transactions) == 0 {
+								return pg.centerLayout(gtx, values.MarginPadding10, values.MarginPadding10, func(gtx C) D {
+									gtx.Constraints.Min.X = gtx.Constraints.Max.X
+									return pg.Theme.Body1("No recent transaction").Layout(gtx)
+								})
+							}
+
+							return pg.recentTransactions.Layout(gtx, len(pg.transactions), func(gtx C, index int) D {
+								row := components.TransactionRow{
+									Transaction: pg.transactions[index],
+									Index:       index,
+								}
+
+								return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+									layout.Rigid(func(gtx C) D {
+										return components.LayoutTransactionRow2(gtx, pg.Load, row)
+									}),
+									layout.Rigid(func(gtx C) D {
+										// No divider for last row
+										if row.Index == len(pg.transactions)-1 {
+											return layout.Dimensions{}
+										}
+
+										gtx.Constraints.Min.X = gtx.Constraints.Max.X
+										separator := pg.Theme.Separator()
+										return layout.E.Layout(gtx, func(gtx C) D {
+											// Show bottom divider for all rows except last
+											return layout.Inset{Left: values.MarginPadding8}.Layout(gtx, separator.Layout)
+										})
+									}),
+								)
 							})
 						})
 					})
 				}),
 				layout.Flexed(.5, func(gtx C) D {
 					return pg.pageContentWrapper(gtx, "Staking Activity", nil, func(gtx C) D {
-						return pg.centerLayout(gtx, values.MarginPadding10, values.MarginPadding10, func(gtx C) D {
-							gtx.Constraints.Min.X = gtx.Constraints.Max.X
+						if len(pg.stakes) == 0 {
+							return pg.centerLayout(gtx, values.MarginPadding10, values.MarginPadding10, func(gtx C) D {
+								gtx.Constraints.Min.X = gtx.Constraints.Max.X
 
-							return pg.Theme.Body1("No recent Staking Activity").Layout(gtx)
+								return pg.Theme.Body1("No recent Staking Activity").Layout(gtx)
+							})
+						}
+
+						return pg.recentStakes.Layout(gtx, len(pg.stakes), func(gtx C, index int) D {
+							row := components.TransactionRow{
+								Transaction: pg.stakes[index],
+								Index:       index,
+							}
+
+							return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+								layout.Rigid(func(gtx C) D {
+									return components.LayoutTransactionRow2(gtx, pg.Load, row)
+								}),
+								layout.Rigid(func(gtx C) D {
+									// No divider for last row
+									if row.Index == len(pg.stakes)-1 {
+										return layout.Dimensions{}
+									}
+
+									gtx.Constraints.Min.X = gtx.Constraints.Max.X
+									separator := pg.Theme.Separator()
+									return layout.E.Layout(gtx, func(gtx C) D {
+										// Show bottom divider for all rows except last
+										return layout.Inset{Left: values.MarginPadding8}.Layout(gtx, separator.Layout)
+									})
+								}),
+							)
 						})
 					})
 				}),
@@ -1273,5 +1346,50 @@ func (pg *OverviewPage) ratesRefreshComponent() func(gtx C) D {
 				})
 			}),
 		)
+	}
+}
+
+func (pg *OverviewPage) loadTransactions() {
+	pg.transactions = make([]sharedW.Transaction, 0)
+	wal := pg.WL.AllSortedWalletList()
+	for _, w := range wal {
+		txs, err := w.GetTransactionsRaw(0, 3, libutils.TxFilterAllTx, true)
+		if err != nil {
+			log.Errorf("error loading transactions: %v", err)
+			return
+		}
+
+		pg.transactions = append(pg.transactions, txs...)
+	}
+
+	sort.Slice(pg.transactions, func(i, j int) bool {
+		return pg.transactions[i].Timestamp > pg.transactions[j].Timestamp
+	})
+
+	if len(pg.transactions) > 3 {
+		pg.transactions = pg.transactions[:3]
+	}
+
+	pg.loadStakes()
+}
+
+func (pg *OverviewPage) loadStakes() {
+	wal := pg.WL.AssetsManager.AllDCRWallets()
+	for _, w := range wal {
+		txs, err := w.GetTransactionsRaw(0, 3, libutils.TxFilterStaking, true)
+		if err != nil {
+			log.Errorf("error loading staking activities: %v", err)
+			return
+		}
+
+		pg.stakes = append(pg.stakes, txs...)
+	}
+
+	sort.Slice(pg.stakes, func(i, j int) bool {
+		return pg.stakes[i].Timestamp > pg.stakes[j].Timestamp
+	})
+
+	if len(pg.stakes) > 3 {
+		pg.stakes = pg.stakes[:3]
 	}
 }

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -1381,8 +1381,11 @@ func (pg *OverviewPage) loadStakes() {
 			log.Errorf("error loading staking activities: %v", err)
 			return
 		}
-
-		pg.stakes = append(pg.stakes, txs...)
+		for _, stakeTx := range txs {
+			if (stakeTx.Type == dcr.TxTypeTicketPurchase) || (stakeTx.Type == dcr.TxTypeRevocation) {
+				pg.stakes = append(pg.stakes, stakeTx)
+			}
+		}
 	}
 
 	sort.Slice(pg.stakes, func(i, j int) bool {

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -950,7 +950,7 @@ func (pg *OverviewPage) txStakingSection(gtx C) D {
 									layout.Rigid(func(gtx C) D {
 										// No divider for last row
 										if row.Index == len(pg.transactions)-1 {
-											return layout.Dimensions{}
+											return D{}
 										}
 
 										gtx.Constraints.Min.X = gtx.Constraints.Max.X
@@ -988,7 +988,7 @@ func (pg *OverviewPage) txStakingSection(gtx C) D {
 								layout.Rigid(func(gtx C) D {
 									// No divider for last row
 									if row.Index == len(pg.stakes)-1 {
-										return layout.Dimensions{}
+										return D{}
 									}
 
 									gtx.Constraints.Min.X = gtx.Constraints.Max.X

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -970,7 +970,6 @@ func (pg *OverviewPage) txStakingSection(gtx C) D {
 						if len(pg.stakes) == 0 {
 							return pg.centerLayout(gtx, values.MarginPadding10, values.MarginPadding10, func(gtx C) D {
 								gtx.Constraints.Min.X = gtx.Constraints.Max.X
-
 								return pg.Theme.Body1(values.StrNoStaking).Layout(gtx)
 							})
 						}

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -929,11 +929,11 @@ func (pg *OverviewPage) txStakingSection(gtx C) D {
 			return layout.Flex{}.Layout(gtx,
 				layout.Flexed(.5, func(gtx C) D {
 					return layout.Inset{Right: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
-						return pg.pageContentWrapper(gtx, "Recent Transactions", nil, func(gtx C) D {
+						return pg.pageContentWrapper(gtx, values.String(values.StrRecentTransactions), nil, func(gtx C) D {
 							if len(pg.transactions) == 0 {
 								return pg.centerLayout(gtx, values.MarginPadding10, values.MarginPadding10, func(gtx C) D {
 									gtx.Constraints.Min.X = gtx.Constraints.Max.X
-									return pg.Theme.Body1("No recent transaction").Layout(gtx)
+									return pg.Theme.Body1(values.String(values.StrNoTransactions)).Layout(gtx)
 								})
 							}
 
@@ -966,12 +966,12 @@ func (pg *OverviewPage) txStakingSection(gtx C) D {
 					})
 				}),
 				layout.Flexed(.5, func(gtx C) D {
-					return pg.pageContentWrapper(gtx, "Staking Activity", nil, func(gtx C) D {
+					return pg.pageContentWrapper(gtx, values.StrStakingActivity, nil, func(gtx C) D {
 						if len(pg.stakes) == 0 {
 							return pg.centerLayout(gtx, values.MarginPadding10, values.MarginPadding10, func(gtx C) D {
 								gtx.Constraints.Min.X = gtx.Constraints.Max.X
 
-								return pg.Theme.Body1("No recent Staking Activity").Layout(gtx)
+								return pg.Theme.Body1(values.StrNoStaking).Layout(gtx)
 							})
 						}
 

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -1376,7 +1376,7 @@ func (pg *OverviewPage) loadTransactions() {
 func (pg *OverviewPage) loadStakes() {
 	wal := pg.WL.AssetsManager.AllDCRWallets()
 	for _, w := range wal {
-		txs, err := w.GetTransactionsRaw(0, 3, libutils.TxFilterStaking, true)
+		txs, err := w.GetTransactionsRaw(0, 6, libutils.TxFilterStaking, true)
 		if err != nil {
 			log.Errorf("error loading staking activities: %v", err)
 			return

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -966,7 +966,7 @@ func (pg *OverviewPage) txStakingSection(gtx C) D {
 					})
 				}),
 				layout.Flexed(.5, func(gtx C) D {
-					return pg.pageContentWrapper(gtx, values.StrStakingActivity, nil, func(gtx C) D {
+					return pg.pageContentWrapper(gtx, values.String(values.StrStakingActivity), nil, func(gtx C) D {
 						if len(pg.stakes) == 0 {
 							return pg.centerLayout(gtx, values.MarginPadding10, values.MarginPadding10, func(gtx C) D {
 								gtx.Constraints.Min.X = gtx.Constraints.Max.X

--- a/ui/page/transaction/transactions_page.go
+++ b/ui/page/transaction/transactions_page.go
@@ -270,7 +270,7 @@ func (pg *TransactionsPage) layoutDesktop(gtx layout.Context) layout.Dimensions 
 
 											return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 												layout.Rigid(func(gtx C) D {
-													return components.LayoutTransactionRow(gtx, pg.Load, row)
+													return components.LayoutTransactionRow(gtx, pg.Load, row, true)
 												}),
 												layout.Rigid(func(gtx C) D {
 													// No divider for last row
@@ -342,7 +342,7 @@ func (pg *TransactionsPage) layoutMobile(gtx layout.Context) layout.Dimensions {
 
 										return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 											layout.Rigid(func(gtx C) D {
-												return components.LayoutTransactionRow(gtx, pg.Load, row)
+												return components.LayoutTransactionRow(gtx, pg.Load, row, true)
 											}),
 											layout.Rigid(func(gtx C) D {
 												// No divider for last row

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -48,6 +48,7 @@ var (
 	MarginPadding44       = unit.Dp(44)
 	MarginPadding48       = unit.Dp(48)
 	MarginPadding50       = unit.Dp(50)
+	MarginPadding52       = unit.Dp(52)
 	MarginPadding56       = unit.Dp(56)
 	MarginPadding60       = unit.Dp(60)
 	MarginPadding62       = unit.Dp(62)

--- a/ui/values/localizable/en.go
+++ b/ui/values/localizable/en.go
@@ -375,6 +375,7 @@ const EN = `
 "noPoliciesYet" = "No policies yet"
 "noProposal" = "No proposals %v"
 "noReward" = "Stakey sees no rewards"
+"noStaking" = "No recent Staking Activity"
 "notAllowed" = "%s API not allowed by current network settings."
 "notApplicable" = "N/A"
 "notAvailable" = "Not available"

--- a/ui/values/strings.go
+++ b/ui/values/strings.go
@@ -484,6 +484,7 @@ const (
 	StrNoPoliciesYet                   = "noPoliciesYet"
 	StrNoProposals                     = "noProposal"
 	StrNoReward                        = "noReward"
+	StrNoStaking                       = "noStaking"
 	StrNotAllowed                      = "notAllowed"
 	StrNotApplicable                   = "notApplicable"
 	StrNotAvailable                    = "notAvailable"


### PR DESCRIPTION
This MR adds tx and staking data on the overview page. Closes  #84 

![Screenshot from 2023-10-09 16-44-22](https://github.com/crypto-power/cryptopower/assets/4796738/493ad9f1-3dd9-496b-b1f4-0ff1fdaaf58c)
