### PR TITLE
dcr: Avoid freeze inside db transaction.

### DIFF
--- a/libwallet/assets/dcr/txindex.go
+++ b/libwallet/assets/dcr/txindex.go
@@ -12,6 +12,9 @@ func (asset *Asset) IndexTransactions() error {
 		return utils.ErrDCRNotInitialized
 	}
 
+	asset.dbMutex.Lock()
+	defer asset.dbMutex.Unlock()
+
 	ctx, _ := asset.ShutdownContextWithCancel()
 
 	var totalIndex int32


### PR DESCRIPTION
In dcr theres a request for the current wallet inside a db transaction, so if a user closes a wallet during *asset.IndexTransactions() It will get the lock at *dcrLoader.UnloadWallet() but then get stuck at l.db.Close() because it cannot close the db while a transation is taking place. So the request in the transation gets stuck trying to get the lock. If that makes sense.