### PR TITLE
Refactor wallet info page and reduce text size in shared componenets for mobile

### DIFF
--- a/ui/cryptomaterial/icon_gallery.go
+++ b/ui/cryptomaterial/icon_gallery.go
@@ -11,7 +11,7 @@ import (
 type Icons struct {
 	ContentAdd, NavigationCheck, NavigationMore, ActionCheckCircle, ActionInfo, NavigationArrowBack,
 	NavigationArrowForward, ActionCheck, NavigationCancel, NavMoreIcon,
-	ImageBrightness1, ContentClear, DropDownIcon, Cached, ContentRemove, SearchIcon, PlayIcon,
+	DotIcon, ContentClear, DropDownIcon, Cached, ContentRemove, SearchIcon, PlayIcon,
 	ActionSettings, ActionSwapHoriz, ActionSwapVertical, NavigationRefresh, ContentCopy *widget.Icon
 
 	OverviewIcon, OverviewIconInactive, WalletIcon, WalletIconInactive, TradeIconActive, TradeIconInactive, MixerInactive, RedAlert, Alert,
@@ -53,7 +53,7 @@ func (i *Icons) StandardMaterialIcons() *Icons {
 	i.ActionInfo = MustIcon(widget.NewIcon(icons.ActionInfo))
 	i.ActionCheck = MustIcon(widget.NewIcon(icons.ActionCheckCircle))
 	i.NavigationCancel = MustIcon(widget.NewIcon(icons.NavigationCancel))
-	i.ImageBrightness1 = MustIcon(widget.NewIcon(icons.ImageBrightness1))
+	i.DotIcon = MustIcon(widget.NewIcon(icons.ImageBrightness1))
 	i.ContentClear = MustIcon(widget.NewIcon(icons.ContentClear))
 	i.DropDownIcon = MustIcon(widget.NewIcon(icons.NavigationArrowDropDown))
 	i.Cached = MustIcon(widget.NewIcon(icons.ActionCached))

--- a/ui/cryptomaterial/progressbar.go
+++ b/ui/cryptomaterial/progressbar.go
@@ -255,7 +255,7 @@ func (mp *MultiLayerProgressBar) Layout(gtx C, isMobileView bool, additionalWidg
 	return layout.Flex{Axis: layout.Vertical}.Layout(gtx, flexWidgets...)
 }
 
-func (t *Theme) ProgressBarCirle(progress int) ProgressCircleStyle {
+func (t *Theme) ProgressBarCircle(progress int) ProgressCircleStyle {
 	return ProgressCircleStyle{ProgressCircleStyle: material.ProgressCircle(t.Base, float32(progress)/100)}
 }
 

--- a/ui/cryptomaterial/slider.go
+++ b/ui/cryptomaterial/slider.go
@@ -150,7 +150,7 @@ func (s *Slider) selectedItemIndicatorLayout(gtx C) D {
 		}.Layout(gtx, func(gtx C) D {
 			list := &layout.List{Axis: layout.Horizontal}
 			return list.Layout(gtx, len(s.slideItems), func(gtx C, i int) D {
-				ic := NewIcon(s.t.Icons.ImageBrightness1)
+				ic := NewIcon(s.t.Icons.DotIcon)
 				ic.Color = values.TransparentColor(values.TransparentBlack, 0.2)
 				if i == s.selected {
 					ic.Color = s.SelectedIndicatorColor

--- a/ui/load/appinfo.go
+++ b/ui/load/appinfo.go
@@ -72,9 +72,7 @@ func (app *AppInfo) ConvertTextSize(size unit.Sp) unit.Sp {
 		return values.TextSize16
 	case values.TextSize18:
 		return values.TextSize14
-	case values.TextSize16:
-		return values.TextSize12
-	case values.TextSize14:
+	case values.TextSize16, values.TextSize14:
 		return values.TextSize12
 	default:
 		return size

--- a/ui/page/components/components.go
+++ b/ui/page/components/components.go
@@ -249,7 +249,7 @@ func TransactionTitleIcon(l *load.Load, wal sharedW.Asset, tx *sharedW.Transacti
 // LayoutTransactionRow is a single transaction row on the transactions and overview
 // page. It lays out a transaction's direction, balance, status. hideTxAssetInfo
 // determines if the transaction should display additional information about the tx
-// such as the wallet the tx belong to etc. This is usefil on pages where
+// such as the wallet the tx belong to etc. This is useful on pages where
 // the tx is displayed from multi wallets.
 func LayoutTransactionRow(gtx C, l *load.Load, wal sharedW.Asset, tx *sharedW.Transaction, hideTxAssetInfo bool) D {
 	gtx.Constraints.Min.X = gtx.Constraints.Max.X
@@ -310,7 +310,7 @@ func LayoutTransactionRow(gtx C, l *load.Load, wal sharedW.Asset, tx *sharedW.Tr
 						Direction:   layout.W,
 					}.Layout(gtx,
 						layout.Rigid(func(gtx C) D {
-							if hideTxAssetInfo {
+							if tx.Type == txhelper.TxTypeRegular {
 								return D{}
 							}
 
@@ -323,12 +323,12 @@ func LayoutTransactionRow(gtx C, l *load.Load, wal sharedW.Asset, tx *sharedW.Tr
 							return walBalTxt.Layout(gtx)
 						}),
 						layout.Rigid(func(gtx C) D {
-							if dcrAsset, ok := wal.(*dcr.Asset); ok && !hideTxAssetInfo {
+							if dcrAsset, ok := wal.(*dcr.Asset); ok {
 								if ok, _ := dcrAsset.TicketHasVotedOrRevoked(tx.Hash); ok {
 									return layout.Inset{
 										Left: values.MarginPadding4,
 									}.Layout(gtx, func(gtx C) D {
-										ic := cryptomaterial.NewIcon(l.Theme.Icons.ImageBrightness1)
+										ic := cryptomaterial.NewIcon(l.Theme.Icons.DotIcon)
 										ic.Color = grayText
 										return ic.Layout(gtx, values.MarginPadding6)
 									})
@@ -342,7 +342,7 @@ func LayoutTransactionRow(gtx C, l *load.Load, wal sharedW.Asset, tx *sharedW.Tr
 								ticketSpender, _ = dcrAsset.TicketSpender(tx.Hash)
 							}
 
-							if ticketSpender == nil || hideTxAssetInfo {
+							if ticketSpender == nil {
 								return D{}
 							}
 							amnt := wal.ToAmount(ticketSpender.VoteReward).ToCoin()
@@ -400,21 +400,22 @@ func LayoutTransactionRow(gtx C, l *load.Load, wal sharedW.Asset, tx *sharedW.Tr
 							layout.Rigid(func(gtx C) D {
 								return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
 									layout.Rigid(func(gtx C) D {
-										if isStaking {
-											if hideTxAssetInfo {
-												title := values.String(values.StrRevoke)
-												if tx.Type == txhelper.TxTypeVote {
-													title = values.String(values.StrVote)
-												}
+										if !isStaking {
+											return status.Layout(gtx)
+										}
 
-												lbl := l.Theme.Label(l.ConvertTextSize(values.TextSize16), fmt.Sprintf("%dd to %s", tx.DaysToVoteOrRevoke, title))
-												lbl.Color = grayText
-												return lbl.Layout(gtx)
-											}
+										if !hideTxAssetInfo {
 											return txStakingStatus(gtx, l, wal, tx)
 										}
 
-										return status.Layout(gtx)
+										title := values.String(values.StrRevoke)
+										if tx.Type == txhelper.TxTypeVote {
+											title = values.String(values.StrVote)
+										}
+
+										lbl := l.Theme.Label(l.ConvertTextSize(values.TextSize16), fmt.Sprintf("%dd to %s", tx.DaysToVoteOrRevoke, title))
+										lbl.Color = grayText
+										return lbl.Layout(gtx)
 									}),
 									layout.Rigid(func(gtx C) D {
 										return layout.Inset{Left: values.MarginPadding7}.Layout(gtx, statusIcon.Layout12dp)

--- a/ui/page/components/components.go
+++ b/ui/page/components/components.go
@@ -257,12 +257,14 @@ func LayoutTransactionRow(gtx C, l *load.Load, wal sharedW.Asset, tx *sharedW.Tr
 		return D{}
 	}
 
+	dp16 := values.MarginPaddingTransform(l.IsMobileView(), values.MarginPadding16)
 	txStatus := TransactionTitleIcon(l, wal, tx)
 	amount := wal.ToAmount(tx.Amount).String()
 	assetIcon := CoinImageBySymbol(l, wal.GetAssetType(), wal.IsWatchingOnlyWallet())
 	walName := l.Theme.Label(values.TextSize12, wal.GetWalletName())
 	grayText := l.Theme.Color.GrayText2
 	insetLeft := values.MarginPadding16
+
 	if !hideTxAssetInfo {
 		insetLeft = values.MarginPadding8
 	}
@@ -273,7 +275,7 @@ func LayoutTransactionRow(gtx C, l *load.Load, wal sharedW.Asset, tx *sharedW.Tr
 		Height:      cryptomaterial.WrapContent,
 		Alignment:   layout.Middle,
 		Padding: layout.Inset{
-			Top:    values.MarginPadding16,
+			Top:    dp16,
 			Bottom: values.MarginPadding10,
 		},
 	}.Layout(gtx,
@@ -355,7 +357,7 @@ func LayoutTransactionRow(gtx C, l *load.Load, wal sharedW.Asset, tx *sharedW.Tr
 			)
 		}),
 		layout.Flexed(1, func(gtx C) D {
-			txSize := values.TextSize16
+			txSize := l.ConvertTextSize(values.TextSize16)
 			if !hideTxAssetInfo {
 				txSize = values.TextSize12
 			}

--- a/ui/page/components/utils.go
+++ b/ui/page/components/utils.go
@@ -118,7 +118,7 @@ func LayoutIconAndTextWithSize(l *load.Load, gtx C, text string, col color.NRGBA
 				return layout.Inset{
 					Right: values.MarginPadding5,
 				}.Layout(gtx, func(gtx C) D {
-					ic := cryptomaterial.NewIcon(l.Theme.Icons.ImageBrightness1)
+					ic := cryptomaterial.NewIcon(l.Theme.Icons.DotIcon)
 					ic.Color = col
 					return ic.Layout(gtx, iconSize)
 				})

--- a/ui/page/components/votebar_widget.go
+++ b/ui/page/components/votebar_widget.go
@@ -57,7 +57,7 @@ func NewVoteBar(l *load.Load) *VoteBar {
 		noColor:       l.Theme.Color.Danger,
 		passTooltip:   l.Theme.Tooltip(),
 		quorumTooltip: l.Theme.Tooltip(),
-		legendIcon:    cryptomaterial.NewIcon(l.Theme.Icons.ImageBrightness1),
+		legendIcon:    cryptomaterial.NewIcon(l.Theme.Icons.DotIcon),
 	}
 
 	_, vb.infoButton = SubpageHeaderButtons(l)

--- a/ui/page/info/info_page.go
+++ b/ui/page/info/info_page.go
@@ -492,7 +492,13 @@ func (pg *WalletInfo) reloadMixerBalances() {
 }
 
 func (pg *WalletInfo) loadTransactions() {
-	txs, err := pg.wallet.GetTransactionsRaw(0, 3, libutils.TxFilterAllTx, true, "")
+	mapInfo, _ := components.TxPageDropDownFields(pg.wallet.GetAssetType(), 0)
+	if len(mapInfo) == 0 {
+		log.Errorf("no tx filters for asset type (%v)", pg.wallet.GetAssetType())
+		return
+	}
+
+	txs, err := pg.wallet.GetTransactionsRaw(0, 3, mapInfo[values.String(values.StrAll)], true,  "")
 	if err != nil {
 		log.Errorf("error loading transactions: %v", err)
 		return

--- a/ui/page/info/info_page.go
+++ b/ui/page/info/info_page.go
@@ -498,7 +498,7 @@ func (pg *WalletInfo) loadTransactions() {
 		return
 	}
 
-	txs, err := pg.wallet.GetTransactionsRaw(0, 3, mapInfo[values.String(values.StrAll)], true,  "")
+	txs, err := pg.wallet.GetTransactionsRaw(0, 3, mapInfo[values.String(values.StrAll)], true, "")
 	if err != nil {
 		log.Errorf("error loading transactions: %v", err)
 		return

--- a/ui/page/info/info_page.go
+++ b/ui/page/info/info_page.go
@@ -44,10 +44,10 @@ type WalletInfo struct {
 	container *widget.List
 
 	transactions       []*sharedW.Transaction
-	recentTransactions layout.List
+	recentTransactions *cryptomaterial.ClickableList
 
 	stakes       []*sharedW.Transaction
-	recentStakes layout.List
+	recentStakes *cryptomaterial.ClickableList
 
 	walletStatusIcon *cryptomaterial.Icon
 	syncSwitch       *cryptomaterial.Switch
@@ -84,14 +84,8 @@ func NewInfoPage(l *load.Load, wallet sharedW.Asset) *WalletInfo {
 		container: &widget.List{
 			List: layout.List{Axis: layout.Vertical},
 		},
-		recentTransactions: layout.List{
-			Axis:      layout.Vertical,
-			Alignment: layout.Middle,
-		},
-		recentStakes: layout.List{
-			Axis:      layout.Vertical,
-			Alignment: layout.Middle,
-		},
+		recentTransactions: l.Theme.NewClickableList(layout.Vertical),
+		recentStakes:       l.Theme.NewClickableList(layout.Vertical),
 	}
 	pg.toBackup = pg.Theme.Button(values.String(values.StrBackupNow))
 	pg.toBackup.Font.Weight = font.Medium
@@ -335,6 +329,14 @@ func (pg *WalletInfo) HandleUserInteractions() {
 				pg.wallet.SaveUserConfigValue(sharedW.AutoSyncConfigKey, b)
 			})
 		}()
+	}
+
+	if clicked, selectedItem := pg.recentTransactions.ItemClicked(); clicked {
+		pg.ParentNavigator().Display(transaction.NewTransactionDetailsPage(pg.Load, pg.wallet, pg.transactions[selectedItem]))
+	}
+
+	if clicked, selectedItem := pg.recentStakes.ItemClicked(); clicked {
+		pg.ParentNavigator().Display(transaction.NewTransactionDetailsPage(pg.Load, pg.wallet, pg.stakes[selectedItem]))
 	}
 
 	if pg.toBackup.Button.Clicked() {

--- a/ui/page/info/info_page.go
+++ b/ui/page/info/info_page.go
@@ -87,6 +87,11 @@ func NewInfoPage(l *load.Load, wallet sharedW.Asset) *WalletInfo {
 		recentTransactions: l.Theme.NewClickableList(layout.Vertical),
 		recentStakes:       l.Theme.NewClickableList(layout.Vertical),
 	}
+	pg.recentTransactions.Radius = cryptomaterial.Radius(14)
+	pg.recentTransactions.IsShadowEnabled = true
+	pg.recentStakes.Radius = cryptomaterial.Radius(14)
+	pg.recentStakes.IsShadowEnabled = true
+
 	pg.toBackup = pg.Theme.Button(values.String(values.StrBackupNow))
 	pg.toBackup.Font.Weight = font.Medium
 	pg.toBackup.TextSize = pg.ConvertTextSize(values.TextSize14)

--- a/ui/page/info/info_page.go
+++ b/ui/page/info/info_page.go
@@ -95,7 +95,7 @@ func NewInfoPage(l *load.Load, wallet sharedW.Asset) *WalletInfo {
 	}
 	pg.toBackup = pg.Theme.Button(values.String(values.StrBackupNow))
 	pg.toBackup.Font.Weight = font.Medium
-	pg.toBackup.TextSize = values.TextSize14
+	pg.toBackup.TextSize = pg.ConvertTextSize(values.TextSize14)
 
 	pg.viewAllTxButton = pg.Theme.OutlineButton(values.String(values.StrViewAll))
 	pg.viewAllTxButton.Font.Weight = font.Medium
@@ -150,23 +150,21 @@ func (pg *WalletInfo) OnNavigatedTo() {
 // Layout lays out the widgets for the main wallets pg.
 func (pg *WalletInfo) Layout(gtx C) D {
 	return pg.Theme.List(pg.container).Layout(gtx, 1, func(gtx C, i int) D {
-		return layout.Inset{Right: values.MarginPadding2}.Layout(gtx, func(gtx C) D {
-			items := []layout.FlexChild{layout.Rigid(pg.walletInfoLayout)}
+		items := []layout.FlexChild{layout.Rigid(pg.walletInfoLayout)}
 
-			if pg.wallet.GetAssetType() == libutils.DCRWalletAsset && pg.wallet.(*dcr.Asset).IsAccountMixerActive() {
-				items = append(items, layout.Rigid(pg.mixerLayout))
-			}
+		if pg.wallet.GetAssetType() == libutils.DCRWalletAsset && pg.wallet.(*dcr.Asset).IsAccountMixerActive() {
+			items = append(items, layout.Rigid(pg.mixerLayout))
+		}
 
-			if len(pg.transactions) > 0 {
-				items = append(items, layout.Rigid(pg.recentTransactionLayout))
-			}
+		if len(pg.transactions) > 0 {
+			items = append(items, layout.Rigid(pg.recentTransactionLayout))
+		}
 
-			if len(pg.stakes) > 0 {
-				items = append(items, layout.Rigid(pg.recentStakeLayout))
-			}
+		if len(pg.stakes) > 0 {
+			items = append(items, layout.Rigid(pg.recentStakeLayout))
+		}
 
-			return layout.Flex{Axis: layout.Vertical}.Layout(gtx, items...)
-		})
+		return layout.Flex{Axis: layout.Vertical}.Layout(gtx, items...)
 	})
 }
 
@@ -531,4 +529,7 @@ func (pg *WalletInfo) OnNavigatedFrom() {
 	pg.wallet.RemoveSyncProgressListener(InfoID)
 	pg.wallet.RemoveTxAndBlockNotificationListener(InfoID)
 	pg.wallet.SetBlocksRescanProgressListener(nil)
+	if pg.wallet.GetAssetType() == libutils.DCRWalletAsset {
+		pg.wallet.(*dcr.Asset).RemoveAccountMixerNotificationListener(InfoID)
+	}
 }

--- a/ui/page/info/sync_status.go
+++ b/ui/page/info/sync_status.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (pg *WalletInfo) initWalletStatusWidgets() {
-	pg.walletStatusIcon = cryptomaterial.NewIcon(pg.Theme.Icons.ImageBrightness1)
+	pg.walletStatusIcon = cryptomaterial.NewIcon(pg.Theme.Icons.DotIcon)
 	pg.syncSwitch = pg.Theme.Switch()
 }
 

--- a/ui/page/info/sync_status.go
+++ b/ui/page/info/sync_status.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"gioui.org/layout"
+	"gioui.org/unit"
 
 	libutils "github.com/crypto-power/cryptopower/libwallet/utils"
 	"github.com/crypto-power/cryptopower/ui/cryptomaterial"
@@ -66,7 +67,7 @@ func (pg *WalletInfo) syncStatusSection(gtx C) D {
 
 // syncBoxTitleRow lays out widgets in the title row inside the sync status box.
 func (pg *WalletInfo) syncBoxTitleRow(gtx C) D {
-	statusLabel := pg.Theme.Label(values.TextSize14, values.String(values.StrOffline))
+	statusLabel := pg.textSize14Label(values.String(values.StrOffline))
 	pg.walletStatusIcon.Color = pg.Theme.Color.Danger
 	if pg.wallet.IsConnectedToNetwork() {
 		statusLabel.Text = values.String(values.StrOnline)
@@ -75,19 +76,25 @@ func (pg *WalletInfo) syncBoxTitleRow(gtx C) D {
 
 	gtx.Constraints.Min.X = gtx.Constraints.Max.X
 	return layout.Flex{Axis: layout.Horizontal, Alignment: layout.End}.Layout(gtx,
-		layout.Rigid(pg.Theme.Label(values.TextSize14, values.String(values.StrWalletStatus)).Layout),
+		layout.Rigid(func(gtx C) D {
+			if pg.IsMobileView() {
+				return D{} // not enough space
+			}
+			return pg.textSize14Label(values.String(values.StrWalletStatus)).Layout(gtx)
+		}),
 		layout.Rigid(func(gtx C) D {
 			if pg.wallet.IsSyncShuttingDown() {
 				return layout.Inset{
 					Left: values.MarginPadding4,
-				}.Layout(gtx, pg.Theme.Label(values.TextSize14, values.String(values.StrCanceling)).Layout)
+				}.Layout(gtx, pg.textSize14Label(values.String(values.StrCanceling)).Layout)
 			}
 			return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
-					return layout.Inset{
-						Right: values.MarginPadding4,
-						Left:  values.MarginPadding4,
-					}.Layout(gtx, func(gtx C) D {
+					inset := layout.Inset{Right: values.MarginPadding4}
+					if !pg.IsMobileView() {
+						inset.Left = values.MarginPadding4
+					}
+					return inset.Layout(gtx, func(gtx C) D {
 						return pg.walletStatusIcon.Layout(gtx, values.MarginPadding15)
 					})
 				}),
@@ -97,15 +104,15 @@ func (pg *WalletInfo) syncBoxTitleRow(gtx C) D {
 						return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
 							layout.Rigid(func(gtx C) D {
 								connectedPeers := fmt.Sprintf("%d", pg.wallet.ConnectedPeers())
-								return pg.Theme.Label(values.TextSize14, values.StringF(values.StrConnectedTo, connectedPeers)).Layout(gtx)
+								return pg.textSize14Label(values.StringF(values.StrConnectedTo, connectedPeers)).Layout(gtx)
 							}),
 						)
 					}
 
 					if !pg.isStatusConnected {
-						return pg.Theme.Label(values.TextSize14, values.String(values.StrNoInternet)).Layout(gtx)
+						return pg.textSize14Label(values.String(values.StrNoInternet)).Layout(gtx)
 					}
-					return pg.Theme.Label(values.TextSize14, values.String(values.StrNoConnectedPeer)).Layout(gtx)
+					return pg.textSize14Label(values.String(values.StrNoConnectedPeer)).Layout(gtx)
 				}),
 			)
 		}),
@@ -113,6 +120,10 @@ func (pg *WalletInfo) syncBoxTitleRow(gtx C) D {
 			return layout.E.Layout(gtx, pg.layoutAutoSyncSection)
 		}),
 	)
+}
+
+func (pg *WalletInfo) textSize14Label(txt string) cryptomaterial.Label {
+	return pg.Theme.Label(pg.ConvertTextSize(values.TextSize14), txt)
 }
 
 func (pg *WalletInfo) syncStatusIcon(gtx C) D {
@@ -125,7 +136,7 @@ func (pg *WalletInfo) syncStatusIcon(gtx C) D {
 
 	i := layout.Inset{Left: values.MarginPadding16}
 	return i.Layout(gtx, func(gtx C) D {
-		return icon.LayoutSize(gtx, values.MarginPadding20)
+		return icon.LayoutSize(gtx, pg.ConvertIconSize(values.MarginPadding20))
 	})
 }
 
@@ -137,48 +148,37 @@ func (pg *WalletInfo) syncContent(gtx C, uniform layout.Inset) D {
 	isBtcORLtcAsset := isBtcAsset || isLtcAsset
 	// Rescanning should happen on a synced chain.
 	isRescanning := pg.wallet.IsRescanning() && !isSyncing
-	isInprogress := isSyncing || isRescanning
+	isInProgress := isSyncing || isRescanning
 	bestBlock := pg.wallet.GetBestBlock()
+	dp8 := values.MarginPadding8
 	return uniform.Layout(gtx, func(gtx C) D {
 		return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
 				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+					layout.Rigid(pg.labelTexSize16Layout(values.String(values.StrLatestBlock), dp8, true)),
 					layout.Rigid(func(gtx C) D {
-						latestBlockTitle := pg.Theme.Body1(values.String(values.StrLatestBlock))
-						latestBlockTitle.Color = pg.Theme.Color.GrayText2
-						return layout.Inset{Bottom: values.MarginPadding8}.Layout(gtx, latestBlockTitle.Layout)
-					}),
-					layout.Rigid(func(gtx C) D {
-						if !isInprogress {
+						if !isInProgress {
 							return D{}
 						}
-						blockHeaderFetched := pg.Theme.Body1(values.String(values.StrBlockHeaderFetched))
-						blockHeaderFetched.Color = pg.Theme.Color.GrayText2
-						return layout.Inset{Bottom: values.MarginPadding8}.Layout(gtx, blockHeaderFetched.Layout)
+						return pg.labelTexSize16Layout(values.String(values.StrBlockHeaderFetched), dp8, true)(gtx)
 					}),
 					layout.Rigid(func(gtx C) D {
 						if isRescanning && (isBtcORLtcAsset) {
 							return D{}
 						}
-						syncProgress := pg.Theme.Body1(values.String(values.StrSyncingProgress))
-						syncProgress.Color = pg.Theme.Color.GrayText2
-						return layout.Inset{Bottom: values.MarginPadding8}.Layout(gtx, syncProgress.Layout)
+						return pg.labelTexSize16Layout(values.String(values.StrSyncingProgress), dp8, true)(gtx)
 					}),
 					layout.Rigid(func(gtx C) D {
-						if !isInprogress || (isRescanning && (isBtcORLtcAsset)) {
+						if !isInProgress || (isRescanning && (isBtcORLtcAsset)) {
 							return D{}
 						}
-						estTime := pg.Theme.Body1(values.String(values.StrSyncCompTime))
-						estTime.Color = pg.Theme.Color.GrayText2
-						return estTime.Layout(gtx)
+						return pg.labelTexSize16Layout(values.String(values.StrSyncCompTime), dp8, true)(gtx)
 					}),
 					layout.Rigid(func(gtx C) D {
 						if !(isRescanning && (isBtcORLtcAsset)) {
 							return D{}
 						}
-						addrDiscovery := pg.Theme.Body1(values.String(values.StrAddressDiscoveryInProgress))
-						addrDiscovery.Color = pg.Theme.Color.GrayText2
-						return layout.Inset{Bottom: values.MarginPadding8}.Layout(gtx, addrDiscovery.Layout)
+						return pg.labelTexSize16Layout(values.String(values.StrAddressDiscoveryInProgress), dp8, true)(gtx)
 					}),
 				)
 			}),
@@ -186,18 +186,15 @@ func (pg *WalletInfo) syncContent(gtx C, uniform layout.Inset) D {
 				return layout.E.Layout(gtx, func(gtx C) D {
 					return layout.Flex{Axis: layout.Vertical, Alignment: layout.End}.Layout(gtx,
 						layout.Rigid(func(gtx C) D {
-							latestBlockTitle := pg.Theme.Body1(fmt.Sprintf("%d (%s)", bestBlock.Height, components.TimeAgo(bestBlock.Timestamp)))
-							return layout.Inset{Bottom: values.MarginPadding8}.Layout(gtx, latestBlockTitle.Layout)
+							latestBlockTitle := fmt.Sprintf("%d (%s)", bestBlock.Height, components.TimeAgo(bestBlock.Timestamp))
+							return pg.labelTexSize16Layout(latestBlockTitle, dp8, false)(gtx)
 						}),
 						layout.Rigid(func(gtx C) D {
-							if !isInprogress || (isRescanning && (isBtcORLtcAsset)) {
+							if !isInProgress || (isRescanning && (isBtcORLtcAsset)) {
 								return D{}
 							}
-							pgrss := pg.fetchSyncProgress()
-							blockHeightFetchedText := values.StringF(values.StrBlockHeaderFetchedCount, bestBlock.Height,
-								pgrss.headersToFetchOrScan)
-							blockHeightFetched := pg.Theme.Body1(blockHeightFetchedText)
-							return layout.Inset{Bottom: values.MarginPadding8}.Layout(gtx, blockHeightFetched.Layout)
+							blockHeightFetched := values.StringF(values.StrBlockHeaderFetchedCount, bestBlock.Height, pg.fetchSyncProgress().headersToFetchOrScan)
+							return pg.labelTexSize16Layout(blockHeightFetched, dp8, false)(gtx)
 						}),
 						layout.Rigid(func(gtx C) D {
 							currentSeconds := time.Now().Unix()
@@ -213,22 +210,31 @@ func (pg *WalletInfo) syncContent(gtx C, uniform layout.Inset) D {
 								syncProgress = values.String(values.StrComplete)
 							}
 
-							syncProgressBody := pg.Theme.Body1(syncProgress)
-							return layout.Inset{Bottom: values.MarginPadding8}.Layout(gtx, syncProgressBody.Layout)
+							return pg.labelTexSize16Layout(syncProgress, dp8, false)(gtx)
 						}),
 						layout.Rigid(func(gtx C) D {
-							if !isInprogress || (isRescanning && (isBtcORLtcAsset)) {
+							if !isInProgress || (isRescanning && (isBtcORLtcAsset)) {
 								return D{}
 							}
 							_, timeLeft := pg.progressStatusDetails()
-							estTime := pg.Theme.Body1(timeLeft)
-							return estTime.Layout(gtx)
+							return pg.labelTexSize16Layout(timeLeft, dp8, false)(gtx)
 						}),
 					)
 				})
 			}),
 		)
 	})
+}
+
+func (pg *WalletInfo) labelTexSize16Layout(txt string, bottomInset unit.Dp, colorGrey bool) func(gtx C) D {
+	return func(gtx C) D {
+		lbl := pg.Theme.Body1(txt)
+		if colorGrey {
+			lbl.Color = pg.Theme.Color.GrayText2
+		}
+		lbl.TextSize = pg.ConvertTextSize(values.TextSize16)
+		return layout.Inset{Bottom: bottomInset}.Layout(gtx, lbl.Layout)
+	}
 }
 
 func (pg *WalletInfo) layoutAutoSyncSection(gtx C) D {
@@ -251,7 +257,7 @@ func (pg *WalletInfo) progressBarRow(gtx C) D {
 		p.Color = pg.Theme.Color.Success
 		p.TrackColor = pg.Theme.Color.Gray2
 
-		progressTitleLabel := pg.Theme.Label(values.TextSize14, fmt.Sprintf("%v%%", progress))
+		progressTitleLabel := pg.textSize14Label(fmt.Sprintf("%v%%", progress))
 		progressTitleLabel.Color = pg.Theme.Color.Text
 		return p.TextLayout(gtx, progressTitleLabel.Layout)
 	})
@@ -297,22 +303,18 @@ func (pg *WalletInfo) rescanDetailsLayout(gtx C, inset layout.Inset) D {
 						})
 					}),
 					layout.Rigid(func(gtx C) D {
-						headersFetchedTitleLabel := pg.Theme.Body2(values.String(values.StrBlocksScanned))
-						headersFetchedTitleLabel.Color = pg.Theme.Color.GrayText2
-
-						blocksScannedLabel := pg.Theme.Body1(fmt.Sprint(pg.rescanUpdate.CurrentRescanHeight))
 						return inset.Layout(gtx, func(gtx C) D {
-							return components.EndToEndRow(gtx, headersFetchedTitleLabel.Layout, blocksScannedLabel.Layout)
+							headersFetchedTitleLabel := pg.labelTexSize16Layout(values.String(values.StrBlocksScanned), 0, true)
+							blocksScannedLabel := pg.labelTexSize16Layout(fmt.Sprint(pg.rescanUpdate.CurrentRescanHeight), 0, false)
+							return components.EndToEndRow(gtx, headersFetchedTitleLabel, blocksScannedLabel)
 						})
 					}),
 					layout.Rigid(func(gtx C) D {
-						progressTitleLabel := pg.Theme.Body2(values.String(values.StrSyncingProgress))
-						progressTitleLabel.Color = pg.Theme.Color.GrayText2
-
-						rescanProgress := values.StringF(values.StrBlocksLeft, pg.rescanUpdate.TotalHeadersToScan-pg.rescanUpdate.CurrentRescanHeight)
-						blocksScannedLabel := pg.Theme.Body1(rescanProgress)
 						return inset.Layout(gtx, func(gtx C) D {
-							return components.EndToEndRow(gtx, progressTitleLabel.Layout, blocksScannedLabel.Layout)
+							progressTitleLabel := pg.labelTexSize16Layout(values.String(values.StrSyncingProgress), 0, true)
+							rescanProgress := values.StringF(values.StrBlocksLeft, pg.rescanUpdate.TotalHeadersToScan-pg.rescanUpdate.CurrentRescanHeight)
+							blocksScannedLabel := pg.labelTexSize16Layout(rescanProgress, 0, false)
+							return components.EndToEndRow(gtx, progressTitleLabel, blocksScannedLabel)
 						})
 					}),
 				)

--- a/ui/page/staking/utils.go
+++ b/ui/page/staking/utils.go
@@ -207,7 +207,7 @@ func multiContent(gtx C, l *load.Load, leftText, rightText string) D {
 				Right: values.MarginPadding5,
 				Left:  values.MarginPadding5,
 			}.Layout(gtx, func(gtx C) D {
-				ic := cryptomaterial.NewIcon(l.Theme.Icons.ImageBrightness1)
+				ic := cryptomaterial.NewIcon(l.Theme.Icons.DotIcon)
 				ic.Color = col
 				return ic.Layout(gtx, values.MarginPadding6)
 			})

--- a/ui/page/staking/utils.go
+++ b/ui/page/staking/utils.go
@@ -164,7 +164,7 @@ func TicketStatusDetails(gtx C, l *load.Load, dcrWallet *dcr.Asset, tx *transact
 				return lbl.Layout(gtx)
 			}),
 			layout.Rigid(func(gtx C) D {
-				p := l.Theme.ProgressBarCirle(int(tx.progress))
+				p := l.Theme.ProgressBarCircle(int(tx.progress))
 				p.Color = tx.status.ProgressBarColor
 				return layout.Inset{Left: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
 					sz := gtx.Dp(values.MarginPadding22)

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -599,7 +599,7 @@ func (sp *startPage) currentPageIndicatorLayout(gtx C) D {
 				return D{}
 			}
 
-			ic := cryptomaterial.NewIcon(sp.Theme.Icons.ImageBrightness1)
+			ic := cryptomaterial.NewIcon(sp.Theme.Icons.DotIcon)
 			ic.Color = values.TransparentColor(values.TransparentBlack, 0.2)
 			if i == sp.currentPageIndex {
 				ic.Color = sp.Theme.Color.Primary

--- a/ui/page/transaction/transaction_details_page.go
+++ b/ui/page/transaction/transaction_details_page.go
@@ -126,7 +126,7 @@ func NewTransactionDetailsPage(l *load.Load, wallet sharedW.Asset, transaction *
 
 	pg.backButton, _ = components.SubpageHeaderButtons(pg.Load)
 
-	pg.dot = cryptomaterial.NewIcon(l.Theme.Icons.ImageBrightness1)
+	pg.dot = cryptomaterial.NewIcon(l.Theme.Icons.DotIcon)
 	pg.dot.Color = l.Theme.Color.Gray1
 
 	pg.moreItems = pg.getMoreItem()

--- a/ui/page/transaction/transaction_details_page.go
+++ b/ui/page/transaction/transaction_details_page.go
@@ -360,18 +360,19 @@ func (pg *TxDetailsPage) txDetailsHeader(gtx C) D {
 									layout.Rigid(pg.Theme.Label(values.TextSize16, values.String(values.StrStatus)+": ").Layout),
 									layout.Rigid(pg.Theme.Label(values.TextSize16, pg.txnWidgets.txStatus.Title).Layout),
 									layout.Rigid(func(gtx C) D {
-										// immature tx section
-										if pg.txnWidgets.txStatus.TicketStatus == dcr.TicketStatusImmature {
-											p := pg.Theme.ProgressBarCirle(pg.getTimeToMatureOrExpire())
-											p.Color = pg.txnWidgets.txStatus.ProgressBarColor
-											return layout.Inset{Left: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
-												sz := gtx.Dp(values.MarginPadding22)
-												gtx.Constraints.Max = image.Point{X: sz, Y: sz}
-												gtx.Constraints.Min = gtx.Constraints.Max
-												return p.Layout(gtx)
-											})
+										if pg.txnWidgets.txStatus.TicketStatus != dcr.TicketStatusImmature {
+											return D{}
 										}
-										return D{}
+
+										// immature tx section
+										p := pg.Theme.ProgressBarCircle(pg.getTimeToMatureOrExpire())
+										p.Color = pg.txnWidgets.txStatus.ProgressBarColor
+										return layout.Inset{Left: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
+											sz := gtx.Dp(values.MarginPadding22)
+											gtx.Constraints.Max = image.Point{X: sz, Y: sz}
+											gtx.Constraints.Min = gtx.Constraints.Max
+											return p.Layout(gtx)
+										})
 									}),
 								)
 							}
@@ -405,19 +406,20 @@ func (pg *TxDetailsPage) txDetailsHeader(gtx C) D {
 									}.Layout(gtx, lbl.Layout)
 								}),
 								layout.Rigid(func(gtx C) D {
-									// immature tx section
-									if pg.transaction.Type == txhelper.TxTypeVote || pg.transaction.Type == txhelper.TxTypeRevocation {
-										title := values.String(values.StrRevoke)
-										if pg.transaction.Type == txhelper.TxTypeVote {
-											title = values.String(values.StrVote)
-										}
-
-										lbl := pg.Theme.Label(values.TextSize16, fmt.Sprintf("%d days to %s", pg.transaction.DaysToVoteOrRevoke, title))
-										lbl.Color = col
-										return lbl.Layout(gtx)
+									immatureVoteOrRevocation := pg.txnWidgets.txStatus.TicketStatus == dcr.TicketStatusImmature && (pg.transaction.Type == txhelper.TxTypeVote || pg.transaction.Type == txhelper.TxTypeRevocation)
+									if !immatureVoteOrRevocation {
+										return D{}
 									}
 
-									return D{}
+									// immature tx section
+									title := values.String(values.StrRevoke)
+									if pg.transaction.Type == txhelper.TxTypeVote {
+										title = values.String(values.StrVote)
+									}
+
+									lbl := pg.Theme.Label(values.TextSize16, fmt.Sprintf("%d days to %s", pg.transaction.DaysToVoteOrRevoke, title))
+									lbl.Color = col
+									return lbl.Layout(gtx)
 								}),
 							)
 						}),
@@ -453,23 +455,23 @@ func (pg *TxDetailsPage) txDetailsHeader(gtx C) D {
 									)
 
 								case dcr.TicketStatusVotedOrRevoked:
-									if pg.ticketSpender != nil { // voted or revoked
-										if pg.ticketSpender.Type == txhelper.TxTypeVote {
-											return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
-												layout.Rigid(func(gtx C) D {
-													lbl := pg.Theme.Label(values.TextSize16, values.String(values.StrReward)+": ")
-													lbl.Color = col
-													return lbl.Layout(gtx)
-												}),
-												layout.Rigid(func(gtx C) D {
-													lbl := pg.Theme.Label(values.TextSize16, pg.wallet.ToAmount(pg.ticketSpender.VoteReward).String())
-													lbl.Color = col
-													return lbl.Layout(gtx)
-												}),
-											)
-										}
+									if pg.ticketSpender == nil || pg.ticketSpender.Type != txhelper.TxTypeVote {
+										return D{}
 									}
-									return D{}
+
+									// voted or revoked
+									return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
+										layout.Rigid(func(gtx C) D {
+											lbl := pg.Theme.Label(values.TextSize16, values.String(values.StrReward)+": ")
+											lbl.Color = col
+											return lbl.Layout(gtx)
+										}),
+										layout.Rigid(func(gtx C) D {
+											lbl := pg.Theme.Label(values.TextSize16, pg.wallet.ToAmount(pg.ticketSpender.VoteReward).String())
+											lbl.Color = col
+											return lbl.Layout(gtx)
+										}),
+									)
 								}
 							}
 							return D{}

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -144,49 +144,49 @@ var (
 
 	// MarginPaddingTransform is used to scale margin/padding for mobile view.
 	MarginPaddingTransform = func(isMobileView bool, size unit.Dp) unit.Dp {
-		if isMobileView {
-			switch size {
-			case MarginPadding24, MarginPadding30:
-				return MarginPadding16
-			case MarginPadding18, MarginPadding16:
-				return MarginPadding12
-			default:
-				return size
-			}
+		if !isMobileView {
+			return size
 		}
 
-		return size
+		switch size {
+		case MarginPadding24, MarginPadding30:
+			return MarginPadding16
+		case MarginPadding18, MarginPadding16:
+			return MarginPadding12
+		default:
+			return size
+		}
 	}
 
 	// TextSizeTransform is used to scale text sizes for mobile view.
 	TextSizeTransform = func(isMobileView bool, size unit.Sp) unit.Sp {
-		if isMobileView {
-			switch size {
-			case TextSize16, TextSize18:
-				return TextSize14
-			case TextSize14:
-				return TextSize12
-			case TextSize20:
-				return TextSize16
-			case TextSize22:
-				return TextSize18
-			case TextSize24:
-				return TextSize20
-			case TextSize28:
-				return TextSize22
-			case TextSize30:
-				return TextSize24
-			case TextSize34:
-				return TextSize28
-			case TextSize32:
-				return TextSize28
-			case TextSize60:
-				return TextSize34
-			default:
-				return size
-			}
+		if !isMobileView {
+			return size
 		}
 
-		return size
+		switch size {
+		case TextSize16, TextSize18:
+			return TextSize14
+		case TextSize14:
+			return TextSize12
+		case TextSize20:
+			return TextSize16
+		case TextSize22:
+			return TextSize18
+		case TextSize24:
+			return TextSize20
+		case TextSize28:
+			return TextSize22
+		case TextSize30:
+			return TextSize24
+		case TextSize34:
+			return TextSize28
+		case TextSize32:
+			return TextSize28
+		case TextSize60:
+			return TextSize34
+		default:
+			return size
+		}
 	}
 )


### PR DESCRIPTION

- Fix some bugs on the wallet info page
- Refactor the wallet info page and reduce text size (in shared components used by the wallet info page)  for mobile
Closes #270 

Note to reviewers: I currently do not have staking, btc and ltc txs to test with atm. This means the second part of #270 is yet to be verified/fixed but I'm putting this up for review and comments—also, a minor tweak of the mobile wallet info card to improve mobile display is part of this PR. 
 
This PR:
<img width="383" alt="Screenshot 2023-12-15 at 2 45 21 AM" src="https://github.com/crypto-power/cryptopower/assets/57448127/1f03c89f-55b2-4019-a495-799f72e0a9eb">

Figma: 
<img width="270" alt="Screenshot 2023-12-15 at 2 51 56 AM" src="https://github.com/crypto-power/cryptopower/assets/57448127/44e498ab-0f94-4518-8cb7-277cfe2c2e0a">
