### PR TITLE
fix crash when pasting an empty text into the editor

### DIFF
--- a/libwallet/assets/dcr/syncnotification.go
+++ b/libwallet/assets/dcr/syncnotification.go
@@ -403,6 +403,11 @@ func (asset *Asset) discoverAddressesFinished() {
 		return
 	}
 
+	err := asset.MarkWalletAsDiscoveredAccounts() // Mark address discovery as completed.
+	if err != nil {
+		log.Error(err)
+	}
+
 	asset.stopUpdatingAddressDiscoveryProgress()
 }
 

--- a/libwallet/assets/wallet/wallet_shared.go
+++ b/libwallet/assets/wallet/wallet_shared.go
@@ -268,6 +268,18 @@ func (wallet *Wallet) GetWalletName() string {
 func (wallet *Wallet) ContainsDiscoveredAccounts() bool {
 	wallet.mu.RLock()
 	defer wallet.mu.RUnlock()
+	// Address discovery was previously not marked as completed for watch only wallets.
+	// This caused the receive page to be inaccessible for watch only wallets even after
+	// address discovery was completed.
+	// This is a temporary fix to allow users to continue using their watch-only wallets
+	// (i.e being able to see their receive address).
+	// This fix would also incorrectly report watch-only wallets that have not finished address discovery as
+	// having completed it.
+	// Although this is not a critical issue, becuase until a watch only wallet has finished the syncing
+	// process (including address discovery), the reveive page will not be accessible.
+	if wallet.IsWatchingOnlyWallet() {
+		return true
+	}
 	return wallet.HasDiscoveredAccounts
 }
 

--- a/libwallet/assets_manager.go
+++ b/libwallet/assets_manager.go
@@ -796,12 +796,12 @@ func (mgr *AssetsManager) LTCHDPrefix() string {
 	}
 }
 
