### PR TITLE
Hide send tab option if wallet is watch only

### DIFF
--- a/ui/page/root/main_page.go
+++ b/ui/page/root/main_page.go
@@ -149,6 +149,7 @@ func (mp *MainPage) OnNavigatedTo() {
 func (mp *MainPage) initTabOptions() {
 	commonTabs := []string{
 		values.String(values.StrInfo),
+		values.String(values.StrReceive),
 		values.String(values.StrTransactions),
 		values.String(values.StrSettings),
 	}
@@ -156,7 +157,6 @@ func (mp *MainPage) initTabOptions() {
 	if !mp.selectedWallet.IsWatchingOnlyWallet() {
 		restrictedAccessTabs := []string{
 			values.String(values.StrSend),
-			values.String(values.StrReceive),
 		}
 
 		// update the tab options with additional items at specific index
@@ -170,8 +170,8 @@ func (mp *MainPage) initTabOptions() {
 		}
 
 		insertIndex := 4
-		if len(commonTabs) == 3 {
-			insertIndex = 2
+		if len(commonTabs) == 4 {
+			insertIndex = 3
 		}
 
 		// update the tab options with additional items at specific index

--- a/ui/page/root/main_page.go
+++ b/ui/page/root/main_page.go
@@ -149,10 +149,18 @@ func (mp *MainPage) OnNavigatedTo() {
 func (mp *MainPage) initTabOptions() {
 	commonTabs := []string{
 		values.String(values.StrInfo),
-		values.String(values.StrSend),
-		values.String(values.StrReceive),
 		values.String(values.StrTransactions),
 		values.String(values.StrSettings),
+	}
+
+	if !mp.selectedWallet.IsWatchingOnlyWallet() {
+		restrictedAccessTabs := []string{
+			values.String(values.StrSend),
+			values.String(values.StrReceive),
+		}
+
+		// update the tab options with additional items at specific index
+		commonTabs = append(commonTabs[:1], append(restrictedAccessTabs, commonTabs[1:]...)...)
 	}
 
 	if mp.selectedWallet.GetAssetType() == libutils.DCRWalletAsset {
@@ -161,8 +169,13 @@ func (mp *MainPage) initTabOptions() {
 			values.String(values.StrStaking),
 		}
 
+		insertIndex := 4
+		if len(commonTabs) == 3 {
+			insertIndex = 2
+		}
+
 		// update the tab options with additional items at specific index
-		commonTabs = append(commonTabs[:4], append(dcrSpecificTabs, commonTabs[4:]...)...)
+		commonTabs = append(commonTabs[:insertIndex], append(dcrSpecificTabs, commonTabs[insertIndex:]...)...)
 	}
 
 	mp.pageNavigationTab = mp.Theme.SegmentedControl(commonTabs)


### PR DESCRIPTION
Fix #200 

This PR hides the send and receive tab options when the selected wallet is a watch only wallet.