### PR TITLE
Handle locked coins properly

### DIFF
--- a/libwallet/assets/btc/wallet.go
+++ b/libwallet/assets/btc/wallet.go
@@ -524,16 +524,18 @@ func (asset *Asset) GetWalletBalance() (*sharedW.Balance, error) {
 		return nil, err
 	}
 
-	var totalBalance, totalSpendable, totalImmatureReward int64
+	var totalBalance, totalSpendable, totalImmatureReward, totalLocked int64
 	for _, acc := range accountsResult.Accounts {
 		totalBalance += acc.Balance.Total.ToInt()
 		totalSpendable += acc.Balance.Spendable.ToInt()
 		totalImmatureReward += acc.Balance.ImmatureReward.ToInt()
+		totalLocked += acc.Balance.Locked.ToInt()
 	}
 
 	return &sharedW.Balance{
 		Total:          Amount(totalBalance),
 		Spendable:      Amount(totalSpendable),
 		ImmatureReward: Amount(totalImmatureReward),
+		Locked:         Amount(totalLocked),
 	}, nil
 }

--- a/libwallet/assets/dcr/wallet.go
+++ b/libwallet/assets/dcr/wallet.go
@@ -294,16 +294,18 @@ func (asset *Asset) GetWalletBalance() (*sharedW.Balance, error) {
 		return nil, err
 	}
 
-	var totalBalance, totalSpendable, totalImmatureReward int64
+	var totalBalance, totalSpendable, totalImmatureReward, totalLocked int64
 	for _, acc := range accountsResult.Accounts {
 		totalBalance += acc.Balance.Total.ToInt()
 		totalSpendable += acc.Balance.Spendable.ToInt()
 		totalImmatureReward += acc.Balance.ImmatureReward.ToInt()
+		totalLocked += acc.Balance.Locked.ToInt()
 	}
 
 	return &sharedW.Balance{
 		Total:          Amount(totalBalance),
-		Spendable:      Amount(totalSpendable),
+		Spendable:      Amount(totalSpendable - totalLocked),
 		ImmatureReward: Amount(totalImmatureReward),
+		Locked:         Amount(totalLocked),
 	}, nil
 }

--- a/libwallet/assets/ltc/accounts.go
+++ b/libwallet/assets/ltc/accounts.go
@@ -109,11 +109,33 @@ func (asset *Asset) GetAccountBalance(accountNumber int32) (*sharedW.Balance, er
 		return nil, err
 	}
 
+	// Account for locked amount.
+	lockedAmount, err := asset.lockedAmount()
+	if err != nil {
+		return nil, err
+	}
+
 	return &sharedW.Balance{
 		Total:          Amount(balance.Total),
-		Spendable:      Amount(balance.Spendable),
+		Spendable:      Amount(balance.Spendable - lockedAmount),
 		ImmatureReward: Amount(balance.ImmatureReward),
+		Locked:         Amount(lockedAmount),
 	}, nil
+}
+
+// lockedAmount is the total value of locked outputs, as locked with
+// LockUnspent.
+func (asset *Asset) lockedAmount() (ltcutil.Amount, error) {
+	lockedOutpoints := asset.Internal().LTC.LockedOutpoints()
+	var sum int64
+	for _, op := range lockedOutpoints {
+		tx, err := asset.GetTransactionRaw(op.Txid)
+		if err != nil {
+			return 0, err
+		}
+		sum += tx.Amount
+	}
+	return ltcutil.Amount(sum), nil
 }
 
 // SpendableForAccount returns the spendable balance for the provided account
@@ -126,7 +148,14 @@ func (asset *Asset) SpendableForAccount(account int32) (int64, error) {
 	if err != nil {
 		return 0, utils.TranslateError(err)
 	}
-	return int64(bals.Spendable), nil
+
+	// Account for locked amount.
+	lockedAmount, err := asset.lockedAmount()
+	if err != nil {
+		return 0, err
+	}
+
+	return int64(bals.Spendable - lockedAmount), nil
 }
 
 // UnspentOutputs returns all the unspent outputs available for the provided

--- a/libwallet/assets/ltc/wallet.go
+++ b/libwallet/assets/ltc/wallet.go
@@ -551,16 +551,18 @@ func (asset *Asset) GetWalletBalance() (*sharedW.Balance, error) {
 		return nil, err
 	}
 
-	var totalBalance, totalSpendable, totalImmatureReward int64
+	var totalBalance, totalSpendable, totalImmatureReward, totalLocked int64
 	for _, acc := range accountsResult.Accounts {
 		totalBalance += acc.Balance.Total.ToInt()
 		totalSpendable += acc.Balance.Spendable.ToInt()
 		totalImmatureReward += acc.Balance.ImmatureReward.ToInt()
+		totalLocked += acc.Balance.Locked.ToInt()
 	}
 
 	return &sharedW.Balance{
 		Total:          Amount(totalBalance),
 		Spendable:      Amount(totalSpendable),
 		ImmatureReward: Amount(totalImmatureReward),
+		Locked:         Amount(totalLocked),
 	}, nil
 }

