### PR TITLE
Unexport `modal.SetLoading` and allow modals show loading btn

### DIFF
--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -154,7 +154,7 @@ func (cm *CreatePasswordModal) SetNegativeButtonCallback(callback func()) *Creat
 	return cm
 }
 
-func (cm *CreatePasswordModal) SetLoading(loading bool) {
+func (cm *CreatePasswordModal) setLoading(loading bool) {
 	cm.isLoading = loading
 	cm.Modal.SetDisabled(loading)
 }
@@ -236,11 +236,13 @@ func (cm *CreatePasswordModal) Handle() {
 				return
 			}
 		}
-		cm.SetLoading(true)
+		cm.setLoading(true)
 		go func() {
 			if cm.positiveButtonClicked(cm.walletName.Editor.Text(), cm.passwordEditor.Editor.Text(), cm) {
 				cm.Dismiss()
+				return
 			}
+			cm.setLoading(false)
 		}()
 	}
 

--- a/ui/modal/create_watch_only_modal.go
+++ b/ui/modal/create_watch_only_modal.go
@@ -76,7 +76,7 @@ func (cm *CreateWatchOnlyModal) EnableName(enable bool) *CreateWatchOnlyModal {
 	return cm
 }
 
-func (cm *CreateWatchOnlyModal) SetLoading(loading bool) {
+func (cm *CreateWatchOnlyModal) setLoading(loading bool) {
 	cm.isLoading = loading
 	cm.Modal.SetDisabled(loading)
 }
@@ -140,10 +140,14 @@ func (cm *CreateWatchOnlyModal) Handle() {
 			return
 		}
 
-		cm.SetLoading(true)
-		if cm.callback(cm.walletName.Editor.Text(), cm.extendedPubKey.Editor.Text(), cm) {
-			cm.Dismiss()
-		}
+		cm.setLoading(true)
+		go func() {
+			if cm.callback(cm.walletName.Editor.Text(), cm.extendedPubKey.Editor.Text(), cm) {
+				cm.Dismiss()
+				return
+			}
+			cm.setLoading(false)
+		}()
 	}
 
 	cm.btnNegative.SetEnabled(!cm.isLoading)

--- a/ui/modal/info_modal.go
+++ b/ui/modal/info_modal.go
@@ -181,7 +181,7 @@ func (in *InfoModal) CheckBox(checkbox cryptomaterial.CheckBoxStyle, mustBeCheck
 	return in
 }
 
-func (in *InfoModal) SetLoading(loading bool) {
+func (in *InfoModal) setLoading(loading bool) {
 	in.isLoading = loading
 	in.Modal.SetDisabled(loading)
 }
@@ -298,12 +298,13 @@ func (in *InfoModal) Handle() {
 			isChecked = in.checkbox.CheckBox.Value
 		}
 
-		in.SetLoading(true)
+		in.setLoading(true)
 		go func() {
 			if in.positiveButtonClicked(isChecked, in) {
 				in.Dismiss()
+				return
 			}
-			in.SetLoading(false)
+			in.setLoading(false)
 		}()
 	}
 

--- a/ui/modal/text_input_modal.go
+++ b/ui/modal/text_input_modal.go
@@ -53,7 +53,7 @@ func (tm *TextInputModal) Hint(hint string) *TextInputModal {
 	return tm
 }
 
