### PR TITLE
multi: Fix bugs and enable wallet creation on the create order page

### DIFF
--- a/libwallet/assets_manager.go
+++ b/libwallet/assets_manager.go
@@ -535,6 +535,27 @@ func (mgr *AssetsManager) WalletWithID(walletID int) sharedW.Asset {
 	return nil
 }
 
+// AssetWallets returns the wallets for the specified asset type(s).
+func (mgr *AssetsManager) AssetWallets(assetTypes ...utils.AssetType) []sharedW.Asset {
+	var wallets []sharedW.Asset
+	for _, asset := range assetTypes {
+		switch asset {
+		case utils.BTCWalletAsset:
+			wallets = append(wallets, mgr.AllBTCWallets()...)
+		case utils.DCRWalletAsset:
+			wallets = append(wallets, mgr.AllDCRWallets()...)
+		case utils.LTCWalletAsset:
+			wallets = append(wallets, mgr.AllLTCWallets()...)
+		}
+	}
+
+	if len(wallets) == 0 && len(assetTypes) == 0 {
+		wallets = mgr.AllWallets()
+	}
+
+	return wallets
+}
+
 func (mgr *AssetsManager) getbadWallet(walletID int) *sharedW.Wallet {
 	if badWallet, ok := mgr.Assets.BTC.BadWallets[walletID]; ok {
 		return badWallet

--- a/ui/page/components/asset_selector.go
+++ b/ui/page/components/asset_selector.go
@@ -21,7 +21,6 @@ const AssetTypeSelectorID = "AssetTypeSelectorID"
 type AssetTypeSelector struct {
 	openSelectorDialog *cryptomaterial.Clickable
 	*assetTypeModal
-	changed bool
 
 	hint            string
 	isDisableBorder bool
@@ -40,7 +39,7 @@ type assetTypeModal struct {
 	*cryptomaterial.Modal
 
 	selectedAssetType  *AssetTypeItem
-	assetTypeCallback  func(*AssetTypeItem)
+	assetTypeCallback  func(*AssetTypeItem) bool
 	dialogTitle        string
 	onAssetTypeClicked func(*AssetTypeItem)
 	assetTypeList      layout.List
@@ -58,14 +57,13 @@ func NewAssetTypeSelector(l *load.Load) *AssetTypeSelector {
 
 	ats.assetTypeModal = newAssetTypeModal(l).
 		assetTypeClicked(func(assetType *AssetTypeItem) {
-			if ats.selectedAssetType != nil {
-				if ats.selectedAssetType.Type.String() != assetType.Type.String() {
-					ats.changed = true
-				}
-			}
-			ats.selectedAssetType = assetType
+			ok := true
 			if ats.assetTypeCallback != nil {
-				ats.assetTypeCallback(assetType)
+				ok = ats.assetTypeCallback(assetType)
+			}
+
+			if ok && (ats.selectedAssetType == nil || ats.selectedAssetType.Type.String() != assetType.Type.String()) {
+				ats.selectedAssetType = assetType
 			}
 		})
 	ats.assetTypeItems = ats.buildExchangeItems()
@@ -142,7 +140,7 @@ func (ats *AssetTypeSelector) Title(title string) *AssetTypeSelector {
 }
 
 // AssetTypeSelected sets the callback executed when an asset type is selected.
-func (ats *AssetTypeSelector) AssetTypeSelected(callback func(*AssetTypeItem)) *AssetTypeSelector {
+func (ats *AssetTypeSelector) AssetTypeSelected(callback func(*AssetTypeItem) bool) *AssetTypeSelector {
 	ats.assetTypeCallback = callback
 	return ats
 }

--- a/ui/page/components/components.go
+++ b/ui/page/components/components.go
@@ -235,6 +235,10 @@ func TransactionTitleIcon(l *load.Load, wal sharedW.Asset, tx *sharedW.Transacti
 func LayoutTransactionRow(gtx layout.Context, l *load.Load, row TransactionRow, isTxPage bool) layout.Dimensions {
 	gtx.Constraints.Min.X = gtx.Constraints.Max.X
 	wal := l.WL.AssetsManager.WalletWithID(row.Transaction.WalletID)
+	if wal == nil {
+		return D{}
+	}
+
 	txStatus := TransactionTitleIcon(l, wal, &row.Transaction)
 	amount := wal.ToAmount(row.Transaction.Amount).String()
 	assetIcon := CoinImageBySymbol(l, wal.GetAssetType(), wal.IsWatchingOnlyWallet())

--- a/ui/page/components/restore_page.go
+++ b/ui/page/components/restore_page.go
@@ -1,4 +1,4 @@
-package info
+package components
 
 import (
 	"image"
@@ -17,7 +17,6 @@ import (
 	"github.com/crypto-power/cryptopower/ui/cryptomaterial"
 	"github.com/crypto-power/cryptopower/ui/load"
 	"github.com/crypto-power/cryptopower/ui/modal"
-	"github.com/crypto-power/cryptopower/ui/page/components"
 	"github.com/crypto-power/cryptopower/ui/values"
 )
 
@@ -60,7 +59,7 @@ func NewRestorePage(l *load.Load, walletName string, walletType libutils.AssetTy
 		toggleSeedInput:  l.Theme.Switch(),
 	}
 
-	pg.backButton, _ = components.SubpageHeaderButtons(l)
+	pg.backButton, _ = SubpageHeaderButtons(l)
 	pg.backButton.Icon = pg.Theme.Icons.ContentClear
 
 	pg.seedInputEditor = l.Theme.Editor(new(widget.Editor), values.String(values.StrEnterWalletSeed))
@@ -96,7 +95,7 @@ func (pg *Restore) Layout(gtx C) D {
 
 func (pg *Restore) layoutDesktop(gtx C) D {
 	body := func(gtx C) D {
-		sp := components.SubPage{
+		sp := SubPage{
 			Load:       pg.Load,
 			Title:      values.String(values.StrRestoreWallet),
 			BackButton: pg.backButton,
@@ -109,12 +108,12 @@ func (pg *Restore) layoutDesktop(gtx C) D {
 		}
 		return sp.Layout(pg.ParentWindow(), gtx)
 	}
-	return components.UniformPadding(gtx, body)
+	return UniformPadding(gtx, body)
 }
 
 func (pg *Restore) layoutMobile(gtx C) D {
 	body := func(gtx C) D {
-		sp := components.SubPage{
+		sp := SubPage{
 			Load:       pg.Load,
 			Title:      values.String(values.StrRestoreWallet),
 			BackButton: pg.backButton,
@@ -127,11 +126,11 @@ func (pg *Restore) layoutMobile(gtx C) D {
 		}
 		return sp.Layout(pg.ParentWindow(), gtx)
 	}
-	return components.UniformMobile(gtx, false, false, body)
+	return UniformMobile(gtx, false, false, body)
 }
 
 func (pg *Restore) restoreLayout(gtx layout.Context) layout.Dimensions {
-	return components.UniformPadding(gtx, func(gtx C) D {
+	return UniformPadding(gtx, func(gtx C) D {
 		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 			layout.Rigid(pg.tabLayout),
 			layout.Rigid(pg.Theme.Separator().Layout),
@@ -353,7 +352,7 @@ func (pg *Restore) restoreFromSeedEditor() {
 
 	seedOrHex := strings.TrimSpace(pg.seedInputEditor.Editor.Text())
 	// Check if the user did input a hex or seed. If its a hex set the correct tabindex.
-	if len(seedOrHex) > components.MaxSeedBytes {
+	if len(seedOrHex) > MaxSeedBytes {
 		pg.tabIndex = 0
 	} else {
 		pg.tabIndex = 1

--- a/ui/page/components/seed_restore_page.go
+++ b/ui/page/components/seed_restore_page.go
@@ -1,4 +1,4 @@
-package info
+package components
 
 import (
 	"fmt"

--- a/ui/page/components/wallet_account_selector.go
+++ b/ui/page/components/wallet_account_selector.go
@@ -444,22 +444,7 @@ func (sm *selectorModal) OnResume() {
 func (sm *selectorModal) setupWallet(assetType ...utils.AssetType) {
 	selectorItems := make([]*SelectorItem, 0)
 
-	var wallets []sharedW.Asset
-	for _, asset := range assetType {
-		switch asset {
-		case utils.BTCWalletAsset:
-			wallets = append(wallets, sm.WL.AssetsManager.AllBTCWallets()...)
-		case utils.DCRWalletAsset:
-			wallets = append(wallets, sm.WL.AssetsManager.AllDCRWallets()...)
-		case utils.LTCWalletAsset:
-			wallets = append(wallets, sm.WL.AssetsManager.AllLTCWallets()...)
-		}
-	}
-
-	if len(wallets) == 0 {
-		wallets = sm.WL.AssetsManager.AllWallets()
-	}
-
+	wallets := sm.WL.AssetsManager.AssetWallets(assetType...)
 	for _, wal := range wallets {
 		if wal.IsWatchingOnlyWallet() && !sm.isWatchOnlyEnabled {
 			continue

--- a/ui/page/components/wallet_setup_page.go
+++ b/ui/page/components/wallet_setup_page.go
@@ -635,13 +635,3 @@ func (pg *CreateWallet) validRestoreWalletInputs() bool {
 
 	return true
 }
-
-// func (pg *CreateWallet) walletCreationSuccessCallback() {
-// 	// display the overview page if the user is creating a wallet
-// 	// for the first time (i.e coming from the onboarding page)
-// 	if len(pg.WL.AssetsManager.AllWallets()) == 1 {
-// 		pg.ParentNavigator().Display(NewHomePage(pg.Load))
-// 		return
-// 	}
-// 	pg.ParentNavigator().Display(NewWalletSelectorPage(pg.Load))
-// }

--- a/ui/page/exchange/create_order_page.go
+++ b/ui/page/exchange/create_order_page.go
@@ -1161,17 +1161,25 @@ func (pg *CreateOrderPage) loadOrderConfig() {
 
 		sourceAccount = exchangeConfig.SourceAccountNumber
 		destinationAccount = exchangeConfig.DestinationAccountNumber
-	} else {
+	}
+
+	noSourceWallet := sourceWallet == nil || sourceWallet.Asset == nil
+	noDestinationWallet := destinationWallet == nil || destinationWallet.Asset == nil
+	if noSourceWallet || noDestinationWallet {
 		// New exchange configuration will be generated using the set asset
 		// types since none existed before. It two distinct asset type wallet
 		// don't exist execution does get here.
 		wallets := pg.WL.AssetsManager.AllWallets()
-		pg.fromCurrency = wallets[0].GetAssetType()
+		if noSourceWallet {
+			pg.fromCurrency = wallets[0].GetAssetType()
+		}
 
-		for _, w := range wallets {
-			if w.GetAssetType() != pg.fromCurrency {
-				pg.toCurrency = w.GetAssetType()
-				break
+		if noDestinationWallet {
+			for _, w := range wallets {
+				if w.GetAssetType() != pg.fromCurrency {
+					pg.toCurrency = w.GetAssetType()
+					break
+				}
 			}
 		}
 	}
@@ -1180,7 +1188,7 @@ func (pg *CreateOrderPage) loadOrderConfig() {
 	pg.sourceWalletSelector = components.NewWalletAndAccountSelector(pg.Load, pg.fromCurrency).
 		Title(values.String(values.StrSource))
 
-	if sourceWallet == nil {
+	if noSourceWallet {
 		isConfigUpdateRequired = true
 		pg.sourceWalletSelector.SetSelectedAsset(pg.fromCurrency)
 		sourceWallet = pg.sourceWalletSelector.SelectedWallet()
@@ -1216,7 +1224,7 @@ func (pg *CreateOrderPage) loadOrderConfig() {
 	pg.destinationWalletSelector = components.NewWalletAndAccountSelector(pg.Load, pg.toCurrency).
 		Title(values.String(values.StrDestination))
 
-	if destinationWallet == nil {
+	if noDestinationWallet {
 		isConfigUpdateRequired = true
 		pg.destinationWalletSelector.SetSelectedAsset(pg.toCurrency)
 		destinationWallet = pg.destinationWalletSelector.SelectedWallet()

--- a/ui/page/root/wallet_selector_page.go
+++ b/ui/page/root/wallet_selector_page.go
@@ -187,7 +187,9 @@ func (pg *WalletSelectorPage) HandleUserInteractions() {
 
 	for asset, clickable := range pg.addWalClickable {
 		if clickable.Clicked() {
-			pg.ParentNavigator().Display(NewCreateWallet(pg.Load, asset))
+			pg.ParentNavigator().Display(components.NewCreateWallet(pg.Load, func() {
+				pg.ParentNavigator().ClosePagesAfter(WalletSelectorPageID)
+			}, asset))
 		}
 	}
 }

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -13,6 +13,7 @@ import (
 	"github.com/crypto-power/cryptopower/ui/cryptomaterial"
 	"github.com/crypto-power/cryptopower/ui/load"
 	"github.com/crypto-power/cryptopower/ui/modal"
+	"github.com/crypto-power/cryptopower/ui/page/components"
 	"github.com/crypto-power/cryptopower/ui/page/root"
 	"github.com/crypto-power/cryptopower/ui/values"
 )
@@ -171,7 +172,10 @@ func (sp *startPage) openWallets(password string) error {
 // Part of the load.Page interface.
 func (sp *startPage) HandleUserInteractions() {
 	if sp.addWalletButton.Clicked() {
-		sp.ParentNavigator().Display(root.NewCreateWallet(sp.Load))
+		sp.ParentNavigator().Display(components.NewCreateWallet(sp.Load, func() {
+			sp.ParentNavigator().Display(root.NewHomePage(sp.Load))
+			return
+		}))
 	}
 
 	if sp.skipButton.Clicked() {

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -174,7 +174,6 @@ func (sp *startPage) HandleUserInteractions() {
 	if sp.addWalletButton.Clicked() {
 		sp.ParentNavigator().Display(components.NewCreateWallet(sp.Load, func() {
 			sp.ParentNavigator().Display(root.NewHomePage(sp.Load))
-			return
 		}))
 	}
 

--- a/ui/values/localizable/en.go
+++ b/ui/values/localizable/en.go
@@ -788,4 +788,5 @@ const EN = `
 "minimumBondStrength" = "Minimum Bond Strength is %d"
 "assets" = "Assets"
 "noWalletsAvailable" = "You cannot spend from a watch only wallet, try creating another wallet."
+"createAssetWalletToSwapMsg" = "You need to create a %s wallet to swap."
 `

--- a/ui/values/strings.go
+++ b/ui/values/strings.go
@@ -898,4 +898,5 @@ const (
 	StrMinimumBondStrength             = "minimumBondStrength"
 	StrAssets                          = "assets"
 	StrNoWalletsAvailable              = "noWalletsAvailable"
+	StrCreateAssetWalletToSwapMsg      = "createAssetWalletToSwapMsg"
 )


### PR DESCRIPTION
This fixes a bug that caused a panic on the create order page and makes it a no-op when an asset with zero wallets is selected as a swap asset.

I'm also wondering if we should prompt the user to create the wallet(1), remove the wallet from the list(2) or just do a no-op(MR).

EDIT: I implemented option (1). 

This required moving some reusable files to the components package. I think it's a step a good direction since DEX is coming and we will also need to be able to create missing wallets from the market/main dex page.

Made a vid of the changes and will upload it soon.



closes #197 