### PR TITLE
Transactions and governance tab is not came back correctly

### DIFF
--- a/ui/page/root/home_page.go
+++ b/ui/page/root/home_page.go
@@ -366,8 +366,11 @@ func (hp *HomePage) HandleUserInteractions() {
 		hp.navigationTab.SetSelectedTab(values.String(values.StrWallets))
 	} else if hp.CurrentPageID() == exchange.TradePageID && hp.navigationTab.SelectedTab() != values.String(values.StrTrade) {
 		hp.navigationTab.SetSelectedTab(values.String(values.StrTrade))
+	} else if hp.CurrentPageID() == transaction.TransactionsPageID && hp.navigationTab.SelectedTab() != values.String(values.StrTransactions) {
+		hp.navigationTab.SetSelectedTab(values.String(values.StrTransactions))
+	} else if hp.CurrentPageID() == governance.GovernancePageID && hp.navigationTab.SelectedTab() != values.String(values.StrGovernance) {
+		hp.navigationTab.SetSelectedTab(values.String(values.StrGovernance))
 	}
-
 	for i, item := range hp.sendReceiveNavItems {
 		for item.Clickable.Clicked() {
 			switch strings.ToLower(item.PageID) {


### PR DESCRIPTION
Close #533 
This PR fixes the error that when returning to the home page, the Transactions/Governance tab was not activated correctly
**Screenshot**
![003](https://github.com/crypto-power/cryptopower/assets/89973752/0792ae88-4fa0-4ae9-aa7a-0117cea48cb6)
![002](https://github.com/crypto-power/cryptopower/assets/89973752/5bde810d-2133-4562-bb54-eca55a474ab6)
![001](https://github.com/crypto-power/cryptopower/assets/89973752/6ca329b2-82f4-4635-863e-3b713466c28d)
