### PR TITLE
Update proposal card with lastest design

### DIFF
--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -964,6 +964,10 @@ func (pg *OverviewPage) recentTrades(gtx C) D {
 }
 
 func (pg *OverviewPage) recentProposal(gtx C) D {
+	if !pg.AssetsManager.IsHTTPAPIPrivacyModeOff(libutils.GovernanceHTTPAPI) {
+		return D{}
+	}
+
 	return pg.pageContentWrapper(gtx, values.String(values.StrRecentProposals), nil, func(gtx C) D {
 		if len(pg.proposalItems) == 0 {
 			gtx.Constraints.Min.X = gtx.Constraints.Max.X


### PR DESCRIPTION
- Update proposal card with lastest design (Mobile&Desktop)
- And fix bug where recent proposals are displayed when governance API is off.

Closes #286

Figma(I think the pre-status layout for the desktop looks incomplete on the Figma design as it's not properly aligned):
<img width="381" alt="Screenshot 2023-12-14 at 11 50 11 PM" src="https://github.com/crypto-power/cryptopower/assets/57448127/a6d974ef-4def-4fde-b7d2-812db86a2850">
<img width="815" alt="Screenshot 2023-12-14 at 11 50 41 PM" src="https://github.com/crypto-power/cryptopower/assets/57448127/d648bbab-c761-487e-abe6-2a794da2f478">

This PR:
<img width="373" alt="Screenshot 2023-12-14 at 11 51 35 PM" src="https://github.com/crypto-power/cryptopower/assets/57448127/e223dd5d-a7ac-4d79-96c6-0cc96acc8a77">
<img width="818" alt="Screenshot 2023-12-14 at 11 51 45 PM" src="https://github.com/crypto-power/cryptopower/assets/57448127/0540c341-c8c7-44f2-a33c-3e9c1c2c2a92">