-func (tm *TextInputModal) SetLoading(loading bool) {
+func (tm *TextInputModal) setLoading(loading bool) {
 	tm.isLoading = loading
 	tm.Modal.SetDisabled(loading)
 }
@@ -115,11 +115,15 @@ func (tm *TextInputModal) Handle() {
 			return
 		}
 
-		tm.SetLoading(true)
+		tm.setLoading(true)
 		tm.SetError("")
-		if tm.callback(tm.textInput.Editor.Text(), tm) {
-			tm.Dismiss()
-		}
+		go func() {
+			if tm.callback(tm.textInput.Editor.Text(), tm) {
+				tm.Dismiss()
+				return
+			}
+			tm.setLoading(false)
+		}()
 	}
 
 	for tm.btnNegative.Clicked() {

--- a/ui/page/accounts/accounts_page.go
+++ b/ui/page/accounts/accounts_page.go
@@ -275,7 +275,6 @@ func (pg *Page) HandleUserInteractions() {
 				_, err := pg.wallet.CreateNewAccount(accountName, password)
 				if err != nil {
 					m.SetError(err.Error())
-					m.SetLoading(false)
 					return false
 				}
 				pg.loadWalletAccount()

--- a/ui/page/accounts/btc_account_details_page.go
+++ b/ui/page/accounts/btc_account_details_page.go
@@ -379,7 +379,6 @@ func (pg *BTCAcctDetailsPage) HandleUserInteractions() {
 				err := pg.wallet.RenameAccount(int32(pg.account.AccountNumber), newName)
 				if err != nil {
 					tim.SetError(err.Error())
-					tim.SetLoading(false)
 					return false
 				}
 				pg.account.AccountName = newName

--- a/ui/page/accounts/dcr_account_details_page.go
+++ b/ui/page/accounts/dcr_account_details_page.go
@@ -392,7 +392,6 @@ func (pg *AcctDetailsPage) HandleUserInteractions() {
 				err := pg.wallet.RenameAccount(pg.account.Number, newName)
 				if err != nil {
 					tim.SetError(err.Error())
-					tim.SetLoading(false)
 					return false
 				}
 				pg.account.Name = newName

--- a/ui/page/accounts/ltc_account_details_page.go
+++ b/ui/page/accounts/ltc_account_details_page.go
@@ -376,7 +376,6 @@ func (pg *LTCAcctDetailsPage) HandleUserInteractions() {
 				err := pg.wallet.RenameAccount(int32(pg.account.AccountNumber), newName)
 				if err != nil {
 					tim.SetError(err.Error())
-					tim.SetLoading(false)
 					return false
 				}
 				pg.account.AccountName = newName

--- a/ui/page/components/restore_page.go
+++ b/ui/page/components/restore_page.go
@@ -291,7 +291,6 @@ func (pg *Restore) restoreFromSeedEditor() {
 					errString = values.StringF(values.StrWalletExist, pg.walletName)
 				}
 				m.SetError(errString)
-				m.SetLoading(false)
 				clearEditor()
 				return false
 			}

--- a/ui/page/components/seed_restore_page.go
+++ b/ui/page/components/seed_restore_page.go
@@ -581,7 +581,6 @@ func (pg *SeedRestore) HandleUserInteractions() {
 						errString = values.StringF(values.StrWalletExist, pg.walletName)
 					}
 					m.SetError(errString)
-					m.SetLoading(false)
 					pg.isRestoring = false
 					return false
 				}

--- a/ui/page/dcrdex/market.go
+++ b/ui/page/dcrdex/market.go
@@ -301,7 +301,6 @@ func dexLoginModal(load *load.Load, dexClient libwallet.DEXClient, positiveBtnCa
 			err := dexClient.Login([]byte(password))
 			if err != nil {
 				pm.SetError(err.Error())
-				pm.SetLoading(false)
 				return false
 			}
 
@@ -1641,7 +1640,6 @@ func (pg *DEXMarketPage) HandleUserInteractions() {
 				defer func() {
 					if err != nil {
 						pm.SetError(err.Error())
-						pm.SetLoading(false)
 					}
 					pg.showLoader = false
 				}()
@@ -1752,7 +1750,6 @@ func (pg *DEXMarketPage) showSelectDEXWalletModal(missingWallet libutils.AssetTy
 			err := pg.createMissingMarketWallet(missingWallet, dexPass, walletPass)
 			if err != nil {
 				pm.SetError(err.Error())
-				pm.SetLoading(false)
 				return false
 			}
 
@@ -1770,7 +1767,6 @@ func (pg *DEXMarketPage) showSelectDEXWalletModal(missingWallet libutils.AssetTy
 			err := pg.AssetsManager.DexClient().Login([]byte(password))
 			if err != nil {
 				pm.SetError(err.Error())
-				pm.SetLoading(false)
 				return false
 			}
 

--- a/ui/page/exchange/order_scheduler_modal.go
+++ b/ui/page/exchange/order_scheduler_modal.go
@@ -138,7 +138,7 @@ func (osm *orderSchedulerModal) OnResume() {
 	osm.ctx, osm.ctxCancel = context.WithCancel(context.TODO())
 }
 
-func (osm *orderSchedulerModal) SetLoading(loading bool) {
+func (osm *orderSchedulerModal) setLoading(loading bool) {
 	osm.isStarting = loading
 	osm.Modal.SetDisabled(loading)
 }
@@ -460,14 +460,12 @@ func (osm *orderSchedulerModal) Layout(gtx layout.Context) D {
 }
 
 func (osm *orderSchedulerModal) startOrderScheduler() {
-	// osm.SetLoading(true)
-
 	go func() {
-		osm.SetLoading(true)
+		osm.setLoading(true)
 		err := osm.sourceWalletSelector.SelectedWallet().UnlockWallet(osm.passwordEditor.Editor.Text())
 		if err != nil {
 			osm.SetError(err.Error())
-			osm.SetLoading(false)
+			osm.setLoading(false)
 			return
 		}
 

--- a/ui/page/exchange/order_settings_modal.go
+++ b/ui/page/exchange/order_settings_modal.go
@@ -139,7 +139,7 @@ func (osm *orderSettingsModal) OnResume() {
 	go osm.feeRateSelector.UpdatedFeeRate(osm.sourceWalletSelector.SelectedWallet())
 }
 
-func (osm *orderSettingsModal) SetLoading(loading bool) {
+func (osm *orderSettingsModal) setLoading(loading bool) {
 	osm.Modal.SetDisabled(loading)
 }
 

--- a/ui/page/governance/agenda_vote_modal.go
+++ b/ui/page/governance/agenda_vote_modal.go
@@ -78,12 +78,10 @@ func (avm *agendaVoteModal) sendVotes(_, password string, _ *modal.CreatePasswor
 	err := avm.dcrImpl.SetVoteChoice(avm.agenda.AgendaID, avm.voteChoice, "", password)
 	if err != nil {
 		avm.CreatePasswordModal.SetError(err.Error())
-		avm.CreatePasswordModal.SetLoading(false)
 		return false
 	}
 	successModal := modal.NewSuccessModal(avm.Load, values.String(values.StrVoteUpdated), modal.DefaultClickFunc())
 	avm.ParentWindow().ShowModal(successModal)
-	avm.Dismiss()
 	avm.onPreferenceUpdated()
 	return true
 }

--- a/ui/page/governance/proposal_vote_modal.go
+++ b/ui/page/governance/proposal_vote_modal.go
@@ -155,7 +155,6 @@ func (vm *voteModal) sendVotes() {
 			err := vm.AssetsManager.Politeia.CastVotes(ctx, w, libwallet.ConvertVotes(votes), vm.proposal.Token, password)
 			if err != nil {
 				pm.SetError(err.Error())
-				pm.SetLoading(false)
 				return false
 			}
 			vm.Dismiss()

--- a/ui/page/governance/treasury_page.go
+++ b/ui/page/governance/treasury_page.go
@@ -357,7 +357,6 @@ func (pg *TreasuryPage) updatePolicyPreference(treasuryItem *components.Treasury
 			err := pg.selectedDCRWallet.SetTreasuryPolicy(treasuryItem.Policy.PiKey, votingPreference, "", password)
 			if err != nil {
 				pm.SetError(err.Error())
-				pm.SetLoading(false)
 				return false
 			}
 

--- a/ui/page/privacy/account_mixer_page.go
+++ b/ui/page/privacy/account_mixer_page.go
@@ -469,7 +469,6 @@ func (pg *AccountMixerPage) showModalPasswordStartAccountMixer() {
 				err := pg.dcrWallet.StartAccountMixer(password)
 				if err != nil {
 					pg.Toast.NotifyError(err.Error())
-					pm.SetLoading(false)
 					return
 				}
 				pm.Dismiss()

--- a/ui/page/privacy/manual_mixer_setup_page.go
+++ b/ui/page/privacy/manual_mixer_setup_page.go
@@ -260,7 +260,6 @@ func (pg *ManualMixerSetupPage) showModalSetupMixerAcct() {
 		SetPositiveButtonCallback(func(_, password string, pm *modal.CreatePasswordModal) bool {
 			errfunc := func(err error) bool {
 				pm.SetError(err.Error())
-				pm.SetLoading(false)
 				return false
 			}
 			mixedAcctNumber := pg.mixedAccountSelector.SelectedAccount().Number

--- a/ui/page/privacy/shared_modals.go
+++ b/ui/page/privacy/shared_modals.go
@@ -73,7 +73,6 @@ func showModalSetupMixerAcct(conf *sharedModalConfig, dcrWallet *dcr.Asset, move
 			err := dcrWallet.CreateMixerAccounts(values.String(values.StrMixed), values.String(values.StrUnmixed), password)
 			if err != nil {
 				pm.SetError(err.Error())
-				pm.SetLoading(false)
 				return false
 			}
 

--- a/ui/page/root/home_page.go
+++ b/ui/page/root/home_page.go
@@ -1034,7 +1034,6 @@ func (hp *HomePage) unlockWalletForSyncing(wal sharedW.Asset, unlock load.NeedUn
 			err := wal.UnlockWallet(password)
 			if err != nil {
 				pm.SetError(err.Error())
-				pm.SetLoading(false)
 				return false
 			}
 			unlock(true)

--- a/ui/page/security/sign_message_page.go
+++ b/ui/page/security/sign_message_page.go
@@ -288,7 +288,6 @@ func (pg *SignMessagePage) HandleUserInteractions() {
 					sig, err := pg.wallet.SignMessage(password, address, message)
 					if err != nil {
 						pm.SetError(err.Error())
-						pm.SetLoading(false)
 						return false
 					}
 

--- a/ui/page/seedbackup/save_seed.go
+++ b/ui/page/seedbackup/save_seed.go
@@ -113,7 +113,6 @@ func (pg *SaveSeedPage) OnNavigatedTo() {
 		SetPositiveButtonCallback(func(_, password string, m *modal.CreatePasswordModal) bool {
 			seed, err := pg.wallet.DecryptSeed(password)
 			if err != nil {
-				m.SetLoading(false)
 				m.SetError(err.Error())
 				return false
 			}

--- a/ui/page/seedbackup/verify_seed.go
+++ b/ui/page/seedbackup/verify_seed.go
@@ -194,13 +194,11 @@ func (pg *VerifySeedPage) verifySeed() {
 					return false
 				}
 
-				m.SetLoading(false)
 				m.SetError(err.Error())
 				return false
 			}
-			m.Dismiss()
-			pg.ParentNavigator().Display(NewBackupSuccessPage(pg.Load, pg.redirectCallback))
 
+			pg.ParentNavigator().Display(NewBackupSuccessPage(pg.Load, pg.redirectCallback))
 			return true
 		})
 	pg.ParentWindow().ShowModal(passwordModal)

--- a/ui/page/send/send_confirm_modal.go
+++ b/ui/page/send/send_confirm_modal.go
@@ -69,7 +69,7 @@ func (scm *sendConfirmModal) SetError(err string) {
 	scm.passwordEditor.SetError(values.TranslateErr(err))
 }
 
-func (scm *sendConfirmModal) SetLoading(loading bool) {
+func (scm *sendConfirmModal) setLoading(loading bool) {
 	scm.isSending = loading
 	scm.Modal.SetDisabled(loading)
 }
@@ -82,12 +82,12 @@ func (scm *sendConfirmModal) broadcastTransaction() {
 		return
 	}
 
-	scm.SetLoading(true)
+	scm.setLoading(true)
 	go func() {
+		defer scm.setLoading(false)
 		_, err := scm.asset.Broadcast(password, scm.txLabel)
 		if err != nil {
 			scm.SetError(err.Error())
-			scm.SetLoading(false)
 			return
 		}
 		successModal := modal.NewSuccessModal(scm.Load, values.String(values.StrTxSent), modal.DefaultClickFunc())

--- a/ui/page/settings/app_settings_page.go
+++ b/ui/page/settings/app_settings_page.go
@@ -627,13 +627,11 @@ func (pg *AppSettingsPage) HandleUserInteractions() {
 			SetPositiveButtonCallback(func(_, password string, pm *modal.CreatePasswordModal) bool {
 				if !utils.StringNotEmpty(password) {
 					pm.SetError(values.String(values.StrErrPassEmpty))
-					pm.SetLoading(false)
 					return false
 				}
 				err := pg.AssetsManager.VerifyStartupPassphrase(password)
 				if err != nil {
 					pm.SetError(err.Error())
-					pm.SetLoading(false)
 					return false
 				}
 				pm.Dismiss()
@@ -647,13 +645,11 @@ func (pg *AppSettingsPage) HandleUserInteractions() {
 					SetPositiveButtonCallback(func(walletName, newPassword string, m *modal.CreatePasswordModal) bool {
 						if !utils.StringNotEmpty(newPassword) {
 							m.SetError(values.String(values.StrErrPassEmpty))
-							m.SetLoading(false)
 							return false
 						}
 						err := pg.AssetsManager.ChangeStartupPassphrase(password, newPassword, sharedW.PassphraseTypePass)
 						if err != nil {
 							m.SetError(err.Error())
-							m.SetLoading(false)
 							return false
 						}
 						pg.showNoticeSuccess(values.String(values.StrStartupPassConfirm))
@@ -678,13 +674,11 @@ func (pg *AppSettingsPage) HandleUserInteractions() {
 				SetPositiveButtonCallback(func(walletName, password string, m *modal.CreatePasswordModal) bool {
 					if !utils.StringNotEmpty(password) {
 						m.SetError(values.String(values.StrErrPassEmpty))
-						m.SetLoading(false)
 						return false
 					}
 					err := pg.AssetsManager.SetStartupPassphrase(password, sharedW.PassphraseTypePass)
 					if err != nil {
 						m.SetError(err.Error())
-						m.SetLoading(false)
 						return false
 					}
 					pg.showNoticeSuccess(values.StringF(values.StrStartupPasswordEnabled, values.String(values.StrEnabled)))
@@ -707,7 +701,6 @@ func (pg *AppSettingsPage) HandleUserInteractions() {
 					err := pg.AssetsManager.RemoveStartupPassphrase(password)
 					if err != nil {
 						pm.SetError(err.Error())
-						pm.SetLoading(false)
 						return false
 					}
 					pg.showNoticeSuccess(values.StringF(values.StrStartupPasswordEnabled, values.String(values.StrDisabled)))
@@ -732,7 +725,6 @@ func (pg *AppSettingsPage) HandleUserInteractions() {
 				dexSeed, err := pg.AssetsManager.DexClient().ExportSeed([]byte(password))
 				if err != nil {
 					pm.SetError(err.Error())
-					pm.SetLoading(false)
 					return false
 				}
 

--- a/ui/page/staking/stake_overview.go
+++ b/ui/page/staking/stake_overview.go
@@ -400,7 +400,6 @@ func (pg *Page) startTicketBuyerPasswordModal() {
 		SetPositiveButtonCallback(func(_, password string, pm *modal.CreatePasswordModal) bool {
 			if !pg.dcrWallet.IsConnectedToNetwork() {
 				pm.SetError(values.String(values.StrNotConnected))
-				pm.SetLoading(false)
 				pg.stake.SetChecked(false)
 				return false
 			}
@@ -408,7 +407,6 @@ func (pg *Page) startTicketBuyerPasswordModal() {
 			err := pg.dcrWallet.StartTicketBuyer(password)
 			if err != nil {
 				pm.SetError(err.Error())
-				pm.SetLoading(false)
 				return false
 			}
 

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -214,7 +214,6 @@ func (sp *startPage) unlock() {
 			err := sp.openWalletsAndDisplayHomePage(password)
 			if err != nil {
 				m.SetError(err.Error())
-				m.SetLoading(false)
 				return false
 			}
 

--- a/ui/page/wallet/wallet_settings_page.go
+++ b/ui/page/wallet/wallet_settings_page.go
@@ -374,7 +374,6 @@ func (pg *SettingsPage) changeSpendingPasswordModal() {
 				newPassword, sharedW.PassphraseTypePass)
 			if err != nil {
 				m.SetError(err.Error())
-				m.SetLoading(false)
 				return false
 			}
 
@@ -383,7 +382,6 @@ func (pg *SettingsPage) changeSpendingPasswordModal() {
 				err := pg.AssetsManager.DexClient().SetWalletPassword([]byte(dexPass), assetID, []byte(newPassword))
 				if err != nil {
 					m.SetError(fmt.Errorf("Failed to update your dex wallet password, try again: %v", err).Error())
-					m.SetLoading(false)
 
 					// Undo password change.
 					if err = pg.wallet.ChangePrivatePassphraseForWallet(newPassword, currentPassword, sharedW.PassphraseTypePass); err != nil {
@@ -410,7 +408,6 @@ func (pg *SettingsPage) changeSpendingPasswordModal() {
 			err := pg.AssetsManager.DexClient().Login([]byte(password))
 			if err != nil {
 				pm.SetError(err.Error())
-				pm.SetLoading(false)
 				return false
 			}
 
@@ -430,7 +427,6 @@ func (pg *SettingsPage) changeSpendingPasswordModal() {
 			err := pg.wallet.UnlockWallet(password)
 			if err != nil {
 				pm.SetError(err.Error())
-				pm.SetLoading(false)
 				return false
 			}
 			pg.wallet.LockWallet()
@@ -469,7 +465,6 @@ func (pg *SettingsPage) deleteWalletModal() {
 		SetPositiveButtonCallback(func(walletName string, m *modal.TextInputModal) bool {
 			if walletName != pg.wallet.GetWalletName() {
 				m.SetError(values.String(values.StrWalletNameMismatch))
-				m.SetLoading(false)
 				return false
 			}
 
@@ -487,7 +482,6 @@ func (pg *SettingsPage) deleteWalletModal() {
 				err := pg.AssetsManager.DeleteWallet(pg.wallet.GetWalletID(), "")
 				if err != nil {
 					m.SetError(err.Error())
-					m.SetLoading(false)
 				} else {
 					walletDeleted()
 				}
@@ -498,14 +492,10 @@ func (pg *SettingsPage) deleteWalletModal() {
 				EnableName(false).
 				EnableConfirmPassword(false).
 				Title(values.String(values.StrConfirmToRemove)).
-				SetNegativeButtonCallback(func() {
-					m.SetLoading(false)
-				}).
 				SetPositiveButtonCallback(func(_, password string, pm *modal.CreatePasswordModal) bool {
 					err := pg.AssetsManager.DeleteWallet(pg.wallet.GetWalletID(), password)
 					if err != nil {
 						pm.SetError(err.Error())
-						pm.SetLoading(false)
 						return false
 					}
 
@@ -530,14 +520,12 @@ func (pg *SettingsPage) renameWalletModal() {
 			name := strings.TrimSpace(newName)
 			if !utils.ValidateLengthName(name) {
 				tm.SetError(values.String(values.StrWalletNameLengthError))
-				tm.SetLoading(false)
 				return false
 			}
 
 			err := pg.wallet.RenameWallet(name)
 			if err != nil {
 				tm.SetError(err.Error())
-				tm.SetLoading(false)
 				return false
 			}
 			info := modal.NewSuccessModal(pg.Load, values.StringF(values.StrWalletRenamed), modal.DefaultClickFunc())
@@ -557,7 +545,6 @@ func (pg *SettingsPage) showSPVPeerDialog() {
 			addrs, ok := validatePeerAddressStr(ipAddress)
 			if !ok {
 				tim.SetError(values.StringF(values.StrValidateHostErr, addrs))
-				tim.SetLoading(false)
 				return false
 			}
 			pg.wallet.SetSpecificPeer(addrs)
@@ -678,7 +665,6 @@ func (pg *SettingsPage) HandleUserInteractions() {
 						errorModal := modal.NewErrorModal(pg.Load, err.Error(), modal.DefaultClickFunc())
 						pg.ParentWindow().ShowModal(errorModal)
 						im.Dismiss()
-
 						return false
 					}
 
@@ -726,7 +712,6 @@ func (pg *SettingsPage) HandleUserInteractions() {
 				SetPositiveButtonCallback(func(textInput string, tim *modal.TextInputModal) bool {
 					if textInput != values.String(values.StrAwareOfRisk) {
 						tim.SetError(values.String(values.StrConfirmPending))
-						tim.SetLoading(false)
 					} else {
 						pg.wallet.SetBoolConfigValueForKey(sharedW.SpendUnmixedFundsKey, true)
 						tim.Dismiss()
@@ -799,7 +784,6 @@ func (pg *SettingsPage) HandleUserInteractions() {
 				_, err := pg.wallet.CreateNewAccount(accountName, password)
 				if err != nil {
 					m.SetError(err.Error())
-					m.SetLoading(false)
 					return false
 				}
 				pg.loadWalletAccount()
@@ -826,25 +810,21 @@ func (pg *SettingsPage) gapLimitModal() {
 			val, err := strconv.ParseUint(gapLimit, 10, 32)
 			if err != nil {
 				tm.SetError(values.String(values.StrGapLimitInputErr))
-				tm.SetLoading(false)
 				return false
 			}
 
 			if val < 1 || val > 1000 {
 				tm.SetError(values.String(values.StrGapLimitInputErr))
-				tm.SetLoading(false)
 				return false
 			}
 			gLimit := uint32(val)
-			tm.SetLoading(true)
 
 			err = pg.wallet.(*dcr.Asset).DiscoverUsage(gLimit)
 			if err != nil {
 				tm.SetError(err.Error())
-				tm.SetLoading(false)
 				return false
 			}
-			tm.SetLoading(false)
+
 			info := modal.NewSuccessModal(pg.Load, values.String(values.StrAddressDiscoveryStarted), modal.DefaultClickFunc()).
 				Body(values.String(values.StrAddressDiscoveryStartedBody))
 			pg.ParentWindow().ShowModal(info)


### PR DESCRIPTION
Issue: Some modals like `InfoModal` , `TextInputModal `, and `CreateWatchOnlyModal` do not show a loading btn when the `positiveButtonClicked` callback is executed. Also it didn't fit the pattern  to have callers `m.SetLoading(false)` when they encounter an error in  the `positiveButtonClicked` callback  when we can do that once the callback returns if need be(we already do `m.SetLoading(true)` before calling the callback).