-func (mgr *AssetsManager) CalculateTotalAssetsBalance() (map[utils.AssetType]sharedW.AssetAmount, error) {
+func (mgr *AssetsManager) CalculateTotalAssetsBalance(includeWatchWallet bool) (map[utils.AssetType]sharedW.AssetAmount, error) {
 	assetsTotalBalance := make(map[utils.AssetType]sharedW.AssetAmount)
 
 	wallets := mgr.AllWallets()
 	for _, wal := range wallets {
-		if wal.IsWatchingOnlyWallet() {
+		if !includeWatchWallet && wal.IsWatchingOnlyWallet() {
 			continue
 		}
 

--- a/ui/cryptomaterial/editor.go
+++ b/ui/cryptomaterial/editor.go
@@ -420,7 +420,9 @@ func (e *Editor) handleEvents(gtx C) {
 	}
 
 	if e.paste.Clicked() {
-		clipboard.ReadOp{Tag: &e.eventKey}.Add(gtx.Ops)
+		if e.eventKey > 0 {
+			clipboard.ReadOp{Tag: &e.eventKey}.Add(gtx.Ops)
+		}
 		e.isShowMenu = false
 	}
 }

--- a/ui/cryptomaterial/theme.go
+++ b/ui/cryptomaterial/theme.go
@@ -327,6 +327,22 @@ func (t *Theme) AssetIcon(asset utils.AssetType) *Image {
 	return icon
 }
 
+// WatchOnlyAssetIcon returns the icon for a watch only wallet.
+func (t *Theme) WatchOnlyAssetIcon(asset utils.AssetType) *Image {
+	var icon *Image
+	switch asset {
+	case utils.DCRWalletAsset:
+		icon = t.Icons.DcrWatchOnly
+	case utils.LTCWalletAsset:
+		icon = t.Icons.LtcWatchOnly
+	case utils.BTCWalletAsset:
+		icon = t.Icons.BtcWatchOnly
+	default:
+		icon = nil
+	}
+	return icon
+}
+
 func (t *Theme) AutoHideSoftKeyBoard(gtx C) {
 	isHide := true
 	for _, e := range t.allEditors {

--- a/ui/page/components/wallet_sync_info.go
+++ b/ui/page/components/wallet_sync_info.go
@@ -142,6 +142,9 @@ func (wsi *WalletSyncInfo) walletNameAndBackupInfo(gtx C) D {
 				Right: values.MarginPadding10,
 			}.Layout(gtx, func(gtx C) D {
 				icon := wsi.Theme.AssetIcon(wsi.wallet.GetAssetType())
+				if wsi.wallet.IsWatchingOnlyWallet() {
+					icon = wsi.Theme.WatchOnlyAssetIcon(wsi.wallet.GetAssetType())
+				}
 				return icon.Layout16dp(gtx)
 			})
 		}))

--- a/ui/page/root/home_page.go
+++ b/ui/page/root/home_page.go
@@ -1044,7 +1044,7 @@ func (hp *HomePage) unlockWalletForSyncing(wal sharedW.Asset, unlock load.NeedUn
 
 func (hp *HomePage) CalculateAssetsUSDBalance() {
 	if hp.AssetsManager.ExchangeRateFetchingEnabled() {
-		assetsBalance, err := hp.AssetsManager.CalculateTotalAssetsBalance()
+		assetsBalance, err := hp.AssetsManager.CalculateTotalAssetsBalance(true)
 		if err != nil {
 			log.Error(err)
 			return

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -1092,7 +1092,7 @@ func (pg *OverviewPage) updateAssetsUSDBalance() {
 }
 
 func (pg *OverviewPage) updateAssetsSliders() {
-	assetsBalance, err := pg.AssetsManager.CalculateTotalAssetsBalance()
+	assetsBalance, err := pg.AssetsManager.CalculateTotalAssetsBalance(true)
 	if err != nil {
 		log.Error(err)
 		return

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -379,9 +379,6 @@ func (pg *OverviewPage) layoutMobile(gtx C) D {
 func (pg *OverviewPage) initInfoWallets() {
 	wallets := pg.AssetsManager.AllWallets()
 	for _, wal := range wallets {
-		if wal.IsWatchingOnlyWallet() {
-			continue
-		}
 		infoSync := components.NewWalletSyncInfo(pg.Load, wal, pg.reload, pg.backup)
 		infoSync.IsSlider = true
 		pg.listInfoWallets = append(pg.listInfoWallets, infoSync)

--- a/ui/page/root/wallet_selector_page.go
+++ b/ui/page/root/wallet_selector_page.go
@@ -117,7 +117,7 @@ func (pg *WalletSelectorPage) OnNavigatedTo() {
 
 	go func() {
 		// calculate total assets balance
-		assetsBalance, err := pg.AssetsManager.CalculateTotalAssetsBalance()
+		assetsBalance, err := pg.AssetsManager.CalculateTotalAssetsBalance(true)
 		if err != nil {
 			log.Error(err)
 		}

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -556,8 +556,14 @@ func (sp *startPage) settingsOptionsLayout(gtx C) D {
 				item.infoButton.Size = values.MarginPaddingTransform(sp.IsMobileView(), values.MarginPadding20)
 
 				borderWidth := values.MarginPadding2
+				borderColor := sp.Theme.Color.Primary
 				if sp.selectedSettingsOptionIndex != i && !item.clickable.IsHovered() {
 					borderWidth = 0
+					borderColor = sp.Theme.Color.Gray1
+				}
+
+				if item.clickable.IsHovered() {
+					borderColor = sp.Theme.Color.Gray1
 				}
 
 				inset := layout.Inset{}
@@ -578,7 +584,7 @@ func (sp *startPage) settingsOptionsLayout(gtx C) D {
 						Background:  sp.Theme.Color.DefaultThemeColors().White,
 						Border: cryptomaterial.Border{
 							Radius: cryptomaterial.Radius(8),
-							Color:  sp.Theme.Color.Primary,
+							Color:  borderColor,
 							Width:  borderWidth,
 						},
 						Margin: layout.Inset{Bottom: values.MarginPadding15},

--- a/ui/page/wallet/single_wallet_main_page.go
+++ b/ui/page/wallet/single_wallet_main_page.go
@@ -193,7 +193,7 @@ func (swmp *SingleWalletMasterPage) initTabOptions() {
 
 		// If 'Send' has been added, adjust the insertIndex accordingly.
 		if !swmp.selectedWallet.IsWatchingOnlyWallet() {
-			insertIndex += 1
+			insertIndex++
 		}
 
 		// Update the commonTabs with DCR-specific items at the determined index.

--- a/ui/page/wallet/wallet_settings_page.go
+++ b/ui/page/wallet/wallet_settings_page.go
@@ -524,6 +524,7 @@ func (pg *SettingsPage) deleteWalletModal() {
 func (pg *SettingsPage) renameWalletModal() {
 	textModal := modal.NewTextInputModal(pg.Load).
 		Hint(values.String(values.StrWalletName)).
+		SetText(pg.wallet.GetWalletName()).
 		PositiveButtonStyle(pg.Load.Theme.Color.Primary, pg.Load.Theme.Color.InvText).
 		SetPositiveButtonCallback(func(newName string, tm *modal.TextInputModal) bool {
 			name := strings.TrimSpace(newName)


### PR DESCRIPTION
closes #445 
closes #458

- fix crash when pasting an empty text into the editor
- add watch only wallet sync card to overview page
- fix hover color for setting options on start page
- fix watch only wallet balance not being accounted for
- show wallet name in the editor while trying to rename wallet
- fix a bug where address discovery was not marked as completed for watch only wallets