### PR TITLE
Improve infinite scroll list functionality

### DIFF
--- a/ui/page/components/items_scroll.go
+++ b/ui/page/components/items_scroll.go
@@ -60,8 +60,8 @@ func NewScroll[T any](load *load.Load, pageSize int32, queryFunc ScrollFunc[T]) 
 
 // FetchScrollData is a mutex protected fetchScrollData function. At the end of
 // the function call a window reload is triggered. Returns that latest records.
-// isReset is used to reset the offset value.
-func (s *Scroll[T]) FetchScrollData(isReset bool, window app.WindowNavigator) {
+// If reset is true, the offset value will be reset to 0.
+func (s *Scroll[T]) FetchScrollData(reset bool, window app.WindowNavigator) {
 	s.mu.Lock()
 	// s.data is not nil when moving from details page to list page.
 	if s.data != nil {
@@ -70,9 +70,8 @@ func (s *Scroll[T]) FetchScrollData(isReset bool, window app.WindowNavigator) {
 		s.offset -= s.pageSize
 	}
 	s.mu.Unlock()
-	// set isReverse to default false as callers of this method are not
-	// perform a reverse scroll action
-	s.fetchScrollData(false, isReset, window)
+	// set isReverse = false since this method is only called when scrolling down
+	s.fetchScrollData(false, reset, window)
 }
 
 // fetchScrollData fetchs the scroll data and manages data returned depending on
@@ -80,11 +79,10 @@ func (s *Scroll[T]) FetchScrollData(isReset bool, window app.WindowNavigator) {
 // the page, all the old data is replaced by the new fetched data making it
 // easier and smoother to scroll on the UI. At the end of the function call
 // a window reload is triggered.
-func (s *Scroll[T]) fetchScrollData(isReverse, isReset bool, window app.WindowNavigator) {
+func (s *Scroll[T]) fetchScrollData(isReverse, reset bool, window app.WindowNavigator) {
 	s.mu.Lock()
 
-	if isReset {
-		// resets the values for use on the next iteration.
+	if reset {
 		s.resetList()
 	}
 
@@ -100,7 +98,7 @@ func (s *Scroll[T]) fetchScrollData(isReverse, isReset bool, window app.WindowNa
 	if isReverse {
 		s.offset -= s.pageSize
 	} else {
-		if s.data != nil && !isReset {
+		if s.data != nil && !reset {
 			s.offset += s.pageSize
 		}
 	}

--- a/ui/page/components/items_scroll.go
+++ b/ui/page/components/items_scroll.go
@@ -12,6 +12,8 @@ import (
 	"github.com/crypto-power/cryptopower/ui/modal"
 )
 
+const maxListSize = 150
+
 // ScrollFunc is a query function that accepts offset and pagesize parameters and
 // returns data interface and an error.
 type ScrollFunc[T any] func(offset, pageSize int32) (data []T, err error)
@@ -123,16 +125,17 @@ func (s *Scroll[T]) fetchScrollData(isReverse, isReset bool, window app.WindowNa
 	}
 
 	if isReverse {
-		// TODO. Prepend and trim list from the bottom when list gets to an accepted list size.
-		// s.data = append(items, s.data...)
-		// s.data = s.data[:len(s.data)-int(s.pageSize)]
+		s.data = append(items, s.data...)
+		s.data = s.data[:len(s.data)-int(s.pageSize)]
 	} else {
 		s.data = append(s.data, items...) // append to existing record
-		// TODO. trim list from the top when list gets to an accepted list size.
-		// if itemsLen == int(tempSize) {
-		// 	s.data = s.data[len(s.data)-int(s.pageSize):]
-		// }
+		if len(s.data) > maxListSize {
+			s.data = s.data[int(s.pageSize):]
+		}
 	}
+
+	// set default scroll position to half the page to make navigation fluid
+	s.list.Position.Offset = int(float32(s.list.Position.Length) * 0.5)
 
 	s.itemsCount = itemsLen
 	s.isLoadingItems = false

--- a/ui/page/exchange/create_order_page.go
+++ b/ui/page/exchange/create_order_page.go
@@ -1022,9 +1022,9 @@ func (pg *CreateOrderPage) layout(gtx C) D {
 	)
 }
 
-func (pg *CreateOrderPage) fetchOrders(offset, pageSize int32) ([]*instantswap.Order, int, bool, error) {
+func (pg *CreateOrderPage) fetchOrders(offset, pageSize int32) ([]*instantswap.Order, int, error) {
 	orders := components.LoadOrders(pg.Load, offset, pageSize, true)
-	return orders, len(orders), false, nil
+	return orders, len(orders), nil
 }
 
 func (pg *CreateOrderPage) layoutHistory(gtx C) D {
@@ -1295,11 +1295,11 @@ func (pg *CreateOrderPage) listenForNotifications() {
 
 	orderNotificationListener := &instantswap.OrderNotificationListener{
 		OnExchangeOrdersSynced: func() {
-			pg.scroll.FetchScrollData(false, pg.ParentWindow())
+			pg.scroll.FetchScrollData(true, pg.ParentWindow())
 			pg.ParentWindow().Reload()
 		},
 		OnOrderCreated: func(order *instantswap.Order) {
-			pg.scroll.FetchScrollData(false, pg.ParentWindow())
+			pg.scroll.FetchScrollData(true, pg.ParentWindow())
 			pg.ParentWindow().Reload()
 		},
 		OnOrderSchedulerStarted: func() {

--- a/ui/page/exchange/create_order_page.go
+++ b/ui/page/exchange/create_order_page.go
@@ -1022,9 +1022,9 @@ func (pg *CreateOrderPage) layout(gtx C) D {
 	)
 }
 
-func (pg *CreateOrderPage) fetchOrders(offset, pageSize int32) ([]*instantswap.Order, int, error) {
+func (pg *CreateOrderPage) fetchOrders(offset, pageSize int32) ([]*instantswap.Order, error) {
 	orders := components.LoadOrders(pg.Load, offset, pageSize, true)
-	return orders, len(orders), nil
+	return orders, nil
 }
 
 func (pg *CreateOrderPage) layoutHistory(gtx C) D {
@@ -1046,10 +1046,9 @@ func (pg *CreateOrderPage) layoutHistory(gtx C) D {
 							Border:      cryptomaterial.Border{Radius: cryptomaterial.Radius(14)},
 							Padding:     layout.UniformInset(values.MarginPadding15),
 							Margin:      layout.Inset{Bottom: values.MarginPadding4, Top: values.MarginPadding4},
-						}.
-							Layout2(gtx, func(gtx C) D {
-								return components.OrderItemWidget(gtx, pg.Load, orderItems[i])
-							})
+						}.Layout2(gtx, func(gtx C) D {
+							return components.OrderItemWidget(gtx, pg.Load, orderItems[i])
+						})
 					})
 				})
 			})

--- a/ui/page/exchange/order_history_page.go
+++ b/ui/page/exchange/order_history_page.go
@@ -216,7 +216,7 @@ func (pg *OrderHistoryPage) layout(gtx C) D {
 	})
 }
 
-func (pg *OrderHistoryPage) fetchOrders(offset, pageSize int32) ([]*instantswap.Order, int, error) {
+func (pg *OrderHistoryPage) fetchOrders(offset, pageSize int32) ([]*instantswap.Order, error) {
 	selectedStatus := pg.statusDropdown.Selected()
 	var statusFilter api.Status
 	switch selectedStatus {
@@ -237,7 +237,7 @@ func (pg *OrderHistoryPage) fetchOrders(offset, pageSize int32) ([]*instantswap.
 	}
 
 	orders := components.LoadOrders(pg.Load, offset, pageSize, true, statusFilter)
-	return orders, len(orders), nil
+	return orders, nil
 }
 
 func (pg *OrderHistoryPage) layoutHistory(gtx C) D {

--- a/ui/page/governance/proposals_page.go
+++ b/ui/page/governance/proposals_page.go
@@ -113,7 +113,7 @@ func (pg *ProposalsPage) isGovernanceAPIAllowed() bool {
 
 // fetchProposals is thread safe and on completing proposals fetch it triggers
 // UI update with the new proposals list.
-func (pg *ProposalsPage) fetchProposals(offset, pageSize int32) ([]*components.ProposalItem, int, error) {
+func (pg *ProposalsPage) fetchProposals(offset, pageSize int32) ([]*components.ProposalItem, error) {
 	var proposalFilter int32
 	selectedType := pg.statusDropDown.Selected()
 	switch selectedType {
@@ -142,7 +142,7 @@ func (pg *ProposalsPage) fetchProposals(offset, pageSize int32) ([]*components.P
 		listItems = proposalItems
 	}
 
-	return listItems, len(listItems), nil
+	return listItems, nil
 }
 
 // HandleUserInteractions is called just before Layout() to determine

--- a/ui/page/staking/stake_list.go
+++ b/ui/page/staking/stake_list.go
@@ -33,16 +33,16 @@ func (pg *Page) stopTxNotificationsListener() {
 	pg.dcrImpl.RemoveTxAndBlockNotificationListener(OverviewPageID)
 }
 
-func (pg *Page) fetchTickets(offset, pageSize int32) ([]*transactionItem, int, error) {
+func (pg *Page) fetchTickets(offset, pageSize int32) ([]*transactionItem, error) {
 	txs, err := pg.WL.SelectedWallet.Wallet.GetTransactionsRaw(offset, pageSize, dcr.TxFilterTickets, true)
 	if err != nil {
-		return nil, -1, err
+		return nil, err
 	}
 
 	tickets, err := stakeToTransactionItems(pg.Load, txs, true, func(filter int32) bool {
 		return filter == dcr.TxFilterTickets
 	})
-	return tickets, len(tickets), err
+	return tickets, err
 }
 
 func (pg *Page) ticketListLayout(gtx C) D {

--- a/ui/page/staking/stake_list.go
+++ b/ui/page/staking/stake_list.go
@@ -33,16 +33,16 @@ func (pg *Page) stopTxNotificationsListener() {
 	pg.dcrImpl.RemoveTxAndBlockNotificationListener(OverviewPageID)
 }
 
-func (pg *Page) fetchTickets(offset, pageSize int32) ([]*transactionItem, int, bool, error) {
+func (pg *Page) fetchTickets(offset, pageSize int32) ([]*transactionItem, int, error) {
 	txs, err := pg.WL.SelectedWallet.Wallet.GetTransactionsRaw(offset, pageSize, dcr.TxFilterTickets, true)
 	if err != nil {
-		return nil, -1, false, err
+		return nil, -1, err
 	}
 
 	tickets, err := stakeToTransactionItems(pg.Load, txs, true, func(filter int32) bool {
 		return filter == dcr.TxFilterTickets
 	})
-	return tickets, len(tickets), false, err
+	return tickets, len(tickets), err
 }
 
 func (pg *Page) ticketListLayout(gtx C) D {

--- a/ui/page/staking/stake_overview.go
+++ b/ui/page/staking/stake_overview.go
@@ -110,7 +110,7 @@ func (pg *Page) OnNavigatedTo() {
 
 		go func() {
 			pg.showMaterialLoader = true
-			pg.scroll.FetchScrollData(false, pg.ParentWindow())
+			pg.scroll.FetchScrollData(true, pg.ParentWindow())
 			pg.showMaterialLoader = false
 		}()
 	}

--- a/ui/page/transaction/transactions_page.go
+++ b/ui/page/transaction/transactions_page.go
@@ -182,12 +182,12 @@ func (pg *TransactionsPage) refreshAvailableTxType() {
 	}()
 }
 
-func (pg *TransactionsPage) loadTransactions(offset, pageSize int32) ([]*sharedW.Transaction, int, bool, error) {
+func (pg *TransactionsPage) loadTransactions(offset, pageSize int32) ([]*sharedW.Transaction, int, error) {
 	wal := pg.WL.SelectedWallet.Wallet
 	mapinfo, _ := components.TxPageDropDownFields(wal.GetAssetType(), pg.selectedTabIndex)
 	if len(mapinfo) < 1 {
 		err := fmt.Errorf("asset type(%v) and tab index(%d) found", wal.GetAssetType(), pg.selectedTabIndex)
-		return nil, -1, false, err
+		return nil, -1, err
 	}
 
 	selectedVal, _, _ := strings.Cut(pg.txTypeDropDown.Selected(), " ")
@@ -195,21 +195,14 @@ func (pg *TransactionsPage) loadTransactions(offset, pageSize int32) ([]*sharedW
 	if !ok {
 		err := fmt.Errorf("unsupported field(%v) for asset type(%v) and tab index(%d) found",
 			selectedVal, wal.GetAssetType(), pg.selectedTabIndex)
-		return nil, -1, false, err
-	}
-
-	isReset := pg.previousTxFilter != txFilter
-	if isReset {
-		// reset the offset to zero
-		offset = 0
-		pg.previousTxFilter = txFilter
+		return nil, -1, err
 	}
 
 	tempTxs, err := wal.GetTransactionsRaw(offset, pageSize, txFilter, true)
 	if err != nil {
 		err = fmt.Errorf("Error loading transactions: %v", err)
 	}
-	return tempTxs, len(tempTxs), isReset, err
+	return tempTxs, len(tempTxs), err
 }
 
 // Layout draws the page UI components into the provided layout context
@@ -369,7 +362,7 @@ func (pg *TransactionsPage) layoutMobile(gtx layout.Context) layout.Dimensions {
 // Part of the load.Page interface.
 func (pg *TransactionsPage) HandleUserInteractions() {
 	for pg.txTypeDropDown.Changed() {
-		go pg.scroll.FetchScrollData(false, pg.ParentWindow())
+		go pg.scroll.FetchScrollData(true, pg.ParentWindow())
 		break
 	}
 
@@ -382,14 +375,14 @@ func (pg *TransactionsPage) HandleUserInteractions() {
 	if tabItemClicked, clickedTabIndex := pg.tabs.ItemClicked(); tabItemClicked {
 		pg.selectedTabIndex = clickedTabIndex
 		pg.refreshAvailableTxType()
-		go pg.scroll.FetchScrollData(false, pg.ParentWindow())
+		go pg.scroll.FetchScrollData(true, pg.ParentWindow())
 	}
 }
 
 func (pg *TransactionsPage) listenForTxNotifications() {
 	txAndBlockNotificationListener := &sharedW.TxAndBlockNotificationListener{
 		OnTransaction: func(transaction *sharedW.Transaction) {
-			pg.scroll.FetchScrollData(false, pg.ParentWindow())
+			pg.scroll.FetchScrollData(true, pg.ParentWindow())
 			pg.ParentWindow().Reload()
 		},
 	}

--- a/ui/page/transaction/transactions_page.go
+++ b/ui/page/transaction/transactions_page.go
@@ -182,12 +182,12 @@ func (pg *TransactionsPage) refreshAvailableTxType() {
 	}()
 }
 
-func (pg *TransactionsPage) loadTransactions(offset, pageSize int32) ([]*sharedW.Transaction, int, error) {
+func (pg *TransactionsPage) loadTransactions(offset, pageSize int32) ([]*sharedW.Transaction, error) {
 	wal := pg.WL.SelectedWallet.Wallet
 	mapinfo, _ := components.TxPageDropDownFields(wal.GetAssetType(), pg.selectedTabIndex)
 	if len(mapinfo) < 1 {
 		err := fmt.Errorf("asset type(%v) and tab index(%d) found", wal.GetAssetType(), pg.selectedTabIndex)
-		return nil, -1, err
+		return nil, err
 	}
 
 	selectedVal, _, _ := strings.Cut(pg.txTypeDropDown.Selected(), " ")
@@ -195,14 +195,14 @@ func (pg *TransactionsPage) loadTransactions(offset, pageSize int32) ([]*sharedW
 	if !ok {
 		err := fmt.Errorf("unsupported field(%v) for asset type(%v) and tab index(%d) found",
 			selectedVal, wal.GetAssetType(), pg.selectedTabIndex)
-		return nil, -1, err
+		return nil, err
 	}
 
 	tempTxs, err := wal.GetTransactionsRaw(offset, pageSize, txFilter, true)
 	if err != nil {
 		err = fmt.Errorf("Error loading transactions: %v", err)
 	}
-	return tempTxs, len(tempTxs), err
+	return tempTxs, err
 }
 
 // Layout draws the page UI components into the provided layout context


### PR DESCRIPTION
Closes #147 
Fixes #93 
and a follow up for #198

This PR improve the current list scroll functionality. It allows data to be continuously updated, without an obvious need to clear the already existing data, up until a maximum list size is attained, after which the first Nth items on the list are trimmed off.

It fixes issues with list items not being reset until the next iteration when `FetchScrollData()` is called.

It Fixes issues with the app freezing when the last item on a scroll list is reached and a user tries to preform more downwards sccroll.