### PR TITLE
add segmented control layout

### DIFF
--- a/ui/cryptomaterial/segmented_control.go
+++ b/ui/cryptomaterial/segmented_control.go
@@ -1,0 +1,103 @@
+package cryptomaterial
+
+import (
+	"gioui.org/font"
+	"gioui.org/layout"
+
+	"github.com/crypto-power/cryptopower/ui/values"
+)
+
+type SegmentedControl struct {
+	theme *Theme
+	list  *ClickableList
+
+	selectedIndex int
+	segmentItems  []string
+
+	changed bool
+}
+
+func (t *Theme) SegmentedControl(segmentItems []string) *SegmentedControl {
+	list := t.NewClickableList(layout.Horizontal)
+	list.IsHoverable = false
+
+	return &SegmentedControl{
+		list:         list,
+		theme:        t,
+		segmentItems: segmentItems,
+	}
+}
+
+func (sc *SegmentedControl) Layout(gtx C) D {
+	sc.handleEvents()
+
+	return LinearLayout{
+		Width:      WrapContent,
+		Height:     WrapContent,
+		Background: sc.theme.Color.Background,
+		Border:     Border{Radius: Radius(8)},
+	}.Layout(gtx,
+		layout.Rigid(func(gtx C) D {
+			return sc.list.Layout(gtx, len(sc.segmentItems), func(gtx C, i int) D {
+				isSelectedSegment := sc.SelectedIndex() == i
+				return layout.Stack{Alignment: layout.Center}.Layout(gtx,
+					layout.Stacked(func(gtx C) D {
+						return layout.Inset{}.Layout(gtx, func(gtx C) D {
+							return layout.Center.Layout(gtx, func(gtx C) D {
+								bg := sc.theme.Color.SurfaceHighlight
+								txt := sc.theme.Label(values.TextSize16, sc.segmentItems[i])
+								txt.Color = sc.theme.Color.GrayText1
+								txt.Font.Weight = font.SemiBold
+								border := Border{Radius: Radius(0)}
+								if isSelectedSegment {
+									bg = sc.theme.Color.Surface
+									txt.Color = sc.theme.Color.Text
+									border = Border{Radius: Radius(8)}
+								}
+								return LinearLayout{
+									Width:      WrapContent,
+									Height:     WrapContent,
+									Padding:    layout.UniformInset(values.MarginPadding8),
+									Background: bg,
+									Margin:     layout.UniformInset(values.MarginPadding5),
+									Border:     border,
+								}.Layout(gtx,
+									layout.Rigid(func(gtx C) D {
+										return txt.Layout(gtx)
+									}),
+								)
+							})
+						})
+					}),
+				)
+			})
+		}),
+	)
+}
+
+func (sc *SegmentedControl) handleEvents() {
+	if segmentItemClicked, clickedSegmentIndex := sc.list.ItemClicked(); segmentItemClicked {
+		sc.selectedIndex = clickedSegmentIndex
+	}
+}
+
+func (sc *SegmentedControl) SelectedIndex() int {
+	return sc.selectedIndex
+}
+
+func (sc *SegmentedControl) SelectedSegment() string {
+	return sc.segmentItems[sc.selectedIndex]
+}
+func (sc *SegmentedControl) Changed() bool {
+	changed := sc.changed
+	sc.changed = false
+	return changed
+}
+
+func (sc *SegmentedControl) SetSelectedSegment(segment string) {
+	for i, item := range sc.segmentItems {
+		if item == segment {
+			sc.selectedIndex = i
+		}
+	}
+}


### PR DESCRIPTION
This PR adds segmented control to the `cryptomaterial` package, i was working on this as part of https://github.com/crypto-power/cryptopower/pull/166, but due to some changes to that PR and the fact that several other layouts would be needing it, i decided to add it as a standalone implementation.

This PR does not include the dragging animation which some segmented controls have, if it is desired it can be added at a later time. but for the sake of avoiding unnecessary delays, i have intentionally left it out

![Screenshot from 2023-10-11 03-03-51](https://github.com/crypto-power/cryptopower/assets/25265396/47f322b9-2eed-458e-a77a-4a2340ba94da)
