### PR TITLE
Support 12 and 24 word seeds from other wallet

### DIFF
--- a/libwallet/assets/btc/wallet.go
+++ b/libwallet/assets/btc/wallet.go
@@ -238,10 +238,10 @@ func LoadExisting(w *sharedW.Wallet, params *sharedW.InitParams) (sharedW.Asset,
 		txAndBlockNotificationListeners: make(map[string]*sharedW.TxAndBlockNotificationListener),
 	}
 
-	// w.EncryptedSeed was previously deleted after verification. Existing
+	// w.EncryptedMnemonic was previously deleted after verification. Existing
 	// wallets created before the change to allow viewing wallet seed in-app
 	// should still behave normal but they can no longer view their seed.
-	if len(w.EncryptedSeed) == 0 && !w.IsBackedUp {
+	if len(w.EncryptedMnemonic) == 0 && !w.IsBackedUp {
 		w.IsBackedUp = true
 		if err := params.DB.Save(w); err != nil {
 			log.Errorf("DB.Save error: %v", err)

--- a/libwallet/assets/dcr/wallet.go
+++ b/libwallet/assets/dcr/wallet.go
@@ -238,10 +238,10 @@ func LoadExisting(w *sharedW.Wallet, params *sharedW.InitParams) (sharedW.Asset,
 		dbMutex:                           &dbMutex,
 	}
 
-	// w.EncryptedSeed was previously deleted after verification. Existing
+	// w.EncryptedMnemonic was previously deleted after verification. Existing
 	// wallets created before the change to allow viewing wallet seed in-app
 	// should still behave normal but they can no longer view their seed.
-	if len(w.EncryptedSeed) == 0 && !w.IsBackedUp {
+	if len(w.EncryptedMnemonic) == 0 && !w.IsBackedUp {
 		w.IsBackedUp = true
 		if err := params.DB.Save(w); err != nil {
 			log.Errorf("DB.Save error: %v", err)

--- a/libwallet/assets/ltc/utils.go
+++ b/libwallet/assets/ltc/utils.go
@@ -62,7 +62,7 @@ func (asset *Asset) DeriveAccountXpub(seedMnemonic string, wordSeedType sharedW.
 	if wordSeedType == sharedW.WordSeed33 {
 		seed, err = walletseed.DecodeUserInput(seedMnemonic)
 	} else {
-		seed, err = bip39.EntropyFromMnemonic(seedMnemonic)
+		seed, err = bip39.NewSeedWithErrorChecking(seedMnemonic, "")
 	}
 	if err != nil {
 		return "", err

--- a/libwallet/assets/ltc/utils.go
+++ b/libwallet/assets/ltc/utils.go
@@ -3,14 +3,12 @@ package ltc
 import (
 	"encoding/binary"
 
-	"decred.org/dcrwallet/v3/walletseed"
 	sharedW "github.com/crypto-power/cryptopower/libwallet/assets/wallet"
 	"github.com/crypto-power/cryptopower/libwallet/utils"
 	"github.com/ltcsuite/ltcd/chaincfg"
 	"github.com/ltcsuite/ltcd/ltcutil"
 	"github.com/ltcsuite/ltcd/ltcutil/hdkeychain"
 	"github.com/ltcsuite/ltcwallet/waddrmgr"
-	"github.com/tyler-smith/go-bip39"
 )
 
 const (
@@ -58,12 +56,7 @@ func (asset *Asset) ToAmount(v int64) sharedW.AssetAmount {
 
 // DeriveAccountXpub derives the xpub for the given account.
 func (asset *Asset) DeriveAccountXpub(seedMnemonic string, wordSeedType sharedW.WordSeedType, account uint32, params *chaincfg.Params) (xpub string, err error) {
-	var seed []byte
-	if wordSeedType == sharedW.WordSeed33 {
-		seed, err = walletseed.DecodeUserInput(seedMnemonic)
-	} else {
-		seed, err = bip39.NewSeedWithErrorChecking(seedMnemonic, "")
-	}
+	seed, err := sharedW.DecodeSeedMnemonic(seedMnemonic, asset.Type, wordSeedType)
 	if err != nil {
 		return "", err
 	}

--- a/libwallet/assets/ltc/wallet.go
+++ b/libwallet/assets/ltc/wallet.go
@@ -253,10 +253,10 @@ func LoadExisting(w *sharedW.Wallet, params *sharedW.InitParams) (sharedW.Asset,
 		txAndBlockNotificationListeners: make(map[string]*sharedW.TxAndBlockNotificationListener),
 	}
 
-	// w.EncryptedSeed was previously deleted after verification. Existing
+	// w.EncryptedMnemonic was previously deleted after verification. Existing
 	// wallets created before the change to allow viewing wallet seed in-app
 	// should still behave normal but they can no longer view their seed.
-	if len(w.EncryptedSeed) == 0 && !w.IsBackedUp {
+	if len(w.EncryptedMnemonic) == 0 && !w.IsBackedUp {
 		w.IsBackedUp = true
 		if err := params.DB.Save(w); err != nil {
 			log.Errorf("DB.Save error: %v", err)

--- a/libwallet/assets/wallet/types.go
+++ b/libwallet/assets/wallet/types.go
@@ -428,9 +428,10 @@ type UnspentOutput struct {
 type WordSeedType int
 
 const (
-	WordSeed12 WordSeedType = 12
-	WordSeed24 WordSeedType = 24
-	WordSeed33 WordSeedType = 33
+	NoneWordSeed WordSeedType = 0
+	WordSeed12   WordSeedType = 12
+	WordSeed24   WordSeedType = 24
+	WordSeed33   WordSeedType = 33
 )
 
 func (s WordSeedType) ToInt() int {

--- a/libwallet/assets/wallet/wallet_shared.go
+++ b/libwallet/assets/wallet/wallet_shared.go
@@ -339,12 +339,12 @@ func CreateNewWallet(pass *AuthInfo, loader loader.AssetLoader,
 		return nil, errors.New("please select word seed type")
 	}
 
-	seed, err := generateSeed(assetType, pass.WordSeedType)
+	mnemonic, err := generateMnemonic(pass.WordSeedType)
 	if err != nil {
 		return nil, err
 	}
 
-	encryptedSeed, err := encryptWalletSeed([]byte(pass.PrivatePass), seed)
+	encryptedSeed, err := encryptWalletMnemonic([]byte(pass.PrivatePass), mnemonic)
 	if err != nil {
 		return nil, err
 	}
@@ -369,7 +369,7 @@ func CreateNewWallet(pass *AuthInfo, loader loader.AssetLoader,
 		if err != nil {
 			return err
 		}
-		return wallet.createWallet(pass.PrivatePass, seed, pass.WordSeedType)
+		return wallet.createWallet(pass.PrivatePass, mnemonic, pass.WordSeedType)
 	}); err != nil {
 		return nil, err
 	}
@@ -474,7 +474,7 @@ func RestoreWallet(seedMnemonic string, pass *AuthInfo, loader loader.AssetLoade
 ) (*Wallet, error) {
 	// Ensure the encrypted seeds are available before creating wallet so we can
 	// return early.
-	encryptedSeed, err := encryptWalletSeed([]byte(pass.PrivatePass), seedMnemonic)
+	encryptedSeed, err := encryptWalletMnemonic([]byte(pass.PrivatePass), seedMnemonic)
 	if err != nil {
 		log.Errorf("wallet.createWallet: error encrypting wallet seed: %v", err)
 		return nil, err
@@ -716,12 +716,12 @@ func (wallet *Wallet) ChangePrivatePassphraseForWallet(oldPrivatePassphrase, new
 	encryptedSeed := wallet.EncryptedSeed
 
 	if encryptedSeed != nil {
-		decryptedSeed, err := decryptWalletSeed(oldPassphrase, encryptedSeed)
+		decryptedSeed, err := decryptWalletMnemonic(oldPassphrase, encryptedSeed)
 		if err != nil {
 			return err
 		}
 
-		encryptedSeed, err = encryptWalletSeed(newPassphrase, decryptedSeed)
+		encryptedSeed, err = encryptWalletMnemonic(newPassphrase, decryptedSeed)
 		if err != nil {
 			return err
 		}

--- a/libwallet/assets/wallet/wallet_shared.go
+++ b/libwallet/assets/wallet/wallet_shared.go
@@ -474,7 +474,7 @@ func RestoreWallet(seedMnemonic string, pass *AuthInfo, loader loader.AssetLoade
 ) (*Wallet, error) {
 	// Ensure the encrypted seeds are available before creating wallet so we can
 	// return early.
-	EncryptedMnemonic, err := encryptWalletMnemonic([]byte(pass.PrivatePass), seedMnemonic)
+	encryptedMnemonic, err := encryptWalletMnemonic([]byte(pass.PrivatePass), seedMnemonic)
 	if err != nil {
 		log.Errorf("wallet.createWallet: error encrypting wallet seed: %v", err)
 		return nil, err
@@ -488,7 +488,7 @@ func RestoreWallet(seedMnemonic string, pass *AuthInfo, loader loader.AssetLoade
 		rootDir:               params.RootDir,
 		logDir:                params.LogDir,
 
-		EncryptedMnemonic:     EncryptedMnemonic,
+		EncryptedMnemonic:     encryptedMnemonic,
 		IsRestored:            true,
 		HasDiscoveredAccounts: false,
 		Type:                  assetType,
@@ -713,15 +713,15 @@ func (wallet *Wallet) ChangePrivatePassphraseForWallet(oldPrivatePassphrase, new
 
 	oldPassphrase := []byte(oldPrivatePassphrase)
 	newPassphrase := []byte(newPrivatePassphrase)
-	EncryptedMnemonic := wallet.EncryptedMnemonic
+	encryptedMnemonic := wallet.EncryptedMnemonic
 
-	if EncryptedMnemonic != nil {
-		decryptedSeed, err := decryptWalletMnemonic(oldPassphrase, EncryptedMnemonic)
+	if encryptedMnemonic != nil {
+		decryptedSeed, err := decryptWalletMnemonic(oldPassphrase, encryptedMnemonic)
 		if err != nil {
 			return err
 		}
 
-		EncryptedMnemonic, err = encryptWalletMnemonic(newPassphrase, decryptedSeed)
+		encryptedMnemonic, err = encryptWalletMnemonic(newPassphrase, decryptedSeed)
 		if err != nil {
 			return err
 		}
@@ -732,7 +732,7 @@ func (wallet *Wallet) ChangePrivatePassphraseForWallet(oldPrivatePassphrase, new
 		return utils.TranslateError(err)
 	}
 
-	wallet.EncryptedMnemonic = EncryptedMnemonic
+	wallet.EncryptedMnemonic = encryptedMnemonic
 	wallet.PrivatePassphraseType = privatePassphraseType
 	err = wallet.db.Save(wallet)
 	if err != nil {

--- a/libwallet/assets/wallet/wallet_utils.go
+++ b/libwallet/assets/wallet/wallet_utils.go
@@ -222,6 +222,7 @@ func VerifyMnemonic(seedMnemonic string, assetType utils.AssetType, seedType Wor
 }
 
 func DecodeSeedMnemonic(seedMnemonic string, assetType utils.AssetType, seedType WordSeedType) (hashedSeed []byte, err error) {
+	seedMnemonic = strings.TrimSpace(seedMnemonic)
 	switch assetType {
 	case utils.BTCWalletAsset, utils.DCRWalletAsset, utils.LTCWalletAsset:
 		words := strings.Split(strings.TrimSpace(seedMnemonic), " ")
@@ -237,12 +238,13 @@ func DecodeSeedMnemonic(seedMnemonic string, assetType utils.AssetType, seedType
 				return nil, err
 			}
 		}
-
 		// seedMnemonic is list of words
 		if seedType == WordSeed33 {
 			hashedSeed, err = walletseed.DecodeUserInput(seedMnemonic)
 		} else {
+			fmt.Println("-------DecodeSeedMnemonic-----22222--->", seedMnemonic)
 			hashedSeed, err = bip39.NewSeedWithErrorChecking(seedMnemonic, "")
+			fmt.Println("------DecodeSeedMnemonic--22222--->", err)
 		}
 	default:
 		err = fmt.Errorf("%v: (%v)", utils.ErrAssetUnknown, assetType)

--- a/libwallet/assets/wallet/wallet_utils.go
+++ b/libwallet/assets/wallet/wallet_utils.go
@@ -117,27 +117,27 @@ func (wallet *Wallet) batchDbTransaction(dbOp func(node storm.Node) error) (err 
 	return err
 }
 
-// DecryptSeed decrypts wallet.EncryptedSeed using privatePassphrase
+// DecryptSeed decrypts wallet.EncryptedMnemonic using privatePassphrase
 func (wallet *Wallet) DecryptSeed(privatePassphrase string) (string, error) {
-	if wallet.EncryptedSeed == nil {
+	if wallet.EncryptedMnemonic == nil {
 		return "", errors.New(utils.ErrNoSeed)
 	}
 
-	return decryptWalletMnemonic([]byte(privatePassphrase), wallet.EncryptedSeed)
+	return decryptWalletMnemonic([]byte(privatePassphrase), wallet.EncryptedMnemonic)
 }
 
 // VerifySeedForWallet compares seedMnemonic with the decrypted
-// wallet.EncryptedSeed.
+// wallet.EncryptedMnemonic.
 func (wallet *Wallet) VerifySeedForWallet(seedMnemonic, privpass string) (bool, error) {
 	wallet.mu.RLock()
 	defer wallet.mu.RUnlock()
 
-	decryptedSeed, err := decryptWalletMnemonic([]byte(privpass), wallet.EncryptedSeed)
+	decryptedMnemonic, err := decryptWalletMnemonic([]byte(privpass), wallet.EncryptedMnemonic)
 	if err != nil {
 		return false, err
 	}
 
-	if decryptedSeed == seedMnemonic {
+	if decryptedMnemonic == seedMnemonic {
 		if wallet.IsBackedUp {
 			return true, nil // return early
 		}
@@ -176,12 +176,12 @@ func decryptWalletMnemonic(pass []byte, encryptedMnemonic []byte) (string, error
 		return "", err
 	}
 
-	decryptedSeed, err := secretbox.EasyOpen(encryptedMnemonic, key)
+	decryptedMnemonic, err := secretbox.EasyOpen(encryptedMnemonic, key)
 	if err != nil {
 		return "", errors.New(utils.ErrInvalidPassphrase)
 	}
 
-	return string(decryptedSeed), nil
+	return string(decryptedMnemonic), nil
 }
 
 // For use with gomobile bind,
@@ -204,13 +204,13 @@ func generateMnemonic(wordSeedType WordSeedType) (v string, err error) {
 			// Generate 33-word seeds from PGWord list
 			return walletseed.EncodeMnemonic(entropy), nil
 		}
-		// Create Seed phrase from entropy
-		// Use bip39 for generate 12-word seeds and 24-word seeds
-		seedPhrase, err := bip39.NewMnemonic(entropy)
+		// Create mnemonic from entropy
+		// Use bip39 to generate 12-word seeds and 24-word seeds
+		mnemonic, err := bip39.NewMnemonic(entropy)
 		if err != nil {
 			return "", err
 		}
-		return seedPhrase, nil
+		return mnemonic, nil
 	}
 
 	return "", fmt.Errorf("entropy is empty")

--- a/libwallet/assets/wallet/wallet_utils.go
+++ b/libwallet/assets/wallet/wallet_utils.go
@@ -242,9 +242,7 @@ func DecodeSeedMnemonic(seedMnemonic string, assetType utils.AssetType, seedType
 		if seedType == WordSeed33 {
 			hashedSeed, err = walletseed.DecodeUserInput(seedMnemonic)
 		} else {
-			fmt.Println("-------DecodeSeedMnemonic-----22222--->", seedMnemonic)
 			hashedSeed, err = bip39.NewSeedWithErrorChecking(seedMnemonic, "")
-			fmt.Println("------DecodeSeedMnemonic--22222--->", err)
 		}
 	default:
 		err = fmt.Errorf("%v: (%v)", utils.ErrAssetUnknown, assetType)

--- a/libwallet/assets/wallet/wallet_utils.go
+++ b/libwallet/assets/wallet/wallet_utils.go
@@ -188,12 +188,15 @@ func decryptWalletMnemonic(pass []byte, encryptedMnemonic []byte) (string, error
 // doesn't support the alternative `GenerateSeed` function because it returns more than 2 types.
 func generateMnemonic(wordSeedType WordSeedType) (v string, err error) {
 	var entropy []byte
-	//33-word seeds and 24-word seeds both use length 32 (256 bits) while 12-word seed uses length 16 (128 bits).
+	// 33-word seeds and 24-word seeds both use length 32 (256 bits) while 12-word seed uses length 16 (128 bits).
 	var length uint8 = dcrhdkeychain.RecommendedSeedLen
 	if wordSeedType == WordSeed12 {
 		length = dcrhdkeychain.MinSeedBytes
 	}
 
+	// The same HD key generation function is used for all assets,
+	// because the HD key chain for each asset has the same
+	// underlying structure (BTC, LTC & DCR).
 	entropy, err = btchdkeychain.GenerateSeed(length)
 	if err != nil {
 		return "", err

--- a/libwallet/assets/wallet/wallet_utils.go
+++ b/libwallet/assets/wallet/wallet_utils.go
@@ -18,7 +18,6 @@ import (
 	dcrhdkeychain "github.com/decred/dcrd/hdkeychain/v3"
 	"github.com/kevinburke/nacl"
 	"github.com/kevinburke/nacl/secretbox"
-	ltchdkeychain "github.com/ltcsuite/ltcd/ltcutil/hdkeychain"
 	"github.com/tyler-smith/go-bip39"
 	"golang.org/x/crypto/scrypt"
 )
@@ -124,7 +123,7 @@ func (wallet *Wallet) DecryptSeed(privatePassphrase string) (string, error) {
 		return "", errors.New(utils.ErrNoSeed)
 	}
 
-	return decryptWalletSeed([]byte(privatePassphrase), wallet.EncryptedSeed)
+	return decryptWalletMnemonic([]byte(privatePassphrase), wallet.EncryptedSeed)
 }
 
 // VerifySeedForWallet compares seedMnemonic with the decrypted
@@ -133,7 +132,7 @@ func (wallet *Wallet) VerifySeedForWallet(seedMnemonic, privpass string) (bool, 
 	wallet.mu.RLock()
 	defer wallet.mu.RUnlock()
 
-	decryptedSeed, err := decryptWalletSeed([]byte(privpass), wallet.EncryptedSeed)
+	decryptedSeed, err := decryptWalletMnemonic([]byte(privpass), wallet.EncryptedSeed)
 	if err != nil {
 		return false, err
 	}
@@ -161,23 +160,23 @@ func naclLoadFromPass(pass []byte) (nacl.Key, error) {
 	return nacl.Load(utils.EncodeHex(hash))
 }
 
-// encryptWalletSeed encrypts the seed with secretbox.EasySeal using pass.
-func encryptWalletSeed(pass []byte, seed string) ([]byte, error) {
+// encryptWalletMnemonic encrypts the mnemonic with secretbox.EasySeal using pass.
+func encryptWalletMnemonic(pass []byte, mnemonic string) ([]byte, error) {
 	key, err := naclLoadFromPass(pass)
 	if err != nil {
 		return nil, err
 	}
-	return secretbox.EasySeal([]byte(seed), key), nil
+	return secretbox.EasySeal([]byte(mnemonic), key), nil
 }
 
-// decryptWalletSeed decrypts the encryptedSeed with secretbox.EasyOpen using pass.
-func decryptWalletSeed(pass []byte, encryptedSeed []byte) (string, error) {
+// decryptWalletMnemonic decrypts the encryptedMnemonic with secretbox.EasyOpen using pass.
+func decryptWalletMnemonic(pass []byte, encryptedMnemonic []byte) (string, error) {
 	key, err := naclLoadFromPass(pass)
 	if err != nil {
 		return "", err
 	}
 
-	decryptedSeed, err := secretbox.EasyOpen(encryptedSeed, key)
+	decryptedSeed, err := secretbox.EasyOpen(encryptedMnemonic, key)
 	if err != nil {
 		return "", errors.New(utils.ErrInvalidPassphrase)
 	}
@@ -187,37 +186,26 @@ func decryptWalletSeed(pass []byte, encryptedSeed []byte) (string, error) {
 
 // For use with gomobile bind,
 // doesn't support the alternative `GenerateSeed` function because it returns more than 2 types.
-func generateSeed(assetType utils.AssetType, wordSeedType WordSeedType) (v string, err error) {
+func generateMnemonic(wordSeedType WordSeedType) (v string, err error) {
 	var entropy []byte
 	//33-word seeds and 24-word seeds both use length 32 (256 bits) while 12-word seed uses length 16 (128 bits).
 	var length uint8 = dcrhdkeychain.RecommendedSeedLen
 	if wordSeedType == WordSeed12 {
 		length = dcrhdkeychain.MinSeedBytes
 	}
-	switch assetType {
-	case utils.BTCWalletAsset:
-		entropy, err = btchdkeychain.GenerateSeed(length)
-		if err != nil {
-			return "", err
-		}
-	case utils.DCRWalletAsset:
-		entropy, err = dcrhdkeychain.GenerateSeed(length)
-		if err != nil {
-			return "", err
-		}
-	case utils.LTCWalletAsset:
-		entropy, err = ltchdkeychain.GenerateSeed(length)
-		if err != nil {
-			return "", err
-		}
+
+	entropy, err = btchdkeychain.GenerateSeed(length)
+	if err != nil {
+		return "", err
 	}
 
 	if len(entropy) > 0 {
 		if wordSeedType == WordSeed33 {
+			// Generate 33-word seeds from PGWord list
 			return walletseed.EncodeMnemonic(entropy), nil
 		}
 		// Create Seed phrase from entropy
-		// Use bip39 for 12-word seeds and 24-word seeds
+		// Use bip39 for generate 12-word seeds and 24-word seeds
 		seedPhrase, err := bip39.NewMnemonic(entropy)
 		if err != nil {
 			return "", err
@@ -225,13 +213,10 @@ func generateSeed(assetType utils.AssetType, wordSeedType WordSeedType) (v strin
 		return seedPhrase, nil
 	}
 
-	// Execution should never get here but error added as a safeguard to
-	// ensure any new asset added must add its own custom way to generate wallet
-	// seed added above, if need be.
-	return "", fmt.Errorf("%v: (%v)", utils.ErrAssetUnknown, assetType)
+	return "", fmt.Errorf("entropy is empty")
 }
 
-func VerifySeed(seedMnemonic string, assetType utils.AssetType, seedType WordSeedType) bool {
+func VerifyMnemonic(seedMnemonic string, assetType utils.AssetType, seedType WordSeedType) bool {
 	_, err := DecodeSeedMnemonic(seedMnemonic, assetType, seedType)
 	return err == nil
 }
@@ -240,13 +225,24 @@ func DecodeSeedMnemonic(seedMnemonic string, assetType utils.AssetType, seedType
 	switch assetType {
 	case utils.BTCWalletAsset, utils.DCRWalletAsset, utils.LTCWalletAsset:
 		words := strings.Split(strings.TrimSpace(seedMnemonic), " ")
+		var entropy []byte
+		// seedMnemonic is hex string
 		if len(words) == 1 {
-			return hex.DecodeString(words[0])
+			entropy, err = hex.DecodeString(words[0])
+			if seedType == WordSeed33 {
+				return entropy, err
+			}
+			seedMnemonic, err = bip39.NewMnemonic(entropy)
+			if err != nil {
+				return nil, err
+			}
 		}
+
+		// seedMnemonic is list of words
 		if seedType == WordSeed33 {
 			hashedSeed, err = walletseed.DecodeUserInput(seedMnemonic)
 		} else {
-			hashedSeed, err = bip39.EntropyFromMnemonic(seedMnemonic)
+			hashedSeed, err = bip39.NewSeedWithErrorChecking(seedMnemonic, "")
 		}
 	default:
 		err = fmt.Errorf("%v: (%v)", utils.ErrAssetUnknown, assetType)

--- a/libwallet/dcr.go
+++ b/libwallet/dcr.go
@@ -158,7 +158,7 @@ func deriveBIP44AccountXPubsForDCR(seedMnemonic string, wordSeedType sharedW.Wor
 	if wordSeedType == sharedW.WordSeed33 {
 		seed, err = walletseed.DecodeUserInput(seedMnemonic)
 	} else {
-		seed, err = bip39.EntropyFromMnemonic(seedMnemonic)
+		seed, err = bip39.NewSeedWithErrorChecking(seedMnemonic, "")
 	}
 	if err != nil {
 		return "", "", err

--- a/libwallet/dcr.go
+++ b/libwallet/dcr.go
@@ -2,6 +2,7 @@ package libwallet
 
 import (
 	"context"
+	"fmt"
 
 	"decred.org/dcrwallet/v3/errors"
 	"decred.org/dcrwallet/v3/walletseed"
@@ -155,10 +156,13 @@ func (mgr *AssetsManager) DCRWalletWithSeed(seedMnemonic string, wordSeedType sh
 func deriveBIP44AccountXPubsForDCR(seedMnemonic string, wordSeedType sharedW.WordSeedType, account uint32, params *chaincfg.Params) (string, string, error) {
 	var seed []byte
 	var err error
+	fmt.Println("-------deriveBIP44AccountXPubsForDCR-----wordSeedType--->", wordSeedType)
 	if wordSeedType == sharedW.WordSeed33 {
 		seed, err = walletseed.DecodeUserInput(seedMnemonic)
 	} else {
+		fmt.Println("-------deriveBIP44AccountXPubsForDCR-----seed--->", seedMnemonic)
 		seed, err = bip39.NewSeedWithErrorChecking(seedMnemonic, "")
+		fmt.Println("-------deriveBIP44AccountXPubsForDCR-----err--->", err)
 	}
 	if err != nil {
 		return "", "", err

--- a/libwallet/dcr.go
+++ b/libwallet/dcr.go
@@ -4,11 +4,9 @@ import (
 	"context"
 
 	"decred.org/dcrwallet/v3/errors"
-	"decred.org/dcrwallet/v3/walletseed"
 
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/hdkeychain/v3"
-	"github.com/tyler-smith/go-bip39"
 
 	"github.com/crypto-power/cryptopower/libwallet/assets/dcr"
 	sharedW "github.com/crypto-power/cryptopower/libwallet/assets/wallet"
@@ -153,13 +151,7 @@ func (mgr *AssetsManager) DCRWalletWithSeed(seedMnemonic string, wordSeedType sh
 // deriveBIP44AccountXPubForDCR derives and returns the legacy and SLIP0044 account
 // xpubs using the BIP44 HD path for accounts: m/44'/<coin type>'/<account>'.
 func deriveBIP44AccountXPubsForDCR(seedMnemonic string, wordSeedType sharedW.WordSeedType, account uint32, params *chaincfg.Params) (string, string, error) {
-	var seed []byte
-	var err error
-	if wordSeedType == sharedW.WordSeed33 {
-		seed, err = walletseed.DecodeUserInput(seedMnemonic)
-	} else {
-		seed, err = bip39.NewSeedWithErrorChecking(seedMnemonic, "")
-	}
+	seed, err := sharedW.DecodeSeedMnemonic(seedMnemonic, utils.DCRWalletAsset, wordSeedType)
 	if err != nil {
 		return "", "", err
 	}

--- a/libwallet/dcr.go
+++ b/libwallet/dcr.go
@@ -2,7 +2,6 @@ package libwallet
 
 import (
 	"context"
-	"fmt"
 
 	"decred.org/dcrwallet/v3/errors"
 	"decred.org/dcrwallet/v3/walletseed"
@@ -156,13 +155,10 @@ func (mgr *AssetsManager) DCRWalletWithSeed(seedMnemonic string, wordSeedType sh
 func deriveBIP44AccountXPubsForDCR(seedMnemonic string, wordSeedType sharedW.WordSeedType, account uint32, params *chaincfg.Params) (string, string, error) {
 	var seed []byte
 	var err error
-	fmt.Println("-------deriveBIP44AccountXPubsForDCR-----wordSeedType--->", wordSeedType)
 	if wordSeedType == sharedW.WordSeed33 {
 		seed, err = walletseed.DecodeUserInput(seedMnemonic)
 	} else {
-		fmt.Println("-------deriveBIP44AccountXPubsForDCR-----seed--->", seedMnemonic)
 		seed, err = bip39.NewSeedWithErrorChecking(seedMnemonic, "")
-		fmt.Println("-------deriveBIP44AccountXPubsForDCR-----err--->", err)
 	}
 	if err != nil {
 		return "", "", err

--- a/ui/page/components/restore_page.go
+++ b/ui/page/components/restore_page.go
@@ -372,19 +372,14 @@ func (pg *Restore) restoreFromSeedEditor() {
 }
 
 func getWordSeedTypeFromSeed(slideWords []string) (sharedW.WordSeedType, error) {
-	wordsLen := len(slideWords)
-	if wordsLen == 12 || wordsLen == 24 || wordsLen == 33 {
-		switch wordsLen {
-		case 12:
-			return sharedW.WordSeed12, nil
-		case 24:
-			return sharedW.WordSeed24, nil
-		case 33:
-			return sharedW.WordSeed33, nil
-		default:
-			return sharedW.NoneWordSeed, nil
-		}
+	switch len(slideWords) {
+	case 12:
+		return sharedW.WordSeed12, nil
+	case 24:
+		return sharedW.WordSeed24, nil
+	case 33:
+		return sharedW.WordSeed33, nil
+	default:
+		return sharedW.NoneWordSeed, fmt.Errorf("invalid word seed")
 	}
-
-	return sharedW.NoneWordSeed, fmt.Errorf("invalid word seed")
 }

--- a/ui/page/components/restore_page.go
+++ b/ui/page/components/restore_page.go
@@ -298,6 +298,7 @@ func (pg *Restore) restoreFromSeedEditor() {
 	slideWords := strings.Split(seedOrHex, " ")
 	wordSeedType := pg.getWordSeedType()
 	var err error
+
 	// Get Word seed type from string seedOrHex when user paste Seed words
 	if len(slideWords) > 1 {
 		wordSeedType, err = getWordSeedTypeFromSeed(slideWords)
@@ -346,7 +347,7 @@ func (pg *Restore) restoreFromSeedEditor() {
 		ShowWalletInfoTip(true).
 		SetParent(pg).
 		SetPositiveButtonCallback(func(walletName, password string, m *modal.CreatePasswordModal) bool {
-			_, err := pg.AssetsManager.RestoreWallet(pg.walletType, pg.walletName, seedOrHex, password, sharedW.PassphraseTypePass, pg.getWordSeedType())
+			_, err := pg.AssetsManager.RestoreWallet(pg.walletType, pg.walletName, seedOrHex, password, sharedW.PassphraseTypePass, wordSeedType)
 			if err != nil {
 				errString := err.Error()
 				if err.Error() == libutils.ErrExist {

--- a/ui/page/components/restore_page.go
+++ b/ui/page/components/restore_page.go
@@ -288,8 +288,6 @@ func (pg *Restore) restoreFromSeedEditor() {
 		pg.seedInputEditor.Editor.SetText("")
 	}
 
-	fmt.Println("--restoreFromSeedEditor--------------->")
-
 	seedOrHex := strings.TrimSpace(pg.seedInputEditor.Editor.Text())
 	// Check if the user did input a hex or seed. If its a hex set the correct tabindex.
 	if len(seedOrHex) > MaxSeedBytes {
@@ -312,7 +310,6 @@ func (pg *Restore) restoreFromSeedEditor() {
 	}
 
 	if !sharedW.VerifyMnemonic(seedOrHex, pg.walletType, wordSeedType) {
-		fmt.Println("--sharedW.VerifyMnemonic----->", seedOrHex)
 		errMsg := values.String(values.StrInvalidHex)
 		if pg.tabIndex == 0 {
 			errMsg = values.String(values.StrInvalidSeedPhrase)
@@ -323,10 +320,7 @@ func (pg *Restore) restoreFromSeedEditor() {
 		return
 	}
 
-	fmt.Println("--aaaaaaaaaaaaaaaaaaaa----->")
-
 	walletWithSameSeed, err := pg.AssetsManager.WalletWithSeed(pg.walletType, seedOrHex, wordSeedType)
-	fmt.Println("---errerrerrerrerr----->", err)
 	if err != nil {
 		log.Error(err)
 		errMsg := values.String(values.StrInvalidHex)

--- a/ui/page/components/restore_page.go
+++ b/ui/page/components/restore_page.go
@@ -288,6 +288,8 @@ func (pg *Restore) restoreFromSeedEditor() {
 		pg.seedInputEditor.Editor.SetText("")
 	}
 
+	fmt.Println("--restoreFromSeedEditor--------------->")
+
 	seedOrHex := strings.TrimSpace(pg.seedInputEditor.Editor.Text())
 	// Check if the user did input a hex or seed. If its a hex set the correct tabindex.
 	if len(seedOrHex) > MaxSeedBytes {
@@ -310,6 +312,7 @@ func (pg *Restore) restoreFromSeedEditor() {
 	}
 
 	if !sharedW.VerifyMnemonic(seedOrHex, pg.walletType, wordSeedType) {
+		fmt.Println("--sharedW.VerifyMnemonic----->", seedOrHex)
 		errMsg := values.String(values.StrInvalidHex)
 		if pg.tabIndex == 0 {
 			errMsg = values.String(values.StrInvalidSeedPhrase)
@@ -320,7 +323,10 @@ func (pg *Restore) restoreFromSeedEditor() {
 		return
 	}
 
-	walletWithSameSeed, err := pg.AssetsManager.WalletWithSeed(pg.walletType, seedOrHex, pg.getWordSeedType())
+	fmt.Println("--aaaaaaaaaaaaaaaaaaaa----->")
+
+	walletWithSameSeed, err := pg.AssetsManager.WalletWithSeed(pg.walletType, seedOrHex, wordSeedType)
+	fmt.Println("---errerrerrerrerr----->", err)
 	if err != nil {
 		log.Error(err)
 		errMsg := values.String(values.StrInvalidHex)

--- a/ui/page/components/seed_restore_page.go
+++ b/ui/page/components/seed_restore_page.go
@@ -546,7 +546,7 @@ func (pg *SeedRestore) HandleUserInteractions() {
 				pg.window.ShowModal(infoModal)
 				pg.resetSeeds()
 				m.Dismiss()
-				pg.ParentNavigator().CloseCurrentPage()
+				pg.window.CloseCurrentPage()
 				if pg.restoreComplete != nil {
 					pg.restoreComplete()
 				}

--- a/ui/page/components/seed_restore_page.go
+++ b/ui/page/components/seed_restore_page.go
@@ -448,7 +448,7 @@ func (pg *SeedRestore) verifySeeds() bool {
 
 	if isValid {
 		pg.seedPhrase = seedphrase
-		if !sharedW.VerifySeed(pg.seedPhrase, pg.walletType, pg.getWordSeedType()) {
+		if !sharedW.VerifyMnemonic(pg.seedPhrase, pg.walletType, pg.getWordSeedType()) {
 			errModal := modal.NewErrorModal(pg.Load, values.String(values.StrInvalidSeedPhrase), modal.DefaultClickFunc())
 			pg.window.ShowModal(errModal)
 			return false

--- a/ui/page/components/seed_restore_page.go
+++ b/ui/page/components/seed_restore_page.go
@@ -54,9 +54,9 @@ type SeedRestore struct {
 	optionsMenuCard cryptomaterial.Card
 	window          app.WindowNavigator
 
-	suggestions    []string
-	allSuggestions []string
-	seedMenu       []seedItemMenu
+	suggestions []string
+	// allSuggestions []string
+	seedMenu []seedItemMenu
 
 	seedPhrase string
 	walletName string
@@ -110,7 +110,7 @@ func NewSeedRestorePage(l *load.Load, walletName string, walletType libutils.Ass
 	pg.initSeedMenu()
 
 	// set suggestions
-	pg.allSuggestions = getWordSeedType().AllWords()
+	// pg.allSuggestions = getWordSeedType().AllWords()
 
 	return pg
 }
@@ -407,7 +407,7 @@ func (pg SeedRestore) suggestionSeeds(text string) []string {
 		return seeds
 	}
 
-	for _, word := range pg.allSuggestions {
+	for _, word := range pg.getWordSeedType().AllWords() {
 		if strings.HasPrefix(strings.ToLower(word), strings.ToLower(text)) {
 			if len(seeds) < pg.suggestionLimit {
 				seeds = append(seeds, word)
@@ -426,7 +426,7 @@ func (pg *SeedRestore) updateSeedResetBtn() bool {
 
 func (pg *SeedRestore) validateSeeds() (bool, string) {
 	seedPhrase := ""
-	allSuggestedWords := strings.Join(pg.allSuggestions, " ")
+	allSuggestedWords := strings.Join(pg.getWordSeedType().AllWords(), " ")
 	numberOfSeed := pg.getWordSeedType().ToInt()
 	for i, editor := range pg.seedEditors.editors {
 		if i >= numberOfSeed {
@@ -443,6 +443,7 @@ func (pg *SeedRestore) validateSeeds() (bool, string) {
 }
 
 func (pg *SeedRestore) verifySeeds() bool {
+	fmt.Println("------verifySeeds----------22222222--->")
 	isValid, seedphrase := pg.validateSeeds()
 	pg.seedPhrase = ""
 
@@ -473,7 +474,7 @@ func (pg *SeedRestore) verifySeeds() bool {
 }
 
 func (pg *SeedRestore) resetSeeds() {
-	pg.allSuggestions = pg.getWordSeedType().AllWords()
+	// pg.allSuggestions = pg.getWordSeedType().AllWords()
 	pg.seedEditors.focusIndex = -1
 	for i := 0; i < len(pg.seedEditors.editors); i++ {
 		pg.seedEditors.editors[i].Edit.Editor.SetText("")
@@ -520,6 +521,7 @@ func (pg *SeedRestore) HandleUserInteractions() {
 	}
 
 	if pg.validateSeed.Clicked() {
+		fmt.Println("------validateSeed----------111111--->")
 		if !pg.verifySeeds() {
 			return
 		}

--- a/ui/page/components/seed_restore_page.go
+++ b/ui/page/components/seed_restore_page.go
@@ -109,9 +109,6 @@ func NewSeedRestorePage(l *load.Load, walletName string, walletType libutils.Ass
 	// init suggestion buttons
 	pg.initSeedMenu()
 
-	// set suggestions
-	// pg.allSuggestions = getWordSeedType().AllWords()
-
 	return pg
 }
 
@@ -473,7 +470,6 @@ func (pg *SeedRestore) verifySeeds() bool {
 }
 
 func (pg *SeedRestore) resetSeeds() {
-	// pg.allSuggestions = pg.getWordSeedType().AllWords()
 	pg.seedEditors.focusIndex = -1
 	for i := 0; i < len(pg.seedEditors.editors); i++ {
 		pg.seedEditors.editors[i].Edit.Editor.SetText("")

--- a/ui/page/components/seed_restore_page.go
+++ b/ui/page/components/seed_restore_page.go
@@ -439,14 +439,13 @@ func (pg *SeedRestore) validateSeeds() (bool, string) {
 
 		seedPhrase += editor.Edit.Editor.Text() + " "
 	}
+
+	seedPhrase = strings.TrimSpace(seedPhrase)
 	return true, seedPhrase
 }
 
 func (pg *SeedRestore) verifySeeds() bool {
-	fmt.Println("------verifySeeds----------22222222--->")
 	isValid, seedphrase := pg.validateSeeds()
-	pg.seedPhrase = ""
-
 	if isValid {
 		pg.seedPhrase = seedphrase
 		if !sharedW.VerifyMnemonic(pg.seedPhrase, pg.walletType, pg.getWordSeedType()) {
@@ -521,7 +520,6 @@ func (pg *SeedRestore) HandleUserInteractions() {
 	}
 
 	if pg.validateSeed.Clicked() {
-		fmt.Println("------validateSeed----------111111--->")
 		if !pg.verifySeeds() {
 			return
 		}

--- a/ui/page/components/utils.go
+++ b/ui/page/components/utils.go
@@ -64,30 +64,31 @@ func RetryFunc(retryAttempts int, sleepDur time.Duration, funcDesc string, errFu
 	return retryAttempts, fmt.Errorf("last error: %s", err)
 }
 
+// SeedWordsToHex will convert seedWords from list of words to hex string
 func SeedWordsToHex(seedWords string, wordSeedType sharedW.WordSeedType) (string, error) {
 	var seedHex string
-	var seedByte []byte
+	var entropy []byte
 	var err error
 	if wordSeedType == sharedW.WordSeed33 {
 		words := strings.Split(strings.TrimSpace(seedWords), " ")
-		seedByte, err = pgpwordlist.DecodeMnemonics(words)
-		if checksumByte(seedByte[:len(seedByte)-1]) != seedByte[len(seedByte)-1] {
+		entropy, err = pgpwordlist.DecodeMnemonics(words)
+		if checksumByte(entropy[:len(entropy)-1]) != entropy[len(entropy)-1] {
 			return seedHex, fmt.Errorf("seed checksum mismatch")
 		}
-		seedByte = seedByte[:len(seedByte)-1]
+		entropy = entropy[:len(entropy)-1]
 
-		if len(seedByte) < MinSeedBytes || len(seedByte) > MaxSeedBytes {
+		if len(entropy) < MinSeedBytes || len(entropy) > MaxSeedBytes {
 			return seedHex, fmt.Errorf("invalid seed bytes length")
 		}
 	} else {
-		seedByte, err = bip39.EntropyFromMnemonic(seedWords)
+		entropy, err = bip39.EntropyFromMnemonic(seedWords)
 	}
 
 	if err != nil {
 		return "", err
 	}
 
-	seedHex = hex.EncodeToString(seedByte)
+	seedHex = hex.EncodeToString(entropy)
 	return seedHex, nil
 }
 

--- a/ui/page/components/wallet_setup_page.go
+++ b/ui/page/components/wallet_setup_page.go
@@ -123,7 +123,7 @@ func NewCreateWallet(l *load.Load, walletCreationSuccessCallback func(), assetTy
 	pg.materialLoader = material.Loader(l.Theme.Base)
 
 	defaultWordSeedType := &cryptomaterial.DropDownItem{
-		Text: values.String(values.Str33WordSeed),
+		Text: values.String(values.Str12WordSeed),
 	}
 
 	pg.seedTypeDropdown = pg.Theme.DropDown(GetWordSeedTypeDropdownItems(), defaultWordSeedType, values.TxDropdownGroup, false)


### PR DESCRIPTION
Close #518 

This PR support 12 and 24 word seed from other wallet, update logic when restore wallet and create wallet

**Screenshot**

![seed2](https://github.com/crypto-power/cryptopower/assets/19331824/79bd7bd4-243b-4548-9c67-d8ba431bf6d3)

The input hex need the dropdown because we need to know the entropy use BIP32 or BIP39
![seed1](https://github.com/crypto-power/cryptopower/assets/19331824/36476b9f-b503-4d67-8407-07203a8b5440)
