### PR TITLE
fix bug with onboarding screens showing when app is quiting

### DIFF
--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -224,7 +224,7 @@ func (sp *startPage) Layout(gtx C) D {
 
 // Desktop layout
 func (sp *startPage) layoutDesktop(gtx C) D {
-	if sp.currentPage < 0 {
+	if sp.currentPage < 0 || sp.isQuitting {
 		return sp.loadingSection(gtx)
 	}
 


### PR DESCRIPTION
the PR fixes #225.

It prevents the onboarding screens from showing up when wallet is shutting down.