### PR TITLE
Remove manual dex wallet unlock during bond posting

### DIFF
--- a/dexc/core.go
+++ b/dexc/core.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -70,6 +71,27 @@ func (dc *DEXClient) WaitForShutdown() <-chan struct{} {
 
 func (dc *DEXClient) Shutdown() {
 	dc.cancelFn()
+}
+
+// WalletIDForAsset returns the wallet ID for the provided assetID. It'll return
+// nil, nil if the asset does not exist in the dex client.
+func (dc *DEXClient) WalletIDForAsset(assetID uint32) (*int, error) {
+	if !dc.HasWallet(int32(assetID)) {
+		return nil, nil
+	}
+
+	settings, err := dc.WalletSettings(assetID)
+	if err != nil {
+		return nil, err
+	}
+
+	walletIDStr := settings[WalletIDConfigKey]
+	walletID, err := strconv.Atoi(walletIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing wallet ID: %w", err)
+	}
+
+	return &walletID, nil
 }
 
 type valStamp struct {

--- a/libwallet/assets_manager.go
+++ b/libwallet/assets_manager.go
@@ -910,7 +910,7 @@ func (mgr *AssetsManager) DexClient() *dexc.DEXClient {
 	return mgr.dexc
 }
 
-func (mgr *AssetsManager) DexcReady() bool {
+func (mgr *AssetsManager) DexcInitialized() bool {
 	mgr.dexcMtx.RLock()
 	defer mgr.dexcMtx.RUnlock()
 	return mgr.dexc != nil
@@ -926,7 +926,7 @@ func (mgr *AssetsManager) InitializeDEX(ctx context.Context) {
 		dexWalletRegistered.Store(true)
 	}
 
-	if mgr.DexcReady() || mgr.startingDEX.Load() {
+	if mgr.DexcInitialized() || mgr.startingDEX.Load() {
 		log.Debug("Attempted to reinitialize a running dex client instance")
 		return
 	}

--- a/ui/page/dcrdex/dcrdex_page.go
+++ b/ui/page/dcrdex/dcrdex_page.go
@@ -52,7 +52,7 @@ func NewDEXPage(l *load.Load) *DEXPage {
 		materialLoader:     material.Loader(l.Theme.Base),
 	}
 
-	if dp.AssetsManager.DexcReady() && dp.AssetsManager.DexClient().IsDEXPasswordSet() {
+	if dp.AssetsManager.DexcInitialized() && dp.AssetsManager.DexClient().IsDEXPasswordSet() {
 		dp.isDexFirstVisit = false
 	}
 
@@ -73,7 +73,7 @@ func (pg *DEXPage) ID() string {
 // displayed.
 // Part of the load.Page interface.
 func (pg *DEXPage) OnNavigatedTo() {
-	if !pg.AssetsManager.DexcReady() {
+	if !pg.AssetsManager.DexcInitialized() {
 		return
 	}
 
@@ -120,7 +120,7 @@ func (pg *DEXPage) Layout(gtx C) D {
 		msg = values.String(values.StrDexMainnetNotReady)
 	} else if !hasMultipleWallets {
 		msg = values.String(values.StrMultipleAssetRequiredMsg)
-	} else if !pg.AssetsManager.DexcReady() {
+	} else if !pg.AssetsManager.DexcInitialized() {
 		msg = values.String(values.StrDEXInitErrorMsg)
 	}
 

--- a/ui/page/dcrdex/dex_interface.go
+++ b/ui/page/dcrdex/dex_interface.go
@@ -16,6 +16,7 @@ type dexClient interface {
 	GetDEXConfig(dexAddr string, certI any) (*core.Exchange, error)
 	BondsFeeBuffer(assetID uint32) uint64
 	HasWallet(assetID int32) bool
+	WalletIDForAsset(assetID uint32) (*int, error)
 	AddWallet(assetID uint32, settings map[string]string, appPW, walletPW []byte) error
 	PostBond(form *core.PostBondForm) (*core.PostBondResult, error)
 	NotificationFeed() *core.NoteFeed

--- a/ui/page/dcrdex/dex_onboarding_page.go
+++ b/ui/page/dcrdex/dex_onboarding_page.go
@@ -1132,7 +1132,7 @@ func (pg *DEXOnboarding) postBond() {
 		return
 	}
 
-	if walletID != nil && pg.AssetsManager.WalletWithID(*walletID) != nil {
+	if walletID != nil {
 		// Wallet has been added to core, no need for password.
 		go func() {
 			postBondFn()
@@ -1156,7 +1156,7 @@ func (pg *DEXOnboarding) postBond() {
 			pg.isLoading = false
 			return true
 		}).
-		SetCancelable(false) // user cannot close modal until addWalletFn && postBondFn exists
+		SetCancelable(false) // user cannot close modal until addWalletFn && postBondFn exits
 
 	pg.ParentWindow().ShowModal(walletPasswordModal)
 }

--- a/ui/page/dcrdex/market.go
+++ b/ui/page/dcrdex/market.go
@@ -1662,8 +1662,7 @@ func (pg *DEXMarketPage) showSelectDEXWalletModal(missingWallet libutils.AssetTy
 		}).
 		SetCancelable(false)
 
-		// Prompt user to provide DEX password then show the wallet password
-		// modal.
+	// Prompt user to provide DEX password then show the wallet password modal.
 	dexPasswordModal := modal.NewCreatePasswordModal(pg.Load).
 		EnableName(false).
 		EnableConfirmPassword(false).

--- a/ui/page/root/home_page.go
+++ b/ui/page/root/home_page.go
@@ -151,7 +151,7 @@ func (hp *HomePage) OnNavigatedTo() {
 	hp.initPageItems()
 
 	go hp.CalculateAssetsUSDBalance()
-	if !hp.AssetsManager.DexcReady() {
+	if !hp.AssetsManager.DexcInitialized() {
 		go hp.AssetsManager.InitializeDEX(hp.dexCtx)
 	}
 
@@ -285,7 +285,7 @@ func (hp *HomePage) displaySelectedPage(title string) {
 	case values.String(values.StrWallets):
 		pg = hp.walletSelectorPage
 	case values.String(values.StrTrade):
-		if !hp.AssetsManager.DexcReady() {
+		if !hp.AssetsManager.DexcInitialized() {
 			// Attempt to initialize dex again.
 			hp.AssetsManager.InitializeDEX(hp.dexCtx)
 		}

--- a/ui/page/settings/app_settings_page.go
+++ b/ui/page/settings/app_settings_page.go
@@ -375,7 +375,7 @@ func (pg *AppSettingsPage) debug() layout.Widget {
 					return pg.clickableRow(gtx, viewLogRow)
 				}),
 				layout.Rigid(func(gtx C) D {
-					if pg.AssetsManager.NetType() != libutils.Testnet || !pg.AssetsManager.DexcReady() {
+					if pg.AssetsManager.NetType() != libutils.Testnet || !pg.AssetsManager.DexcInitialized() {
 						return D{}
 					}
 
@@ -533,7 +533,7 @@ func (pg *AppSettingsPage) HandleUserInteractions() {
 			SetNegativeButtonText(values.String(values.StrCancel)).
 			SetPositiveButtonText(values.String(values.StrDelete)).
 			SetPositiveButtonCallback(func(_ bool, in *modal.InfoModal) bool {
-				if pg.AssetsManager.DexcReady() {
+				if pg.AssetsManager.DexcInitialized() {
 					if err := pg.AssetsManager.DeleteDEXData(); err != nil {
 						return false
 					}

--- a/ui/page/wallet/wallet_settings_page.go
+++ b/ui/page/wallet/wallet_settings_page.go
@@ -386,7 +386,7 @@ func (pg *SettingsPage) changeSpendingPasswordModal() {
 
 					// Undo password change.
 					if err = pg.wallet.ChangePrivatePassphraseForWallet(newPassword, currentPassword, sharedW.PassphraseTypePass); err != nil {
-						log.Errorf("Failed to undo pass update: %v", err)
+						log.Errorf("Failed to undo wallet passphrase change: %v", err)
 					}
 
 					return false

--- a/ui/values/localizable/en.go
+++ b/ui/values/localizable/en.go
@@ -917,4 +917,5 @@ const EN = `
 "destinationWallet" = "Destination Wallet"
 "swtichToTestnet" = "Switch to Testnet"
 "dexMainnetNotReady" = "DCRDEX is currently in beta testing and has been disabled on mainnet to prevent potential loss of funds. Please switch to testnet to try it out."
+"updateDEXWalletPasswordReason" = "Your %s wallet (%s) is connected to your DEX account. Please provided your DEX password to update DEX with the new wallet password."
 `

--- a/ui/values/localizable/en.go
+++ b/ui/values/localizable/en.go
@@ -917,5 +917,5 @@ const EN = `
 "destinationWallet" = "Destination Wallet"
 "swtichToTestnet" = "Switch to Testnet"
 "dexMainnetNotReady" = "DCRDEX is currently in beta testing and has been disabled on mainnet to prevent potential loss of funds. Please switch to testnet to try it out."
-"updateDEXWalletPasswordReason" = "Your %s wallet (%s) is connected to your DEX account. Please provid your DEX password to update DEX with the new wallet password."
+"updateDEXWalletPasswordReason" = "Your %s wallet (%s) is connected to your DEX account. Please provide your DEX password to update DEX with the new wallet password."
 `

--- a/ui/values/localizable/en.go
+++ b/ui/values/localizable/en.go
@@ -917,5 +917,5 @@ const EN = `
 "destinationWallet" = "Destination Wallet"
 "swtichToTestnet" = "Switch to Testnet"
 "dexMainnetNotReady" = "DCRDEX is currently in beta testing and has been disabled on mainnet to prevent potential loss of funds. Please switch to testnet to try it out."
-"updateDEXWalletPasswordReason" = "Your %s wallet (%s) is connected to your DEX account. Please provided your DEX password to update DEX with the new wallet password."
+"updateDEXWalletPasswordReason" = "Your %s wallet (%s) is connected to your DEX account. Please provid your DEX password to update DEX with the new wallet password."
 `

--- a/ui/values/strings.go
+++ b/ui/values/strings.go
@@ -1026,4 +1026,5 @@ const (
 	StrDestinationWallet               = "destinationWallet"
 	StrSwitchToTestnet                 = "swtichToTestnet"
 	StrDexMainnetNotReady              = "dexMainnetNotReady"
+	StrUpdateDEXWalletPasswordReason   = "updateDEXWalletPasswordReason"
 )


### PR DESCRIPTION
This PR removes password requests for an existing dex wallet and adds support for dex wallet pass updates.