### PR TITLE
Fix wallet display and follow-up changes

### DIFF
--- a/ui/page/privacy/account_mixer_page.go
+++ b/ui/page/privacy/account_mixer_page.go
@@ -316,10 +316,7 @@ func (pg *AccountMixerPage) mixerPageLayout(gtx C) D {
 // to be eventually drawn on screen.
 // Part of the load.Page interface.
 func (pg *AccountMixerPage) Layout(gtx layout.Context) layout.Dimensions {
-	if pg.IsMobileView() {
-		return pg.mixerPageLayout(gtx)
-	}
-	return cryptomaterial.UniformPadding(gtx, pg.mixerPageLayout)
+	return pg.mixerPageLayout(gtx)
 }
 
 // HandleUserInteractions is called just before Layout() to determine

--- a/ui/page/root/single_wallet_main_page.go
+++ b/ui/page/root/single_wallet_main_page.go
@@ -182,12 +182,11 @@ func (swmp *SingleWalletMasterPage) initTabOptions() {
 	}
 
 	swmp.pageNavigationTab = swmp.Theme.SegmentedControl(commonTabs, cryptomaterial.SegmentTypeSplit)
-	swmp.pageNavigationTab.DisableUniform(true)
-	// default layout padding based on design
+	dp5 := values.MarginPadding5
 	swmp.pageNavigationTab.ContentPadding = layout.Inset{
-		Left:  values.MarginPadding24,
-		Right: values.MarginPadding24,
-		Top:   values.MarginPadding32,
+		Left:  dp5,
+		Right: dp5,
+		Top:   values.MarginPaddingTransform(swmp.IsMobileView(), values.MarginPadding32),
 	}
 }
 
@@ -396,25 +395,13 @@ func (swmp *SingleWalletMasterPage) OnNavigatedFrom() {
 // to be eventually drawn on screen.
 // Part of the load.Page interface.
 func (swmp *SingleWalletMasterPage) Layout(gtx C) D {
-	// TODO: mobile layout
-	// if swmp.Load.IsMobileView() {
-	// 	return swmp.layoutMobile(gtx)
-	// }
-	return swmp.layoutDesktop(gtx)
-}
-
-func (swmp *SingleWalletMasterPage) layoutDesktop(gtx C) D {
 	return layout.Stack{}.Layout(gtx,
 		layout.Expanded(func(gtx C) D {
-			alignment := layout.Middle
-			if swmp.IsMobileView() {
-				alignment = layout.Start
-			}
 			return cryptomaterial.LinearLayout{
 				Width:       cryptomaterial.MatchParent,
 				Height:      cryptomaterial.MatchParent,
 				Orientation: layout.Vertical,
-				Alignment:   alignment,
+				Alignment:   layout.Middle,
 			}.Layout(gtx,
 				layout.Rigid(swmp.LayoutTopBar),
 				layout.Rigid(func(gtx C) D {
@@ -422,8 +409,10 @@ func (swmp *SingleWalletMasterPage) layoutDesktop(gtx C) D {
 						Top:    values.MarginPadding24,
 						Bottom: values.MarginPadding16,
 					}.Layout(gtx, func(gtx C) D {
-						// design states the entire UI dimension should be 600px
-						gtx.Constraints.Max.X = gtx.Dp(values.MarginPadding600)
+						if !swmp.IsMobileView() {
+							// design states the entire UI dimension should be 600px
+							gtx.Constraints.Max.X = gtx.Dp(values.MarginPadding600)
+						}
 						return swmp.pageNavigationTab.Layout(gtx, func(gtx C) D {
 							if swmp.CurrentPage() == nil {
 								return D{}

--- a/ui/page/root/wallet_settings_page.go
+++ b/ui/page/root/wallet_settings_page.go
@@ -156,31 +156,16 @@ func (pg *WalletSettingsPage) loadWalletAccount() {
 // to be eventually drawn on screen.
 // Part of the load.Page interface.
 func (pg *WalletSettingsPage) Layout(gtx C) D {
-	body := func(gtx C) D {
-		w := []func(gtx C) D{
-			pg.generalSection(),
-			pg.securityTools(),
-			pg.debug(),
-			pg.dangerZone(),
-		}
-
-		return pg.Theme.List(pg.pageContainer).Layout(gtx, len(w), func(gtx C, i int) D {
-			return w[i](gtx)
-		})
+	w := []func(gtx C) D{
+		pg.generalSection(),
+		pg.securityTools(),
+		pg.debug(),
+		pg.dangerZone(),
 	}
 
-	if pg.Load.IsMobileView() {
-		return pg.layoutMobile(gtx, body)
-	}
-	return pg.layoutDesktop(gtx, body)
-}
-
-func (pg *WalletSettingsPage) layoutDesktop(gtx C, body layout.Widget) D {
-	return body(gtx)
-}
-
-func (pg *WalletSettingsPage) layoutMobile(gtx C, body layout.Widget) D {
-	return components.UniformMobile(gtx, false, false, body)
+	return pg.Theme.List(pg.pageContainer).Layout(gtx, len(w), func(gtx C, i int) D {
+		return w[i](gtx)
+	})
 }
 
 func (pg *WalletSettingsPage) generalSection() layout.Widget {

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -149,7 +149,7 @@ var (
 		}
 
 		switch size {
-		case MarginPadding24, MarginPadding30:
+		case MarginPadding24, MarginPadding30, MarginPadding32:
 			return MarginPadding16
 		case MarginPadding18, MarginPadding16:
 			return MarginPadding12


### PR DESCRIPTION
- Enable uniform padding on the wallet page.
- Disable unnecessary uniform padding on the wallet settings page.
- Use the same design on the wallet account page (See: https://github.com/crypto-power/cryptopower/pull/336#issuecomment-1861500712)