--- a/libwallet/assets/wallet/types.go
+++ b/libwallet/assets/wallet/types.go
@@ -60,7 +60,7 @@ type BlockInfo struct {
 
 // FeeEstimate defines the fee estimate returned by the API.
 type FeeEstimate struct {
-	// Number of confrmed blocks that show the average fee rate represented below.
+	// Number of confirmed blocks that show the average fee rate represented below.
 	ConfirmedBlocks int32
 	// Feerate shows estimate fee rate in Sat/kvB or Lit/kvB.
 	Feerate AssetAmount
@@ -95,10 +95,11 @@ type UnsignedTransaction struct {
 }
 
 type Balance struct {
-	// fields common to both DCR and BTC
+	// Fields common to all assets.
 	Total          AssetAmount
 	Spendable      AssetAmount
 	ImmatureReward AssetAmount
+	Locked         AssetAmount
 
 	// DCR only fields
 	ImmatureStakeGeneration AssetAmount

--- a/ui/page/accounts/accounts_page.go
+++ b/ui/page/accounts/accounts_page.go
@@ -212,14 +212,18 @@ func (pg *Page) accountItemLayout(gtx C, account *sharedW.Account) D {
 			if bal.LockedByTickets != nil {
 				locked = pg.wallet.ToAmount(locked.ToInt() + bal.LockedByTickets.ToInt())
 			}
-			immature := bal.ImmatureReward
-			if bal.ImmatureStakeGeneration != nil {
-				immature = pg.wallet.ToAmount(immature.ToInt() + bal.ImmatureStakeGeneration.ToInt())
-			}
 			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 				layout.Rigid(pg.accountBalanceLayout(values.String(values.StrLabelSpendable), bal.Spendable, layout.Horizontal)),
 				layout.Rigid(pg.accountBalanceLayout(values.String(values.StrLocked), locked, layout.Horizontal)),
-				layout.Rigid(pg.accountBalanceLayout(values.String(values.StrImmature), immature, layout.Horizontal)),
+				layout.Rigid(func(gtx C) D {
+					if pg.wallet.GetAssetType() != libutils.DCRWalletAsset {
+						return D{}
+					}
+
+					// Display immature for only DCR.
+					immature := pg.wallet.ToAmount(bal.ImmatureReward.ToInt() + bal.ImmatureStakeGeneration.ToInt())
+					return pg.accountBalanceLayout(values.String(values.StrImmature), immature, layout.Horizontal)(gtx)
+				}),
 			)
 		}),
 	)

--- a/ui/page/accounts/btc_account_details_page.go
+++ b/ui/page/accounts/btc_account_details_page.go
@@ -38,6 +38,8 @@ type BTCAcctDetailsPage struct {
 	renameAccount            *cryptomaterial.Clickable
 
 	totalBalance            string
+	spendableBalance        string
+	lockedBalance           string
 	hdPath                  string
 	keys                    string
 	extendedKey             string
@@ -77,6 +79,8 @@ func NewBTCAcctDetailsPage(l *load.Load, wallet sharedW.Asset, account *sharedW.
 // Part of the load.Page interface.
 func (pg *BTCAcctDetailsPage) OnNavigatedTo() {
 	pg.totalBalance = pg.account.Balance.Total.String()
+	pg.spendableBalance = pg.account.Balance.Spendable.String()
+	pg.lockedBalance = pg.account.Balance.Locked.String()
 
 	pg.hdPath = pg.AssetsManager.BTCHDPrefix() + strconv.Itoa(int(pg.account.AccountNumber)) + "'"
 
@@ -269,6 +273,12 @@ func (pg *BTCAcctDetailsPage) accountBalanceLayout(gtx C) D {
 					}),
 				)
 			}),
+			layout.Rigid(func(gtx C) D {
+				return pg.acctBalLayout(gtx, values.String(values.StrLabelSpendable), pg.spendableBalance, false)
+			}),
+			layout.Rigid(func(gtx C) D {
+				return pg.acctBalLayout(gtx, values.String(values.StrLocked), pg.lockedBalance, false)
+			}),
 		)
 	})
 }
