### PR TITLE
multi: Add dextest network.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ cryptopower [options]
 ```
 
 - Run `./cryptopower --network=testnet` to run cryptopower on the testnet network.
+- Run `./cryptopower --network=dextest` to run cryptopower with the decred dex simnet harness.
 - Run `cryptopower -h` or `cryptopower help` to get general information of commands and options that can be issued on the cli.
 - Use `cryptopower <command> -h` or `cryptopower help <command>` to get detailed information about a command.
 

--- a/config.go
+++ b/config.go
@@ -25,7 +25,7 @@ const (
 )
 
 type config struct {
-	Network          string `long:"network" description:"Network to use (mainnet, testnet or simnet). Cannot be changed from the app once set."`
+	Network          string `long:"network" description:"Network to use (mainnet, simnet, testnet, dextest). Default is mainnet. Cannot be changed from the app once set."`
 	HomeDir          string `long:"appdata" description:"Directory where the app configuration file and wallet data is stored"`
 	ConfigFile       string `long:"configfile" description:"Filename of the config file in the app directory"`
 	ShowVersion      bool   `short:"V" long:"version" description:"Display version information and exit"`
@@ -35,6 +35,9 @@ type config struct {
 	Quiet            bool   `short:"q" long:"quiet" description:"Easy way to set debuglevel to error"`
 	SpendUnconfirmed bool   `long:"spendunconfirmed" description:"Allow the assetsManager to use transactions that have not been confirmed"`
 	Profile          int    `long:"profile" description:"Runs local web server for profiling"`
+	DEXTestAddr      string `long:"dextestaddr" description:"If using the dextest network, set an address for the dex harness to be used as a persistant peer for all new wallets."`
+
+	net libutils.NetworkType
 }
 
 func defaultConfig(defaultHomeDir string) config {

--- a/dexc/core.go
+++ b/dexc/core.go
@@ -256,7 +256,7 @@ func parseDEXNet(net libutils.NetworkType) (dex.Network, error) {
 		return dex.Mainnet, nil
 	case libutils.Testnet:
 		return dex.Testnet, nil
-	case libutils.Regression, libutils.Simulation:
+	case libutils.Regression, libutils.Simulation, libutils.DEXTest:
 		return dex.Simnet, nil
 	default:
 		return 0, fmt.Errorf("unknown network %s", net)

--- a/libwallet/assets/wallet/types.go
+++ b/libwallet/assets/wallet/types.go
@@ -38,11 +38,12 @@ type WConfig struct {
 // InitParams defines the basic parameters required to instantiate any
 // wallet interface.
 type InitParams struct {
-	RootDir  string
-	NetType  utils.NetworkType
-	DB       *storm.DB
-	DbDriver string
-	LogDir   string
+	RootDir     string
+	NetType     utils.NetworkType
+	DB          *storm.DB
+	DbDriver    string
+	LogDir      string
+	DEXTestAddr string
 }
 
 // AuthInfo defines the complete information required to either create a

--- a/libwallet/assets/wallet/wallet_utils.go
+++ b/libwallet/assets/wallet/wallet_utils.go
@@ -3,6 +3,7 @@ package wallet
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"sort"
 	"strconv"
@@ -291,7 +292,13 @@ func ParseWalletPeers(peerAddresses string, port string) ([]string, []error) {
 	if peerAddresses != "" {
 		addresses := strings.Split(peerAddresses, ";")
 		for _, address := range addresses {
-			peerAddress, err := utils.NormalizeAddress(address, port)
+			host, p, err := net.SplitHostPort(address)
+			// If err assume because port was not supplied.
+			if err != nil {
+				host = address
+				p = port
+			}
+			peerAddress, err := utils.NormalizeAddress(host, p)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("SPV peer address(%s) is invalid: %v", peerAddress, err))
 			} else {

--- a/libwallet/assets_manager.go
+++ b/libwallet/assets_manager.go
@@ -74,7 +74,7 @@ type AssetsManager struct {
 
 // initializeAssetsFields validate the network provided is valid for all assets before proceeding
 // to initialize the rest of the other fields.
-func initializeAssetsFields(rootDir, dbDriver, logDir string, netType utils.NetworkType) (*AssetsManager, error) {
+func initializeAssetsFields(rootDir, dbDriver, logDir string, netType utils.NetworkType, dexTestAddr string) (*AssetsManager, error) {
 	dcrChainParams, err := initializeDCRWalletParameters(netType)
 	if err != nil {
 		log.Errorf("error initializing DCR parameters: %s", err.Error())
@@ -94,10 +94,11 @@ func initializeAssetsFields(rootDir, dbDriver, logDir string, netType utils.Netw
 	}
 
 	params := &sharedW.InitParams{
-		DbDriver: dbDriver,
-		RootDir:  rootDir,
-		NetType:  netType,
-		LogDir:   logDir,
+		DbDriver:    dbDriver,
+		RootDir:     rootDir,
+		NetType:     netType,
+		LogDir:      logDir,
+		DEXTestAddr: dexTestAddr,
 	}
 
 	mgr := &AssetsManager{
@@ -120,7 +121,7 @@ func initializeAssetsFields(rootDir, dbDriver, logDir string, netType utils.Netw
 }
 
 // NewAssetsManager creates a new AssetsManager instance.
-func NewAssetsManager(rootDir, logDir string, netType utils.NetworkType) (*AssetsManager, error) {
+func NewAssetsManager(rootDir, logDir string, netType utils.NetworkType, dexTestAddr string) (*AssetsManager, error) {
 	errors.Separator = ":: "
 
 	// Create a root dir that has the path up the network folder.
@@ -131,7 +132,7 @@ func NewAssetsManager(rootDir, logDir string, netType utils.NetworkType) (*Asset
 
 	// validate the network type before proceeding to initialize the othe fields.
 	dbDriver := "bdb" // TODO: Should be a constant.
-	mgr, err := initializeAssetsFields(rootDir, dbDriver, logDir, netType)
+	mgr, err := initializeAssetsFields(rootDir, dbDriver, logDir, netType, dexTestAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/libwallet/utils/netparams.go
+++ b/libwallet/utils/netparams.go
@@ -18,6 +18,7 @@ const (
 	Testnet    NetworkType = "testnet"
 	Regression NetworkType = "regression"
 	Simulation NetworkType = "simulation"
+	DEXTest    NetworkType = "dextest"
 	Unknown    NetworkType = "unknown"
 )
 
@@ -39,6 +40,8 @@ func ToNetworkType(str string) NetworkType {
 		return Regression
 	case "simulation", "sim", "simnet":
 		return Simulation
+	case "dextest":
+		return DEXTest
 	default:
 		return Unknown
 	}
@@ -52,19 +55,28 @@ type ChainsParams struct {
 }
 
 var (
-	DCRmainnetParams = dcrcfg.MainNetParams()
-	DCRtestnetParams = dcrcfg.TestNet3Params()
-	DCRSimnetParams  = dcrcfg.SimNetParams()
-	DCRRegnetParams  = dcrcfg.RegNetParams()
-	BTCmainnetParams = &btccfg.MainNetParams
-	BTCtestnetParams = &btccfg.TestNet3Params
-	BTCSimnetParams  = &btccfg.SimNetParams
-	BTCRegnetParams  = &btccfg.RegressionNetParams
-	LTCmainnetParams = &ltccfg.MainNetParams
-	LTCtestnetParams = &ltccfg.TestNet4Params
-	LTCSimnetParams  = &ltccfg.SimNetParams
-	LTCRegnetParams  = &ltccfg.RegressionNetParams
+	DCRmainnetParams      = dcrcfg.MainNetParams()
+	DCRtestnetParams      = dcrcfg.TestNet3Params()
+	DCRSimnetParams       = dcrcfg.SimNetParams()
+	DCRRegnetParams       = dcrcfg.RegNetParams()
+	BTCmainnetParams      = &btccfg.MainNetParams
+	BTCtestnetParams      = &btccfg.TestNet3Params
+	BTCSimnetParams       = &btccfg.SimNetParams
+	BTCRegnetParamsVal    = btccfg.RegressionNetParams
+	LTCmainnetParams      = &ltccfg.MainNetParams
+	LTCtestnetParams      = &ltccfg.TestNet4Params
+	LTCSimnetParams       = &ltccfg.SimNetParams
+	LTCRegnetParamsVal    = ltccfg.RegressionNetParams
+	DCRDEXSimnetParams    = dcrcfg.SimNetParams()
+	BTCDEXRegnetParamsVal = btccfg.RegressionNetParams
+	LTCDEXRegnetParamsVal = ltccfg.RegressionNetParams
 )
+
+func init() {
+	DCRDEXSimnetParams.DefaultPort = "19560"
+	BTCDEXRegnetParamsVal.DefaultPort = "20575"
+	LTCDEXRegnetParamsVal.DefaultPort = "20585"
+}
 
 // NetDir returns data directory name for a given asset's type and network connected.
 // If "unknown" is returned, unsupported asset type or network was detected.
@@ -99,6 +111,8 @@ func DCRChainParams(netType NetworkType) (*dcrcfg.Params, error) {
 		return DCRSimnetParams, nil
 	case Regression:
 		return DCRRegnetParams, nil
+	case DEXTest:
+		return DCRDEXSimnetParams, nil
 	default:
 		return nil, fmt.Errorf("%v: (%v)", ErrInvalidNet, netType)
 	}
@@ -115,7 +129,9 @@ func BTCChainParams(netType NetworkType) (*btccfg.Params, error) {
 	case Simulation:
 		return BTCSimnetParams, nil
 	case Regression:
-		return BTCRegnetParams, nil
+		return &BTCRegnetParamsVal, nil
+	case DEXTest:
+		return &BTCDEXRegnetParamsVal, nil
 	default:
 		return nil, fmt.Errorf("%v: (%v)", ErrInvalidNet, netType)
 	}
@@ -132,7 +148,9 @@ func LTCChainParams(netType NetworkType) (*ltccfg.Params, error) {
 	case Simulation:
 		return LTCSimnetParams, nil
 	case Regression:
-		return LTCRegnetParams, nil
+		return &LTCRegnetParamsVal, nil
+	case DEXTest:
+		return &LTCDEXRegnetParamsVal, nil
 	default:
 		return nil, fmt.Errorf("%v: (%v)", ErrInvalidNet, netType)
 	}

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func main() {
 			logger.SetLogLevels(cfg.DebugLevel)
 		}
 
-		assetsManager, err := libwallet.NewAssetsManager(cfg.HomeDir, logDir, netType)
+		assetsManager, err := libwallet.NewAssetsManager(cfg.HomeDir, logDir, netType, cfg.DEXTestAddr)
 		if err != nil {
 			return nil, err
 		}

--- a/ui/page/dcrdex/certs.go
+++ b/ui/page/dcrdex/certs.go
@@ -10,6 +10,7 @@ package dcrdex
 const (
 	decredDEXServerMainnet = "dex.decred.org:7232"
 	decredDEXServerTestnet = "bison.exchange:27232"
+	decredDEXServerSimnet  = "127.0.0.1:17273"
 )
 
 var dexDotDecredCert = []byte(`-----BEGIN CERTIFICATE-----
