### PR TITLE
multi: implement in-app network type switch

### DIFF
--- a/app/widgetdisplaypage.go
+++ b/app/widgetdisplaypage.go
@@ -1,0 +1,35 @@
+package app
+
+import (
+	"gioui.org/layout"
+)
+
+const WidgetDisplayPageID = "widgetdisplaypage"
+
+// WidgetDisplayPage is a page that takes a widget to layout and does nothing
+// more than displaying the widget.
+type WidgetDisplayPage struct {
+	*GenericPageModal
+	widget layout.Widget
+}
+
+func NewWidgetDisplayPage(widget layout.Widget) *WidgetDisplayPage {
+	return &WidgetDisplayPage{
+		GenericPageModal: NewGenericPageModal(WidgetDisplayPageID),
+		widget:           widget,
+	}
+}
+
+// OnNavigatedTo implements Page.
+func (*WidgetDisplayPage) OnNavigatedTo() {}
+
+// HandleUserInteractions implements Page.
+func (*WidgetDisplayPage) HandleUserInteractions() {}
+
+// Layout implements Page.
+func (pg *WidgetDisplayPage) Layout(gtx layout.Context) layout.Dimensions {
+	return pg.widget(gtx)
+}
+
+// OnNavigatedFrom implements Page.
+func (*WidgetDisplayPage) OnNavigatedFrom() {}

