### PR TITLE
Reduce top inset for segmented controls and light refactor

### DIFF
--- a/ui/cryptomaterial/segmented_control.go
+++ b/ui/cryptomaterial/segmented_control.go
@@ -63,7 +63,7 @@ func (t *Theme) SegmentedControl(segmentTitles []string, segmentType SegmentType
 		slideActionTitle:     NewSlideAction(),
 		Padding:              layout.UniformInset(values.MarginPadding8),
 		ContentPadding: layout.Inset{
-			Top: values.MarginPadding16,
+			Top: values.MarginPadding14,
 		},
 		Alignment: layout.Middle,
 	}
@@ -130,7 +130,7 @@ func (sc *SegmentedControl) Layout(gtx C, body func(gtx C) D, isMobileView ...bo
 	if sc.disableUniformPadding {
 		return widget(gtx)
 	}
-	return UniformPadding(gtx, widget, sc.isMobileView)
+	return UniformPaddingWithTopInset(values.MarginPadding15, gtx, widget, sc.isMobileView)
 }
 
 func (sc *SegmentedControl) layoutContent(body layout.Widget) layout.Widget {

--- a/ui/cryptomaterial/util.go
+++ b/ui/cryptomaterial/util.go
@@ -139,7 +139,7 @@ func AnyKeyWithOptionalModifier(modifier key.Modifiers, keys ...string) key.Set 
 	return key.Set(keysWithModifier)
 }
 