@@ -49,7 +50,27 @@ hW4bgtaK
 -----END CERTIFICATE-----
 `)
 
+var dexSimSSGenCert = []byte(`-----BEGIN CERTIFICATE-----
+MIICpTCCAgagAwIBAgIQZMfxMkSi24xMr4CClCODrzAKBggqhkjOPQQDBDBJMSIw
+IAYDVQQKExlkY3JkZXggYXV0b2dlbmVyYXRlZCBjZXJ0MSMwIQYDVQQDExp1YnVu
+dHUtcy0xdmNwdS0yZ2ItbG9uMS0wMTAeFw0yMDA2MDgxMjM4MjNaFw0zMDA2MDcx
+MjM4MjNaMEkxIjAgBgNVBAoTGWRjcmRleCBhdXRvZ2VuZXJhdGVkIGNlcnQxIzAh
+BgNVBAMTGnVidW50dS1zLTF2Y3B1LTJnYi1sb24xLTAxMIGbMBAGByqGSM49AgEG
+BSuBBAAjA4GGAAQApXJpVD7si8yxoITESq+xaXWtEpsCWU7X+8isRDj1cFfH53K6
+/XNvn3G+Yq0L22Q8pMozGukA7KuCQAAL0xnuo10AecWBN0Zo2BLHvpwKkmAs71C+
+5BITJksqFxvjwyMKbo3L/5x8S/JmAWrZoepBLfQ7HcoPqLAcg0XoIgJjOyFZgc+j
+gYwwgYkwDgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB/wQFMAMBAf8wZgYDVR0RBF8w
+XYIadWJ1bnR1LXMtMXZjcHUtMmdiLWxvbjEtMDGCCWxvY2FsaG9zdIcEfwAAAYcQ
+AAAAAAAAAAAAAAAAAAAAAYcEsj5QQYcEChAABYcQ/oAAAAAAAAAYPqf//vUPXDAK
+BggqhkjOPQQDBAOBjAAwgYgCQgFMEhyTXnT8phDJAnzLbYRktg7rTAbTuQRDp1PE
+jf6b2Df4DkSX7JPXvVi3NeBru+mnrOkHBUMqZd0m036aC4q/ZAJCASa+olu4Isx7
+8JE3XB6kGr+s48eIFPtmq1D0gOvRr3yMHrhJe3XDNqvppcHihG0qNb0gyaiX18Cv
+vF8Ti1x2vTkD
+-----END CERTIFICATE-----
+`)
+
 var CertStore = map[string][]byte{
 	decredDEXServerMainnet: dexDotDecredCert,
 	decredDEXServerTestnet: dexTestSSGenCert,
+	decredDEXServerSimnet:  dexSimSSGenCert,
 }

--- a/ui/page/dcrdex/dex_onboarding_page.go
+++ b/ui/page/dcrdex/dex_onboarding_page.go
@@ -45,6 +45,9 @@ var (
 		libutils.Testnet: {{
 			Text: decredDEXServerTestnet,
 		}},
+		libutils.DEXTest: {{
+			Text: decredDEXServerSimnet,
+		}},
 	}
 
 	// formWidth is the width for form elements on the onboarding DEX page.

--- a/ui/page/wallet/wallet_settings_page.go
+++ b/ui/page/wallet/wallet_settings_page.go
@@ -588,14 +588,21 @@ func validatePeerAddressStr(addrs string) (string, bool) {
 			continue
 		}
 
-		if net.ParseIP(addr) != nil {
+		host, _, err := net.SplitHostPort(addr)
+		// If err assume because port was not supplied.
+		if err == nil {
+			host = addr
+		}
+
+		if net.ParseIP(host) != nil {
 			addrMap[addr] = &struct{}{}
 			continue // ok
 		}
 
-		if _, err := url.ParseRequestURI(addr); err != nil {
+		if _, err := url.ParseRequestURI(host); err != nil {
 			return addr, false
 		}
+
 		addrMap[addr] = &struct{}{}
 	}
 


### PR DESCRIPTION
closes #408

It looked like creating separate params was the easiest and least code. The dex simnet uses a combination of simnet and regnets. This pr also allows setting the port for persistant peers.