### PR TITLE
Fix crash when import watch-only wallet and click send button

### DIFF
--- a/app/masterpage.go
+++ b/app/masterpage.go
@@ -1,7 +1,5 @@
 package app
 
-import "fmt"
-
 // MasterPage is a page that can display subpages. It is an extension of the
 // GenericPageModal which provides access to the Window or PageNavigator that
 // was used to display the MasterPage. The ParentNavigator of a MasterPage is
@@ -87,8 +85,6 @@ func (masterPage *MasterPage) ClearStackAndDisplay(newPage Page) {
 // CloseAllPages dismisses all pages in the stack.
 // Part of the PageNavigator interface.
 func (masterPage *MasterPage) CloseAllPages() {
-	fmt.Println("------CloseAllPages---111----")
 	masterPage.subPages.Reset()
-	fmt.Println("------CloseAllPages---2222----")
 	masterPage.ParentWindow().Reload()
 }

--- a/app/masterpage.go
+++ b/app/masterpage.go
@@ -1,5 +1,7 @@
 package app
 
+import "fmt"
+
 // MasterPage is a page that can display subpages. It is an extension of the
 // GenericPageModal which provides access to the Window or PageNavigator that
 // was used to display the MasterPage. The ParentNavigator of a MasterPage is
@@ -85,6 +87,8 @@ func (masterPage *MasterPage) ClearStackAndDisplay(newPage Page) {
 // CloseAllPages dismisses all pages in the stack.
 // Part of the PageNavigator interface.
 func (masterPage *MasterPage) CloseAllPages() {
+	fmt.Println("------CloseAllPages---111----")
 	masterPage.subPages.Reset()
+	fmt.Println("------CloseAllPages---2222----")
 	masterPage.ParentWindow().Reload()
 }

--- a/libwallet/assets/dcr/wallet.go
+++ b/libwallet/assets/dcr/wallet.go
@@ -155,7 +155,8 @@ func CreateWatchOnlyWallet(walletName, extendedPublicKey string, params *sharedW
 		syncData: &SyncData{
 			syncProgressListeners: make(map[string]sharedW.SyncProgressListener),
 		},
-		txAndBlockNotificationListeners: make(map[string]sharedW.TxAndBlockNotificationListener),
+		txAndBlockNotificationListeners:  make(map[string]sharedW.TxAndBlockNotificationListener),
+		accountMixerNotificationListener: make(map[string]AccountMixerNotificationListener),
 	}
 
 	dcrWallet.SetNetworkCancelCallback(dcrWallet.SafelyCancelSync)

--- a/ui/cryptomaterial/slider.go
+++ b/ui/cryptomaterial/slider.go
@@ -57,8 +57,12 @@ func (s *Slider) Layout(gtx C, items []layout.Widget) D {
 		s.items = items
 		s.isSliderItemsSet = true
 	}
-	s.handleClickEvent()
 
+	if len(s.items) == 0 {
+		return D{}
+	}
+
+	s.handleClickEvent()
 	gtx.Constraints.Max = s.items[s.selected](gtx).Size
 	return layout.Stack{Alignment: layout.S}.Layout(gtx,
 		layout.Expanded(s.items[s.selected]),
@@ -136,10 +140,6 @@ func (s *Slider) selectedItemIndicatorLayout(gtx C) D {
 
 func (s *Slider) containerLayout(gtx C, content layout.Widget) D {
 	return s.card.Layout(gtx, content)
-}
-
-func (s *Slider) centerLayout(gtx C, content layout.Widget) D {
-	return layout.Center.Layout(gtx, content)
 }
 
 func (s *Slider) RefreshItems() {

--- a/ui/page/root/home_page.go
+++ b/ui/page/root/home_page.go
@@ -215,13 +215,15 @@ func (hp *HomePage) HandleUserInteractions() {
 				hp.ParentWindow().ShowModal(components.NewReceiveModal(hp.Load))
 			case values.StrSend:
 				allWallets := hp.WL.AssetsManager.AllWallets()
-				if len(allWallets) == 1 {
-					if allWallets[0].IsWatchingOnlyWallet() {
-						if hp.WL.SelectedWallet == nil {
-							hp.showWarningNoWallet()
-							return
-						}
+				isSendAvailable := false
+				for _, wallet := range allWallets {
+					if !wallet.IsWatchingOnlyWallet() {
+						isSendAvailable = true
 					}
+				}
+				if !isSendAvailable {
+					hp.showWarningNoWallet()
+					return
 				}
 				hp.ParentWindow().ShowModal(send.NewSendPage(hp.Load, true))
 			}

--- a/ui/page/root/home_page.go
+++ b/ui/page/root/home_page.go
@@ -214,9 +214,14 @@ func (hp *HomePage) HandleUserInteractions() {
 			case values.StrReceive:
 				hp.ParentWindow().ShowModal(components.NewReceiveModal(hp.Load))
 			case values.StrSend:
-				if hp.WL.SelectedWallet == nil {
-					hp.showWarningNoWallet()
-					return
+				allWallets := hp.WL.AssetsManager.AllWallets()
+				if len(allWallets) == 1 {
+					if allWallets[0].IsWatchingOnlyWallet() {
+						if hp.WL.SelectedWallet == nil {
+							hp.showWarningNoWallet()
+							return
+						}
+					}
 				}
 				hp.ParentWindow().ShowModal(send.NewSendPage(hp.Load, true))
 			}

--- a/ui/page/root/home_page.go
+++ b/ui/page/root/home_page.go
@@ -40,7 +40,6 @@ type HomePage struct {
 	appLevelSettingsButton *cryptomaterial.Clickable
 	appNotificationButton  *cryptomaterial.Clickable
 	hideBalanceButton      *cryptomaterial.Clickable
-	checkBox               cryptomaterial.CheckBoxStyle
 	infoButton             cryptomaterial.IconButton // TOD0: use *cryptomaterial.Clickable
 
 	bottomNavigationBar  components.BottomNavigationBar
@@ -215,6 +214,10 @@ func (hp *HomePage) HandleUserInteractions() {
 			case values.StrReceive:
 				hp.ParentWindow().ShowModal(components.NewReceiveModal(hp.Load))
 			case values.StrSend:
+				if hp.WL.SelectedWallet == nil {
+					hp.showWarningNoWallet()
+					return
+				}
 				hp.ParentWindow().ShowModal(send.NewSendPage(hp.Load, true))
 			}
 		}
@@ -275,6 +278,16 @@ func (hp *HomePage) HandleUserInteractions() {
 			}
 		}
 	}
+}
+
+func (hp *HomePage) showWarningNoWallet() {
+	go func() {
+		info := modal.NewCustomModal(hp.Load).
+			PositiveButtonStyle(hp.Theme.Color.Primary, hp.Theme.Color.Surface).
+			SetContentAlignment(layout.W, layout.W, layout.Center).
+			Body(values.String(values.StrNoWalletsAvailable))
+		hp.ParentWindow().ShowModal(info)
+	}()
 }
 
 // KeysToHandle returns an expression that describes a set of key combinations

--- a/ui/values/localizable/en.go
+++ b/ui/values/localizable/en.go
@@ -787,5 +787,5 @@ const EN = `
 "bondStrengthErrMsg" = "Bond Strength must be a valid number"
 "minimumBondStrength" = "Minimum Bond Strength is %d"
 "assets" = "Assets"
-"noWalletsAvailable" = "There are no wallets available for this function, Please try again later."
+"noWalletsAvailable" = "You cannot spend from a watch only wallet, try creating another wallet."
 `

--- a/ui/values/localizable/en.go
+++ b/ui/values/localizable/en.go
@@ -786,4 +786,5 @@ const EN = `
 "bondStrengthErrMsg" = "Bond Strength must be a valid number"
 "minimumBondStrength" = "Minimum Bond Strength is %d"
 "assets" = "Assets"
+"noWalletsAvailable" = "There are no wallets available for this function, Please try again later."
 `

--- a/ui/values/strings.go
+++ b/ui/values/strings.go
@@ -896,4 +896,5 @@ const (
 	StrBondStrengthErrMsg              = "bondStrengthErrMsg"
 	StrMinimumBondStrength             = "minimumBondStrength"
 	StrAssets                          = "assets"
+	StrNoWalletsAvailable              = "noWalletsAvailable"
 )

--- a/ui/window.go
+++ b/ui/window.go
@@ -282,6 +282,9 @@ func (win *Window) prepareToDisplayUI(evt system.FrameEvent) *op.Ops {
 		if modal := win.navigator.TopModal(); modal != nil {
 			gtx = gtx.Disabled()
 		}
+		if win.navigator.CurrentPage() == nil {
+			win.navigator.Display(page.NewStartPage(win.load))
+		}
 		return win.navigator.CurrentPage().Layout(gtx)
 	})
 


### PR DESCRIPTION
Resolve #182 

This PR fix:
- App crash when import only watch-only wallet.
- App crash when click send button
- App crash when import mixed account of watch-only wallet
- App crash when delete wallet.

![pr1](https://github.com/crypto-power/cryptopower/assets/19331824/b1cb3402-25a7-410a-968a-98a032da427a)