@@ -290,10 +300,10 @@ func (pg *BTCAcctDetailsPage) acctBalLayout(gtx C, balType string, balance strin
 		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
 				if isTotalBalance {
-					return pg.Theme.Label(values.TextSize34, balance).Layout(gtx)
+					return components.LayoutBalanceSize(gtx, pg.Load, balance, values.TextSize34)
 				}
 
-				return pg.Theme.Label(values.TextSize34, balance).Layout(gtx)
+				return components.LayoutBalanceWithUnit(gtx, pg.Load, balance)
 			}),
 			layout.Rigid(func(gtx C) D {
 				txt := pg.theme.Body2(balType)

--- a/ui/page/accounts/dcr_account_details_page.go
+++ b/ui/page/accounts/dcr_account_details_page.go
@@ -40,7 +40,6 @@ type AcctDetailsPage struct {
 	showExtendedKeyButton    *cryptomaterial.Clickable
 	infoButton               cryptomaterial.IconButton
 
-	nonSpendableBal  int64
 	lockedBalance    string
 	totalBalance     string
 	spendableBalance string
@@ -84,12 +83,6 @@ func NewDCRAcctDetailsPage(l *load.Load, wallet sharedW.Asset, account *sharedW.
 func (pg *AcctDetailsPage) OnNavigatedTo() {
 
 	bal := pg.account.Balance
-	pg.nonSpendableBal = bal.ImmatureReward.ToInt() +
-		bal.LockedByTickets.ToInt() +
-		bal.VotingAuthority.ToInt() +
-		bal.ImmatureStakeGeneration.ToInt() +
-		bal.Locked.ToInt()
-
 	pg.lockedBalance = pg.wallet.ToAmount(bal.Locked.ToInt() + bal.LockedByTickets.ToInt()).String()
 	pg.totalBalance = bal.Total.String()
 	pg.spendableBalance = bal.Spendable.String()
@@ -235,10 +228,6 @@ func (pg *AcctDetailsPage) accountBalanceLayout(gtx C) D {
 				return pg.acctBalLayout(gtx, values.String(values.StrLabelSpendable), pg.spendableBalance, false)
 			}),
 			layout.Rigid(func(gtx C) D {
-				if pg.nonSpendableBal == 0 {
-					return D{}
-				}
-
 				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 					layout.Rigid(func(gtx C) D {
 						return pg.acctBalLayout(gtx, values.String(values.StrLocked), pg.lockedBalance, false)

--- a/ui/page/accounts/ltc_account_details_page.go
+++ b/ui/page/accounts/ltc_account_details_page.go
@@ -38,6 +38,8 @@ type LTCAcctDetailsPage struct {
 	renameAccount            *cryptomaterial.Clickable
 
 	totalBalance            string
+	spendableBalance        string
+	lockedBalance           string
 	hdPath                  string
 	keys                    string
 	extendedKey             string
@@ -77,6 +79,8 @@ func NewLTCAcctDetailsPage(l *load.Load, wallet sharedW.Asset, account *sharedW.
 // Part of the load.Page interface.
 func (pg *LTCAcctDetailsPage) OnNavigatedTo() {
 	pg.totalBalance = pg.account.Balance.Total.String()
+	pg.spendableBalance = pg.account.Balance.Spendable.String()
+	pg.lockedBalance = pg.account.Balance.Locked.String()
 
 	pg.hdPath = pg.AssetsManager.LTCHDPrefix() + strconv.Itoa(int(pg.account.AccountNumber)) + "'"
 
@@ -266,6 +270,12 @@ func (pg *LTCAcctDetailsPage) accountBalanceLayout(gtx C) D {
 					}),
 				)
 			}),
+			layout.Rigid(func(gtx C) D {
+				return pg.acctBalLayout(gtx, values.String(values.StrLabelSpendable), pg.spendableBalance, false)
+			}),
+			layout.Rigid(func(gtx C) D {
+				return pg.acctBalLayout(gtx, values.String(values.StrLocked), pg.lockedBalance, false)
+			}),
 		)
 	})
 }
@@ -287,10 +297,10 @@ func (pg *LTCAcctDetailsPage) acctBalLayout(gtx C, balType string, balance strin
 		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
 				if isTotalBalance {
-					return pg.Theme.Label(values.TextSize34, balance).Layout(gtx)
+					return components.LayoutBalanceSize(gtx, pg.Load, balance, values.TextSize34)
 				}
 
-				return pg.Theme.Label(values.TextSize34, balance).Layout(gtx)
+				return components.LayoutBalanceWithUnit(gtx, pg.Load, balance)
 			}),
 			layout.Rigid(func(gtx C) D {
 				txt := pg.theme.Body2(balType)

--- a/ui/values/localizable/en.go
+++ b/ui/values/localizable/en.go
@@ -836,7 +836,6 @@ const EN = `
 "rfp" = "RFP"
 "proposedFor" = "Proposed for "
 "accounts" = "Accounts"
-"amountSpendable" = "Amount Spendable"
 "stakingInfo" = "Staking Info"
 "timeLeft" = "Time Left"
 "totalReward" = "Total Reward"

--- a/ui/values/strings.go
+++ b/ui/values/strings.go
@@ -946,7 +946,6 @@ const (
 	StrRFP                             = "rfp"
 	StrProposedFor                     = "proposedFor"
 	StrAccounts                        = "accounts"
-	StrAmountSpendable                 = "amountSpendable"
 	StrStakingInfo                     = "stakingInfo"
 	StrTimeLeft                        = "timeLeft"
 	StrTotalReward                     = "totalReward"


### PR DESCRIPTION
As requested by @itswisdomagain.
 
- Prevent dcr wallets from returning locked unspent utoxs in `wallet.UnspentOutputs`
- Display the correct locked, immature and spendable amounts on the wallet account page

UI

<img width="664" alt="Screenshot 2024-01-17 at 4 33 04 AM" src="https://github.com/crypto-power/cryptopower/assets/57448127/46a5de47-4df4-458c-9955-03dfcf6d6a7d">

<img width="620" alt="Screenshot 2024-01-17 at 4 32 44 AM" src="https://github.com/crypto-power/cryptopower/assets/57448127/17904d3a-91a2-4850-868c-fd59243ae59b">