-func UniformPadding(gtx layout.Context, body layout.Widget, isMobileView ...bool) layout.Dimensions {
+func UniformPaddingWithTopInset(topInset unit.Dp, gtx layout.Context, body layout.Widget, isMobileView ...bool) D {
 	_isMobileView := len(isMobileView) > 0 && isMobileView[0]
 	width := gtx.Constraints.Max.X
 	paddingHorizontal := values.MarginPadding24
@@ -156,9 +156,13 @@ func UniformPadding(gtx layout.Context, body layout.Widget, isMobileView ...bool
 	}
 
 	return layout.Inset{
-		Top:    values.MarginPadding24,
+		Top:    topInset,
 		Right:  paddingHorizontal,
 		Bottom: bottomPadding,
 		Left:   paddingHorizontal,
 	}.Layout(gtx, body)
+}
+
+func UniformPadding(gtx layout.Context, body layout.Widget, isMobileView ...bool) D {
+	return UniformPaddingWithTopInset(values.MarginPadding24, gtx, body, isMobileView...)
 }

--- a/ui/page/dcrdex/dex_onboarding_page.go
+++ b/ui/page/dcrdex/dex_onboarding_page.go
@@ -3,7 +3,6 @@ package dcrdex
 import (
 	"context"
 	"fmt"
-	"image"
 	"image/color"
 	"net/url"
 	"strconv"
@@ -259,27 +258,27 @@ func (pg *DEXOnboarding) Layout(gtx C) D {
 			Radius: cryptomaterial.Radius(8),
 		},
 		Alignment: layout.Middle,
-	}.Layout(gtx,
-		layout.Rigid(func(gtx C) D {
-			txt := pg.Theme.Body1(values.String(values.StrDCRDEXWelcomeMessage))
-			txt.Font.Weight = font.Bold
-			return pg.centerLayout(gtx, dp16, dp20, txt.Layout)
-		}),
-		layout.Rigid(pg.onBoardingStepRow),
-		layout.Rigid(func(gtx C) D {
-			gtx.Constraints.Min = gtx.Constraints.Max
-			return pg.Theme.Separator().Layout(gtx)
-		}),
-		layout.Rigid(func(gtx C) D {
-			return pg.Theme.List(pg.scrollContainer).Layout(gtx, 1, func(gtx C, i int) D {
-				gtx.Constraints.Max = image.Point{
-					X: gtx.Dp(formWidth),
-					Y: gtx.Constraints.Max.Y,
-				}
-				return pg.onBoardingSteps[pg.currentStep].stepFn(gtx)
-			})
-		}),
-	)
+	}.Layout2(gtx, func(gtx C) D {
+		return pg.Theme.List(pg.scrollContainer).Layout(gtx, 1, func(gtx C, i int) D {
+			return layout.Flex{Axis: vertical, Alignment: layout.Middle}.Layout(gtx,
+				layout.Rigid(func(gtx C) D {
+					txt := pg.Theme.Body1(values.String(values.StrDCRDEXWelcomeMessage))
+					txt.Font.Weight = font.Bold
+					return pg.centerLayout(gtx, dp16, dp20, txt.Layout)
+				}),
+				layout.Rigid(pg.onBoardingStepRow),
+				layout.Rigid(func(gtx C) D {
+					return pg.Theme.Separator().Layout(gtx)
+				}),
+				layout.Rigid(func(gtx C) D {
+					gtx.Constraints.Max.X = gtx.Dp(formWidth)
+					gtx.Constraints.Min.X = gtx.Constraints.Max.X
+					pg.serverDropDown.Width = formWidth
+					return pg.onBoardingSteps[pg.currentStep].stepFn(gtx)
+				}),
+			)
+		})
+	})
 }
 
 func (pg *DEXOnboarding) centerLayout(gtx C, top, bottom unit.Dp, content layout.Widget) D {
@@ -431,14 +430,10 @@ func (pg *DEXOnboarding) stepChooseServer(gtx C) D {
 
 // subStepAddServer returns a form to add a server.
 func (pg *DEXOnboarding) subStepAddServer(gtx C) D {
-	width := gtx.Dp(formWidth)
-	if pg.wantCustomServer {
-		width = gtx.Dp(formWidth + values.MarginPadding100)
-	}
 	return layout.Flex{Axis: layout.Vertical, Alignment: layout.Middle}.Layout(gtx,
 		layout.Rigid(func(gtx C) D {
 			return cryptomaterial.LinearLayout{
-				Width:       width,
+				Width:       cryptomaterial.MatchParent,
 				Height:      cryptomaterial.WrapContent,
 				Orientation: layout.Horizontal,
 				Margin:      layout.Inset{Top: values.MarginPadding20, Bottom: dp16},
@@ -507,7 +502,7 @@ func (pg *DEXOnboarding) formFooterButtons(gtx C) D {
 	}
 
 	return cryptomaterial.LinearLayout{
-		Width:     gtx.Dp(formWidth),
+		Width:     cryptomaterial.MatchParent,
 		Height:    cryptomaterial.WrapContent,
 		Spacing:   layout.SpaceBetween,
 		Alignment: layout.Middle,
@@ -706,8 +701,6 @@ func (pg *DEXOnboarding) viewOnlyCard(bg *color.NRGBA, info func(gtx C) D) func(
 
 func (pg *DEXOnboarding) stepWaitForBondConfirmation(gtx C) D {
 	dp12 := values.MarginPadding12
-	width := formWidth + values.MarginPadding100
-	gtx.Constraints.Max.X = gtx.Dp(width)
 	layoutFlex := layout.Flex{Axis: layout.Vertical, Alignment: layout.Middle}.Layout(gtx,
 		layout.Rigid(func(gtx C) D {
 			return pg.centerLayout(gtx, dp20, dp12, pg.Theme.H6(values.String(values.StrPostBond)).Layout)
@@ -717,7 +710,7 @@ func (pg *DEXOnboarding) stepWaitForBondConfirmation(gtx C) D {
 		}),
 		layout.Rigid(func(gtx C) D {
 			return cryptomaterial.LinearLayout{
-				Width:       gtx.Dp(width),
+				Width:       cryptomaterial.MatchParent,
 				Height:      cryptomaterial.WrapContent,
 				Background:  pg.Theme.Color.Gray4,
 				Orientation: layout.Vertical,

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -290,7 +290,7 @@ func (pg *OverviewPage) layoutDesktop(gtx C) D {
 		pg.recentProposal,
 	}
 
-	return cryptomaterial.UniformPadding(gtx, func(gtx C) D {
+	return cryptomaterial.UniformPaddingWithTopInset(values.MarginPadding15, gtx, func(gtx C) D {
 		return pg.Theme.List(pg.scrollContainer).Layout(gtx, 1, func(gtx C, i int) D {
 			return layout.Center.Layout(gtx, func(gtx C) D {
 				return layout.Inset{Right: values.MarginPadding2}.Layout(gtx, func(gtx C) D {


### PR DESCRIPTION
As requested by @itswisdomagain.

- Reduced top inset for segmented controls 
- Reduce the top inset for the overview page to ensure a uniform top inset for all main pages
- Make the whole onboarding page scrollable

Before:
<img width="802" alt="Master - page with segmented control" src="https://github.com/crypto-power/cryptopower/assets/57448127/3e0c5609-19cf-4807-95b4-0592f6e87d24">

After:

<img width="1026" alt="Page with segmented control in this PR" src="https://github.com/crypto-power/cryptopower/assets/57448127/d0d21c30-101a-4fdf-8c87-c4a2e7e445c0">

Pages on master with similar top inset:
<img width="799" alt="Wallet15PX" src="https://github.com/crypto-power/cryptopower/assets/57448127/5b2afde7-0196-4ded-88a9-59461b6e894d">

