### PR TITLE
page/root: display correct wallet page after deleting existing wallet

### DIFF
--- a/libwallet/assets_manager.go
+++ b/libwallet/assets_manager.go
@@ -505,6 +505,10 @@ func (mgr *AssetsManager) AllWallets() (wallets []sharedW.Asset) {
 // DeleteWallet deletes a wallet from the assets manager.
 func (mgr *AssetsManager) DeleteWallet(walletID int, privPass string) error {
 	wallet := mgr.WalletWithID(walletID)
+	if wallet == nil { // already deleted?
+		return nil
+	}
+
 	if err := wallet.DeleteWallet(privPass); err != nil {
 		return err
 	}

--- a/ui/page/root/wallet_settings_page.go
+++ b/ui/page/root/wallet_settings_page.go
@@ -437,13 +437,12 @@ func (pg *WalletSettingsPage) deleteWalletModal() {
 			}
 
 			walletDeleted := func() {
+				m.Dismiss()
+				pg.ParentWindow().CloseAllPages()
 				if pg.WL.AssetsManager.LoadedWalletsCount() > 0 {
-					m.Dismiss()
-					pg.ParentNavigator().CloseCurrentPage()
-					pg.ParentWindow().Display(NewWalletSelectorPage(pg.Load))
-				} else {
-					m.Dismiss()
-					pg.ParentWindow().CloseAllPages()
+					hp := NewHomePage(pg.Load)
+					pg.ParentWindow().Display(hp)
+					hp.Display(NewWalletSelectorPage(hp.Load))
 				}
 			}
 


### PR DESCRIPTION
Closes #206.

After deleting a wallet, we only care about returning to the wallet page(if there are more wallets). This MR fixes a bug that overwrites the "HomePage" display with just the wallet selection page display after deleting a wallet.