### PR TITLE
Add governance tab after trade tab and remove voting tab from dcr wallet

### DIFF
--- a/ui/page/governance/governance_page.go
+++ b/ui/page/governance/governance_page.go
@@ -19,7 +19,9 @@ import (
 	"github.com/crypto-power/cryptopower/ui/values"
 )
 
-const GovernancePageID = "Governance"
+const (
+	GovernancePageID = "Governance"
+)
 
 type Page struct {
 	*load.Load
@@ -52,6 +54,10 @@ func NewGovernancePage(l *load.Load) *Page {
 	return pg
 }
 
+func (pg *Page) ID() string {
+	return GovernancePageID
+}
+
 // OnNavigatedTo is called when the page is about to be displayed and
 // may be used to initialize page features that are only relevant when
 // the page is displayed.
@@ -65,7 +71,7 @@ func (pg *Page) OnNavigatedTo() {
 }
 
 func (pg *Page) isGovernanceFeatureEnabled() bool {
-	return pg.WL.SelectedWallet.Wallet.ReadBoolConfigValueForKey(sharedW.FetchProposalConfigKey, false)
+	return true
 }
 
 func (pg *Page) isProposalsAPIAllowed() bool {

--- a/ui/page/root/home_page.go
+++ b/ui/page/root/home_page.go
@@ -41,7 +41,6 @@ type HomePage struct {
 	appLevelSettingsButton *cryptomaterial.Clickable
 	appNotificationButton  *cryptomaterial.Clickable
 	hideBalanceButton      *cryptomaterial.Clickable
-	checkBox               cryptomaterial.CheckBoxStyle
 	infoButton             cryptomaterial.IconButton // TOD0: use *cryptomaterial.Clickable
 
 	bottomNavigationBar  components.BottomNavigationBar
@@ -60,6 +59,7 @@ var navigationTabTitles = []string{
 	values.String(values.StrOverview),
 	values.String(values.StrWallets),
 	values.String(values.StrTrade),
+	values.String(values.StrGovernance),
 }
 
 func NewHomePage(l *load.Load) *HomePage {
@@ -194,6 +194,8 @@ func (hp *HomePage) HandleUserInteractions() {
 			pg = NewWalletSelectorPage(hp.Load)
 		case values.String(values.StrTrade):
 			pg = NewTradePage(hp.Load)
+		case values.String(values.StrGovernance):
+			pg = governance.NewGovernancePage(hp.Load)
 		}
 
 		hp.Display(pg)
@@ -205,6 +207,8 @@ func (hp *HomePage) HandleUserInteractions() {
 		hp.navigationTab.SetSelectedTab(values.String(values.StrWallets))
 	} else if hp.CurrentPageID() == TradePageID && hp.navigationTab.SelectedTab() != values.String(values.StrTrade) {
 		hp.navigationTab.SetSelectedTab(values.String(values.StrTrade))
+	} else if hp.CurrentPageID() == governance.GovernancePageID && hp.navigationTab.SelectedTab() != values.String(values.StrGovernance) {
+		hp.navigationTab.SetSelectedTab(values.String(values.StrGovernance))
 	}
 
 	for _, item := range hp.drawerNav.AppNavBarItems {

--- a/ui/page/root/main_page.go
+++ b/ui/page/root/main_page.go
@@ -22,7 +22,6 @@ import (
 	"github.com/crypto-power/cryptopower/ui/load"
 	"github.com/crypto-power/cryptopower/ui/modal"
 	"github.com/crypto-power/cryptopower/ui/page/components"
-	"github.com/crypto-power/cryptopower/ui/page/governance"
 	"github.com/crypto-power/cryptopower/ui/page/info"
 	"github.com/crypto-power/cryptopower/ui/page/privacy"
 	"github.com/crypto-power/cryptopower/ui/page/seedbackup"
@@ -159,13 +158,6 @@ func (mp *MainPage) initNavItems() {
 				ImageInactive: mp.Theme.Icons.StakeIconInactive,
 				Title:         values.String(values.StrStaking),
 				PageID:        staking.OverviewPageID,
-			},
-			{
-				Clickable:     mp.Theme.NewClickable(true),
-				Image:         mp.Theme.Icons.GovernanceActiveIcon,
-				ImageInactive: mp.Theme.Icons.GovernanceInactiveIcon,
-				Title:         values.String(values.StrVoting),
-				PageID:        governance.GovernancePageID,
 			},
 			{
 				Clickable:     mp.Theme.NewClickable(true),
@@ -459,8 +451,6 @@ func (mp *MainPage) HandleUserInteractions() {
 				}
 			case staking.OverviewPageID:
 				pg = staking.NewStakingPage(mp.Load)
-			case governance.GovernancePageID:
-				pg = governance.NewGovernancePage(mp.Load)
 			case WalletSettingsPageID:
 				pg = NewWalletSettingsPage(mp.Load)
 			}


### PR DESCRIPTION
Closes #130 
Adds a governance tab after the trade tab and removes the vote option from the side bar in dcr wallet 
![Screenshot 2023-10-10 134411](https://github.com/crypto-power/cryptopower/assets/54014025/2fb83b12-879a-4884-9476-bb87122e9591)