--- a/config.go
+++ b/config.go
@@ -19,14 +19,12 @@ import (
 )
 
 const (
-	defaultNetwork        = "mainnet"
 	defaultConfigFileName = "cryptopower.conf"
 	defaultLogFilename    = "cryptopower.log"
 	defaultLogDirname     = "logs"
 )
 
 type config struct {
-	Network          string `long:"network" description:"Network to use"`
 	HomeDir          string `long:"appdata" description:"Directory where the app configuration file and wallet data is stored"`
 	ConfigFile       string `long:"configfile" description:"Filename of the config file in the app directory"`
 	ShowVersion      bool   `short:"V" long:"version" description:"Display version information and exit"`
@@ -36,13 +34,10 @@ type config struct {
 	Quiet            bool   `short:"q" long:"quiet" description:"Easy way to set debuglevel to error"`
 	SpendUnconfirmed bool   `long:"spendunconfirmed" description:"Allow the assetsManager to use transactions that have not been confirmed"`
 	Profile          int    `long:"profile" description:"Runs local web server for profiling"`
-
-	net libutils.NetworkType
 }
 
 func defaultConfig(defaultHomeDir string) config {
 	return config{
-		Network:    defaultNetwork,
 		HomeDir:    defaultHomeDir,
 		ConfigFile: filepath.Join(defaultHomeDir, defaultConfigFileName),
 		LogDir:     filepath.Join(defaultHomeDir, defaultLogDirname),
@@ -229,18 +224,10 @@ func loadConfig() (*config, error) {
 		cfg.MaxLogZips = 0
 	}
 
-	cfg.net = libutils.ToNetworkType(cfg.Network)
-	if cfg.net == libutils.Unknown {
-		return loadConfigError(fmt.Errorf("network type is not supported: %s", cfg.Network))
-	}
-
 	// Parse, validate, and set debug log level(s).
 	if cfg.Quiet {
 		cfg.DebugLevel = "error"
 	}
-
-	cfg.Network = string(cfg.net)
-	cfg.LogDir = filepath.Join(cfg.LogDir, cfg.Network)
 
 	// Special show command to list supported subsystems and exit.
 	if cfg.DebugLevel == "show" {

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ const (
 )
 
 type config struct {
+	Network          string `long:"network" description:"Network to use (mainnet, testnet or simnet). Cannot be changed from the app once set."`
 	HomeDir          string `long:"appdata" description:"Directory where the app configuration file and wallet data is stored"`
 	ConfigFile       string `long:"configfile" description:"Filename of the config file in the app directory"`
 	ShowVersion      bool   `short:"V" long:"version" description:"Display version information and exit"`
@@ -222,6 +223,10 @@ func loadConfig() (*config, error) {
 	// logger variables may be used. This creates the LogDir if needed.
 	if cfg.MaxLogZips < 0 {
 		cfg.MaxLogZips = 0
+	}
+
+	if cfg.Network != "" && libutils.ToNetworkType(cfg.Network) == libutils.Unknown {
+		return loadConfigError(fmt.Errorf("network type is not supported: %s", cfg.Network))
 	}
 
 	// Parse, validate, and set debug log level(s).

--- a/libwallet/assets_manager.go
+++ b/libwallet/assets_manager.go
@@ -374,10 +374,17 @@ func (mgr *AssetsManager) Shutdown() {
 		mgr.InstantSwap.StopSync()
 	}
 
+	// Shutdown dexc before closing wallets.
+	if mgr.dexc != nil && mgr.dexc.IsInitialized() {
+		mgr.dexc.Shutdown()
+		mgr.dexc.WaitForShutdown()
+	}
+
 	for _, wallet := range mgr.AllWallets() {
 		wallet.Shutdown() // Cancels the wallet sync too.
 		wallet.CancelRescan()
 	}
+	mgr.Assets = new(Assets)
 
 	// Disable all active network connections
 	utils.ShutdownHTTPClients()
@@ -958,6 +965,7 @@ func (mgr *AssetsManager) InitializeDEX(ctx context.Context) {
 		<-mgr.dexc.WaitForShutdown()
 		mgr.dexcMtx.Lock()
 		mgr.dexc = nil
+		// TODO: Also unregister the custom wallet constructors!
 		mgr.dexcMtx.Unlock()
 	}()
 }
@@ -976,7 +984,13 @@ func (mgr *AssetsManager) DeleteDEXData() error {
 
 	// Shutdown the DEX client.
 	mgr.dexc.Shutdown()
+	// TODO: Verify that it is possible to listen to this channel here and in
+	// the goroutine in InitializeDEX; it's possible that only one of the
+	// listeners will receive a value. But if the channel was closed, then maybe
+	// both will get the ntfn?
 	<-shutdownChan // wait for shutdown
+
+	// TODO: Set mgr.dexc to nil and unregister the custom wallet constructors!
 
 	// Delete dex client db.
 	return os.Remove(dexDBFile)

--- a/libwallet/utils/httpclient.go
+++ b/libwallet/utils/httpclient.go
@@ -109,7 +109,7 @@ func ShutdownHTTPClients() {
 	for _, c := range activeAPIs {
 		c.cancelFunc()
 	}
-	activeAPIs = nil
+	activeAPIs = make(map[string]*Client)
 }
 
 func (c *Client) getRequestBody(method string, body interface{}) ([]byte, error) {

--- a/log.go
+++ b/log.go
@@ -188,6 +188,13 @@ var subsystemBLoggers = map[string]btclog.Logger{
 // create roll files in the same directory.  It must be called before the
 // package-global log rotater variables are used.
 func initLogRotator(logDir string, maxRolls int) {
+	// Close any previously initialized log rotators.
+	for _, rotator := range logRotators {
+		if rotator != nil {
+			rotator.Close() // TODO: what to do with error?
+		}
+	}
+
 	logRotators = map[string]*rotator.Rotator{
 		btcLogger:  nil,
 		dcrLogger:  nil,

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func main() {
 
 	// Init the AssetsManager using the user-selected netType or mainnet if the
 	// user has not selected a netType from the app's settings page.
-	appInfo, err := load.StartApp(Version, buildDate, appCfg, initializeAssetsManager)
+	appInfo, err := load.StartApp(Version, buildDate, cfg.Network, appCfg, initializeAssetsManager)
 	if err != nil {
 		log.Errorf("init assetsManager error: %v", err)
 		return

--- a/main.go
+++ b/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"fmt"
+	golog "log"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"path/filepath"
 	"time"
 
 	"gioui.org/app"
@@ -14,6 +16,7 @@ import (
 	"github.com/crypto-power/cryptopower/logger"
 	"github.com/crypto-power/cryptopower/ui"
 	_ "github.com/crypto-power/cryptopower/ui/assets"
+	"github.com/crypto-power/cryptopower/ui/load"
 )
 
 const (
@@ -37,19 +40,10 @@ func main() {
 		return
 	}
 
-	//  Initialize loggers and set log level before the asset manager is
-	//  initialized.
-	initLogRotator(cfg.LogDir, cfg.MaxLogZips)
-	if cfg.DebugLevel == "" {
-		logger.SetLogLevels(utils.DefaultLogLevel)
-	} else {
-		logger.SetLogLevels(cfg.DebugLevel)
-	}
-
 	if cfg.Profile > 0 {
 		go func() {
-			log.Info(fmt.Sprintf("Starting profiling server on port %d", cfg.Profile))
-			log.Error(http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", cfg.Profile), nil))
+			golog.Printf("Starting profiling server on port %d\n", cfg.Profile)
+			golog.Println(http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", cfg.Profile), nil))
 		}()
 	}
 
@@ -64,23 +58,53 @@ func main() {
 		buildDate = time.Now()
 	}
 
-	assetsManager, err := libwallet.NewAssetsManager(cfg.HomeDir, cfg.LogDir, cfg.net)
+	initializeAssetsManager := func(netType utils.NetworkType) (*libwallet.AssetsManager, error) {
+		//  Initialize loggers and set log level before the asset manager is
+		//  initialized.
+		logDir := filepath.Join(cfg.LogDir, string(netType))
+		initLogRotator(logDir, cfg.MaxLogZips)
+		if cfg.DebugLevel == "" {
+			logger.SetLogLevels(utils.DefaultLogLevel)
+		} else {
+			logger.SetLogLevels(cfg.DebugLevel)
+		}
+
+		assetsManager, err := libwallet.NewAssetsManager(cfg.HomeDir, logDir, netType)
+		if err != nil {
+			return nil, err
+		}
+
+		// if debuglevel is passed at commandLine persist the option.
+		if cfg.DebugLevel != "" && assetsManager.IsAssetManagerDB() {
+			assetsManager.SetLogLevels(cfg.DebugLevel)
+		}
+
+		if assetsManager.IsAssetManagerDB() {
+			// now that assets manager is up, set stored debuglevel
+			logger.SetLogLevels(assetsManager.GetLogLevels())
+		}
+
+		return assetsManager, nil
+	}
+
+	// Load the app-wide config which stores information such as the netType
+	// last used by the user.
+	appCfgFilePath := filepath.Join(cfg.HomeDir, "config.json")
+	appCfg, err := load.AppConfigFromFile(appCfgFilePath)
+	if err != nil {
+		fmt.Printf("Error: %s\n", err.Error())
+		return
+	}
+
+	// Init the AssetsManager using the user-selected netType or mainnet if the
+	// user has not selected a netType from the app's settings page.
+	appInfo, err := load.StartApp(Version, buildDate, appCfg, initializeAssetsManager)
 	if err != nil {
 		log.Errorf("init assetsManager error: %v", err)
 		return
 	}
 
-	// if debuglevel is passed at commandLine persist the option.
-	if cfg.DebugLevel != "" && assetsManager.IsAssetManagerDB() {
-		assetsManager.SetLogLevels(cfg.DebugLevel)
-	}
-
-	if assetsManager.IsAssetManagerDB() {
-		// now that assets manager is up, set stored debuglevel
-		logger.SetLogLevels(assetsManager.GetLogLevels())
-	}
-
-	win, err := ui.CreateWindow(assetsManager, Version, buildDate)
+	win, err := ui.CreateWindow(appInfo)
 	if err != nil {
 		log.Errorf("Could not initialize window: %s\ns", err)
 		return
@@ -90,7 +114,7 @@ func main() {
 		// Wait until we receive the shutdown request.
 		<-win.Quit
 		// Terminate all the backend processes safely.
-		assetsManager.Shutdown()
+		appInfo.AssetsManager.Shutdown()
 		// Backend process terminated safely trigger app shutdown now.
 		win.IsShutdown <- struct{}{}
 	}()

--- a/ui/load/appconfig.go
+++ b/ui/load/appconfig.go
@@ -22,13 +22,17 @@ type AppConfigValues struct {
 	NetType string `json:"netType"`
 }
 
-// AppConfigFromFile attempts to load and parse the JSON file at the
-// specified path, and read the stored config values. Returns a new, empty
-// AppConfig instance if there is no file at the specified path.
+var defaultAppConfigValues = &AppConfigValues{
+	NetType: string(libutils.Mainnet),
+}
+
+// AppConfigFromFile attempts to load and parse the JSON file at the specified
+// path, and read the stored config values. If there is no file at the specified
+// path, a new AppConfig instance with default values will be returned.
 func AppConfigFromFile(jsonFilePath string) (*AppConfig, error) {
 	cfg := &AppConfig{
 		jsonFilePath: jsonFilePath,
-		values:       &AppConfigValues{},
+		values:       defaultAppConfigValues, // updated below if the json file exists
 	}
 
 	cfgJSON, err := os.ReadFile(jsonFilePath)

--- a/ui/load/appconfig.go
+++ b/ui/load/appconfig.go
@@ -1,0 +1,82 @@
+package load
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+
+	libutils "github.com/crypto-power/cryptopower/libwallet/utils"
+)
+
+// AppConfig is a helper for reading and storing app-wide config values using a
+// JSON file.
+type AppConfig struct {
+	mtx          sync.RWMutex
+	jsonFilePath string
+	values       *AppConfigValues
+}
+
+// AppConfigValues are app-wide configuration options with their values.
+type AppConfigValues struct {
+	NetType string `json:"netType"`
+}
+
+// AppConfigFromFile attempts to load and parse the JSON file at the
+// specified path, and read the stored config values. Returns a new, empty
+// AppConfig instance if there is no file at the specified path.
+func AppConfigFromFile(jsonFilePath string) (*AppConfig, error) {
+	cfg := &AppConfig{
+		jsonFilePath: jsonFilePath,
+	}
+
+	cfgJSON, err := os.ReadFile(jsonFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cfg, nil
+		}
+		return nil, fmt.Errorf("os.ReadFile error: %v", err)
+	}
+
+	if err = json.Unmarshal(cfgJSON, &cfg.values); err != nil {
+		return nil, fmt.Errorf("unmarshal cfg json error: %v", err)
+	}
+
+	return cfg, nil
+}
+
+// Values returns a read-only copy of the current app-wide cofiguration values.
+func (cfg *AppConfig) Values() AppConfigValues {
+	cfg.mtx.RLock()
+	defer cfg.mtx.RUnlock()
+	values := cfg.values
+	return *values // return a copy to prevent unprotected mutation
+}
+
+// Update provides access to the current app-wide cofiguration values for
+// updating in a concurrent-safe manner. Concurrent reads and updates are
+// prevented when an update operation is on. Returns an error if the updated
+// config values cannot be persisted to the JSON file; and the update is
+// discarded.
+func (cfg *AppConfig) Update(updateFn func(*AppConfigValues)) error {
+	// Write-lock the mtx to prevent concurrent updates and reads.
+	cfg.mtx.Lock()
+	defer cfg.mtx.Unlock()
+
+	// Allow the caller to update a temporary copy of the values. Only accept
+	// the update if the changes can be persisted to file below.
+	tempValues := *cfg.values // copy the values before updating
+	updateFn(&tempValues)
+
+	// Persist the changes to the temp values copy to the json file.
+	cfgJSON, err := json.Marshal(tempValues)
+	if err != nil {
+		return fmt.Errorf("json.Marshal error: %v", err)
+	}
+	if err = os.WriteFile(cfg.jsonFilePath, cfgJSON, libutils.UserFilePerm); err != nil {
+		return fmt.Errorf("os.WriteFile error: %v", err)
+	}
+
+	cfg.values = &tempValues
+	return nil
+}

--- a/ui/load/appconfig.go
+++ b/ui/load/appconfig.go
@@ -28,6 +28,7 @@ type AppConfigValues struct {
 func AppConfigFromFile(jsonFilePath string) (*AppConfig, error) {
 	cfg := &AppConfig{
 		jsonFilePath: jsonFilePath,
+		values:       &AppConfigValues{},
 	}
 
 	cfgJSON, err := os.ReadFile(jsonFilePath)

--- a/ui/load/appinfo.go
+++ b/ui/load/appinfo.go
@@ -1,12 +1,22 @@
 package load
 
 import (
+	"fmt"
+	"sync"
 	"time"
 
+	giouiApp "gioui.org/app"
+	"gioui.org/layout"
 	"gioui.org/unit"
+	"gioui.org/widget/material"
+	"github.com/crypto-power/cryptopower/app"
 	"github.com/crypto-power/cryptopower/libwallet"
+	"github.com/crypto-power/cryptopower/libwallet/utils"
+	"github.com/crypto-power/cryptopower/ui/assets"
 	"github.com/crypto-power/cryptopower/ui/values"
 )
+
+type AssetsManagerInitFn func(utils.NetworkType) (*libwallet.AssetsManager, error)
 
 // TODO: This should ultimately replace Load, acting as the container for all
 // properties and methods that every app page and window relies on. Should
@@ -16,36 +26,176 @@ type AppInfo struct {
 	buildDate   time.Time
 	startUpTime time.Time
 
+	cfg               *AppConfig
+	initAssetsManager AssetsManagerInitFn
+	AssetsManager     *libwallet.AssetsManager
+
+	windowMtx sync.Mutex
+	window    *giouiApp.Window
+	startPage app.Page
+
 	currentAppWidth unit.Dp
 	isMobileView    bool
-
-	AssetsManager *libwallet.AssetsManager
 }
 
 // StartApp returns an instance of AppInfo with the startUpTime set to the current time.
-func StartApp(version string, buildDate time.Time, assetsManager *libwallet.AssetsManager) *AppInfo {
-	return &AppInfo{
-		version:       version,
-		buildDate:     buildDate,
-		startUpTime:   time.Now(),
-		AssetsManager: assetsManager,
+func StartApp(version string, buildDate time.Time, appCfg *AppConfig, initAssetsManager AssetsManagerInitFn) (*AppInfo, error) {
+	net := utils.Mainnet
+	if netType := appCfg.Values().NetType; netType != "" {
+		net = utils.ToNetworkType(netType)
 	}
+
+	assetsManager, err := initAssetsManager(net)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AppInfo{
+		version:           version,
+		buildDate:         buildDate,
+		startUpTime:       time.Now(),
+		cfg:               appCfg,
+		initAssetsManager: initAssetsManager,
+		AssetsManager:     assetsManager,
+	}, nil
 }
 
+// BuildDate returns the app's build date.
 func (app *AppInfo) BuildDate() time.Time {
 	return app.buildDate
 }
 
+// Version returns the app's version.
 func (app *AppInfo) Version() string {
 	return app.version
 }
 
+// StartupTime returns the app's startup time.
 func (app *AppInfo) StartupTime() time.Time {
 	return app.startUpTime
 }
 
+// ReadyForDisplay marks the app as display-ready by storing the window and
+// startPage used by the app.
+//
+// TODO: Is it possible to create Load here and bring the actual display
+// functionality over from the ui package?
+func (app *AppInfo) ReadyForDisplay(window *giouiApp.Window, startPage app.Page) {
+	app.windowMtx.Lock()
+	defer app.windowMtx.Unlock()
+
+	if app.window != nil || app.startPage != nil {
+		panic("duplicate call to AppInfo.ReadyForDisplay()")
+	}
+
+	app.window = window
+	app.startPage = startPage
+}
+
+// Window returns the gio app window that hosts this app and is used to display
+// different pages and modals.
+//
+// TODO: Is it possible for Window to be a custom type that has navigation
+// methods?
+func (app *AppInfo) Window() *giouiApp.Window {
+	app.windowMtx.Lock()
+	defer app.windowMtx.Unlock()
+	return app.window
+}
+
+// StartPage returns the first page that is displayed when the app is launched.
+// This page would be re-displayed if the app is restarted, e.g. when the
+// network type is changed.
+func (app *AppInfo) StartPage() app.Page {
+	app.windowMtx.Lock()
+	defer app.windowMtx.Unlock()
+	return app.startPage
+}
+
+// ChangeAssetsManagerNetwork changes the network type used by the app to the
+// value provided. A new AssetsManager for the specified network type is
+// initialized and returned, but not used. Call ChangeAssetsManager to use the
+// new AssetsManager.
+func (app *AppInfo) ChangeAssetsManagerNetwork(netType utils.NetworkType) (*libwallet.AssetsManager, error) {
+	currentNetType := app.AssetsManager.NetType()
+	if netType == currentNetType {
+		return nil, fmt.Errorf("new network type is the same as current network type")
+	}
+
+	// Initialize a new AssetsManager for the new netType. This will be used to
+	// replace the current AssetsManager after the current one is shutdown.
+	newAssetsManager, err := app.initAssetsManager(netType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init new AssetsManager for %s network: %v", netType, err)
+	}
+
+	// Save the new netType to appCfg and only proceed with the network switch
+	// if updating the cfg is successful.
+	err = app.cfg.Update(func(appCfgValues *AppConfigValues) {
+		appCfgValues.NetType = string(netType)
+	})
+	if err != nil {
+		newAssetsManager.Shutdown()
+		return nil, fmt.Errorf("update app config error: %v", err)
+	}
+
+	return newAssetsManager, nil
+}
+
+// ChangeAssetsManager closes all open pages, shuts down the current
+// AssetsManager, switches to the provided AssetsManager and then restarts the
+// app by displaying the app's first page.
+//
+// TODO: If *AppInfo.Window is changed to a custom type that implements
+// app.WindowNavigator, this method won't need to take an app.PageNavigator
+// parameter. See the TODO comment on *AppInfo.ReadyForDisplay() and
+// *AppInfo.Window().
+func (app *AppInfo) ChangeAssetsManager(newAssetsManager *libwallet.AssetsManager, pageNav app.PageNavigator) {
+	appStartPage := app.StartPage()
+	if appStartPage == nil {
+		// Something is wrong. Close the app and let the user restart the app.
+		// The new netType will be used.
+		panic("cannot complete network type change without a pre-set app StartPage")
+	}
+
+	// Note when the network type / assets manager switch began. We want to
+	// ensure that the temporary "restarting app" page is visible to the user
+	// for some seconds at least.
+	start := time.Now()
+
+	// Close all pages that are currently open and display a temporary
+	// "restarting app" page.
+	currentNetType, newNetType := app.AssetsManager.NetType(), newAssetsManager.NetType()
+	pageNav.ClearStackAndDisplay(networkSwitchTempPage(currentNetType, newNetType))
+
+	// Display the newNetType on the app title if its not on mainnet.
+	appTitle := giouiApp.Title(values.String(values.StrAppName))
+	if newNetType != utils.Mainnet {
+		appTitle = giouiApp.Title(values.StringF(values.StrAppTitle, newNetType.Display()))
+	}
+	app.Window().Option(appTitle)
+
+	// Shutdown the current AssetsManager and begin using the new one.
+	app.AssetsManager.Shutdown()
+	app.AssetsManager = newAssetsManager
+
+	// If the network type / assets manager switch was swift, wait a bit so the
+	// user clearly sees the temporary "restarting app" page before displaying
+	// the app's start page.
+	minWait := 3 * time.Second
+	if timeTaken := time.Since(start); timeTaken < minWait {
+		<-time.After(minWait - timeTaken)
+	}
+	pageNav.ClearStackAndDisplay(appStartPage)
+}
+
 // SetCurrentAppWidth sets the specified value as the app's current width, using
 // the provided device-dependent metric unit conversion.
+//
+// TODO: If actual display functionality is brought here over from the ui
+// package, setting the app window's current width will be more seamless and
+// this method can be unexported. See the TODO comment on
+// *AppInfo.ReadyForDisplay().
 func (app *AppInfo) SetCurrentAppWidth(appWidth int, metric unit.Metric) {
 	app.currentAppWidth = metric.PxToDp(appWidth)
 	app.isMobileView = app.currentAppWidth <= values.StartMobileView
@@ -62,7 +212,8 @@ func (app *AppInfo) IsMobileView() bool {
 	return app.isMobileView
 }
 
-// This function return text size for desktop and mobile
+// ConvertTextSize returns the appropriate text size for desktop and mobile,
+// that corresponds to the provided value.
 func (app *AppInfo) ConvertTextSize(size unit.Sp) unit.Sp {
 	if !app.isMobileView {
 		return size
@@ -81,7 +232,8 @@ func (app *AppInfo) ConvertTextSize(size unit.Sp) unit.Sp {
 	}
 }
 
-// This function return icon size for desktop and mobile
+// ConvertIconSize returns the appropriate icon size for desktop and mobile,
+// that corresponds to the provided value.
 func (app *AppInfo) ConvertIconSize(size unit.Dp) unit.Dp {
 	if !app.isMobileView {
 		return size
@@ -92,4 +244,14 @@ func (app *AppInfo) ConvertIconSize(size unit.Dp) unit.Dp {
 	default:
 		return size
 	}
+}
+
+func networkSwitchTempPage(currentNetType, newNetType utils.NetworkType) app.Page {
+	theme := material.NewTheme(assets.FontCollection())
+	text := fmt.Sprintf("Switching from %s to %s, please wait...", currentNetType, newNetType)
+	lbl := material.Body1(theme, text)
+	return app.NewWidgetDisplayPage(func(gtx layout.Context) layout.Dimensions {
+		gtx.Constraints.Min = gtx.Constraints.Max
+		return layout.Center.Layout(gtx, lbl.Layout)
+	})
 }

--- a/ui/page/dcrdex/dcrdex_page.go
+++ b/ui/page/dcrdex/dcrdex_page.go
@@ -117,7 +117,9 @@ func (pg *DEXPage) Layout(gtx C) D {
 	var msg string
 	var actionBtn *cryptomaterial.Button
 	if isMainnet {
-		actionBtn = &pg.switchToTestnetBtn
+		if pg.CanChangeNetworkType() {
+			actionBtn = &pg.switchToTestnetBtn
+		}
 		msg = values.String(values.StrDexMainnetNotReady)
 	} else if !hasMultipleWallets {
 		msg = values.String(values.StrMultipleAssetRequiredMsg)

--- a/ui/page/dcrdex/dcrdex_page.go
+++ b/ui/page/dcrdex/dcrdex_page.go
@@ -12,6 +12,7 @@ import (
 	"github.com/crypto-power/cryptopower/ui/cryptomaterial"
 	"github.com/crypto-power/cryptopower/ui/load"
 	"github.com/crypto-power/cryptopower/ui/page/components"
+	"github.com/crypto-power/cryptopower/ui/page/settings"
 	"github.com/crypto-power/cryptopower/ui/values"
 )
 
@@ -152,8 +153,8 @@ func (pg *DEXPage) isMultipleAssetTypeWalletAvailable() bool {
 // Part of the load.Page interface.
 func (pg *DEXPage) HandleUserInteractions() {
 	if pg.switchToTestnetBtn.Button.Clicked() {
-		log.Info("TODO: implement switch to testnet")
-	} // TODO: implement switch to testnet
+		settings.ChangeNetworkType(pg.Load, pg.ParentWindow(), string(libutils.Testnet))
+	}
 
 	if pg.CurrentPage() != nil {
 		pg.CurrentPage().HandleUserInteractions()

--- a/ui/page/settings/app_settings_page.go
+++ b/ui/page/settings/app_settings_page.go
@@ -42,6 +42,7 @@ type AppSettingsPage struct {
 	pageContainer *widget.List
 
 	changeStartupPass       *cryptomaterial.Clickable
+	network                 *cryptomaterial.Clickable
 	language                *cryptomaterial.Clickable
 	currency                *cryptomaterial.Clickable
 	help                    *cryptomaterial.Clickable
@@ -83,6 +84,7 @@ func NewAppSettingsPage(l *load.Load) *AppSettingsPage {
 		privacyActive:           l.Theme.Switch(),
 
 		changeStartupPass: l.Theme.NewClickable(false),
+		network:           l.Theme.NewClickable(false),
 		language:          l.Theme.NewClickable(false),
 		currency:          l.Theme.NewClickable(false),
 		help:              l.Theme.NewClickable(false),
@@ -257,6 +259,14 @@ func (pg *AppSettingsPage) general() layout.Widget {
 		return pg.wrapSection(gtx, values.String(values.StrGeneral), func(gtx C) D {
 			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
+					networkRow := row{
+						title:     values.String(values.StrNetwork),
+						clickable: pg.network,
+						label:     pg.Theme.Body2(pg.AssetsManager.NetType().Display()),
+					}
+					return pg.clickableRow(gtx, networkRow)
+				}),
+				layout.Rigid(func(gtx C) D {
 					languageRow := row{
 						title:     values.String(values.StrLanguage),
 						clickable: pg.language,
@@ -410,7 +420,7 @@ func (pg *AppSettingsPage) clickableRow(gtx C, row row) D {
 	return row.clickable.Layout(gtx, func(gtx C) D {
 		return layout.Inset{Top: values.MarginPadding5, Bottom: values.MarginPaddingMinus5}.Layout(gtx, func(gtx C) D {
 			return pg.subSection(gtx, row.title, func(gtx C) D {
-				return layout.Flex{}.Layout(gtx,
+				return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
 					layout.Rigid(row.label.Layout),
 					layout.Rigid(func(gtx C) D {
 						return pg.Theme.Icons.ChevronRight.LayoutTransform(gtx, pg.Load.IsMobileView(), values.MarginPadding20)
@@ -433,6 +443,19 @@ func (pg *AppSettingsPage) subSectionLabel(title string) layout.Widget {
 // displayed.
 // Part of the load.Page interface.
 func (pg *AppSettingsPage) HandleUserInteractions() {
+	for pg.network.Clicked() {
+		currentNetType := string(pg.AssetsManager.NetType())
+		networkSelectorModal := preference.NewListPreference(pg.Load, "", currentNetType, preference.NetworkTypes).
+			Title(values.StrNetwork).
+			UpdateValues(func(selectedNetType string) {
+				if selectedNetType != currentNetType {
+					ChangeNetworkType(pg.Load, pg.ParentWindow(), selectedNetType)
+				}
+			})
+		pg.ParentWindow().ShowModal(networkSelectorModal)
+		break
+	}
+
 	for pg.language.Clicked() {
 		langSelectorModal := preference.NewListPreference(pg.Load,
 			sharedW.LanguagePreferenceKey, values.DefaultLanguage, preference.LangOptions).
@@ -647,6 +670,32 @@ func (pg *AppSettingsPage) HandleUserInteractions() {
 			pg.ParentWindow().ShowModal(currentPasswordModal)
 		}
 	}
+}
+
+func ChangeNetworkType(load *load.Load, windowNav app.WindowNavigator, newNetType string) {
+	modalTitle := values.String(values.StrSwitchToTestnet)
+	if newNetType == string(libutils.Mainnet) {
+		modalTitle = values.String(values.StrSwitchToMainnet)
+	}
+
+	confirmNetworkSwitchModal := modal.NewCustomModal(load).
+		Title(modalTitle).
+		Body("Your app will restart to apply this change. Continue?"). // TODO: localize
+		SetCancelable(true).
+		SetPositiveButtonText(values.String(values.StrYes)).
+		SetNegativeButtonText(values.String(values.StrCancel)).
+		SetPositiveButtonCallback(func(isChecked bool, confirmModal *modal.InfoModal) bool {
+			newAssetsManager, err := load.ChangeAssetsManagerNetwork(libutils.ToNetworkType(newNetType))
+			if err != nil {
+				errorModal := modal.NewErrorModal(load, err.Error(), modal.DefaultClickFunc())
+				windowNav.ShowModal(errorModal)
+			} else {
+				// Complete the network switch in the background.
+				go load.ChangeAssetsManager(newAssetsManager, windowNav)
+			}
+			return true
+		})
+	windowNav.ShowModal(confirmNetworkSwitchModal)
 }
 
 func (pg *AppSettingsPage) showNoticeSuccess(title string) {

--- a/ui/page/settings/app_settings_page.go
+++ b/ui/page/settings/app_settings_page.go
@@ -259,6 +259,9 @@ func (pg *AppSettingsPage) general() layout.Widget {
 		return pg.wrapSection(gtx, values.String(values.StrGeneral), func(gtx C) D {
 			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
+					if !pg.CanChangeNetworkType() {
+						return D{}
+					}
 					networkRow := row{
 						title:     values.String(values.StrNetwork),
 						clickable: pg.network,

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -411,7 +411,7 @@ func (sp *startPage) loadingSection(gtx C) D {
 				return inset.Layout(gtx, sp.addWalletButton.Layout)
 			}),
 			layout.Rigid(func(gtx C) D {
-				if sp.loading {
+				if sp.loading || !sp.CanChangeNetworkType() {
 					return D{}
 				}
 				switchNetworkText := values.String(values.StrSwitchToTestnet)

--- a/ui/preference/list_preference.go
+++ b/ui/preference/list_preference.go
@@ -19,6 +19,11 @@ type (
 )
 
 var (
+	NetworkTypes = []ItemPreference{
+		{Key: string(libutils.Mainnet), Value: libutils.Mainnet.Display()},
+		{Key: string(libutils.Testnet), Value: libutils.Testnet.Display()},
+	}
+
 	// ExchOptions holds the configurable options for exchange servers.
 	ExchOptions = []ItemPreference{
 		{Key: values.BinanceExchange, Value: values.StrUsdBinance},

--- a/ui/values/localizable/en.go
+++ b/ui/values/localizable/en.go
@@ -915,7 +915,8 @@ const EN = `
 "loginToTradeDEX" = "Please login with your DEX password."
 "login" = "Login"
 "destinationWallet" = "Destination Wallet"
-"swtichToTestnet" = "Switch to Testnet"
+"switchToMainnet" = "Switch to Mainnet"
+"switchToTestnet" = "Switch to Testnet"
 "dexMainnetNotReady" = "DCRDEX is currently in beta testing and has been disabled on mainnet to prevent potential loss of funds. Please switch to testnet to try it out."
 "updateDEXWalletPasswordReason" = "Your %s wallet (%s) is connected to your DEX account. Please provide your DEX password to update DEX with the new wallet password."
 `

--- a/ui/values/strings.go
+++ b/ui/values/strings.go
@@ -103,7 +103,7 @@ func String(key string) string {
 		}
 	}
 
-	return ""
+	return key
 }
 
 func StringF(key string, a ...interface{}) string {
@@ -1024,7 +1024,8 @@ const (
 	StrLoginToTradeDEX                 = "loginToTradeDEX"
 	StrLogin                           = "login"
 	StrDestinationWallet               = "destinationWallet"
-	StrSwitchToTestnet                 = "swtichToTestnet"
+	StrSwitchToMainnet                 = "switchToMainnet"
+	StrSwitchToTestnet                 = "switchToTestnet"
 	StrDexMainnetNotReady              = "dexMainnetNotReady"
 	StrUpdateDEXWalletPasswordReason   = "updateDEXWalletPasswordReason"
 )


### PR DESCRIPTION
- Add network type switch to settings page
- Replace --network config arg with network type settings value, default to mainnet
- Show network switch button in start page if current network has no wallets
- Implement switchToTestnetBtn click handler in DEXPage