### PR TITLE
Change display in TradePage.HandleUserInteraction only when the nav tab changes

### DIFF
--- a/ui/page/exchange/create_order_page.go
+++ b/ui/page/exchange/create_order_page.go
@@ -272,7 +272,6 @@ func (pg *CreateOrderPage) walletCreationSuccessFunc(isSourceWallet bool, asset 
 		pg.updateWalletAndAccountSelector(nil, []libutils.AssetType{asset})
 	}
 	pg.ParentNavigator().ClosePagesAfter(CreateOrderPageID)
-	pg.ParentNavigator().ClosePagesAfter(CreateOrderPageID)
 	pg.ParentWindow().Reload()
 }
 

--- a/ui/page/exchange/trade_page.go
+++ b/ui/page/exchange/trade_page.go
@@ -101,18 +101,20 @@ func (pg *TradePage) HandleUserInteractions() {
 		selectedIndex++ // Adjust index for mobile view
 	}
 
-	switch selectedIndex {
-	case 0: // DCRDEX
-		if pg.CurrentPageID() != dcrdex.DCRDEXPageID {
-			pg.Display(dcrdex.NewDEXPage(pg.Load))
-		}
-	case 1: // Centralized Exchange
-		if pg.CurrentPageID() != CreateOrderPageID {
-			pg.Display(NewCreateOrderPage(pg.Load))
-		}
-	case 2: // Trade History
-		if pg.CurrentPageID() != OrderHistoryPageID {
-			pg.Display(NewOrderHistoryPage(pg.Load))
+	if pg.CurrentPage() == nil || pg.tab.Changed() {
+		switch selectedIndex {
+		case 0: // DCRDEX
+			if pg.CurrentPageID() != dcrdex.DCRDEXPageID {
+				pg.Display(dcrdex.NewDEXPage(pg.Load))
+			}
+		case 1: // Centralized Exchange
+			if pg.CurrentPageID() != CreateOrderPageID {
+				pg.Display(NewCreateOrderPage(pg.Load))
+			}
+		case 2: // Trade History
+			if pg.CurrentPageID() != OrderHistoryPageID {
+				pg.Display(NewOrderHistoryPage(pg.Load))
+			}
 		}
 	}
 


### PR DESCRIPTION
This diff prevents the master `TradePage` from overriding the current page in `HandleUserInteractions`. 

Closes #234 
