### PR TITLE
Update golangci-lint to v1.59.1 and disable pkg caching

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install linter
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.58
+          version: v1.59.1
           skip-pkg-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           version: v1.59.1
           skip-pkg-cache: true
-          args: --out-format=colored-line-number
+          args: --out-format=colored-line-number --timeout=10m
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,9 +33,10 @@ jobs:
             ${{ runner.os }}-go-
       
       - name: Install linter
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.54
+          version: v1.58
+          skip-pkg-cache: true
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           version: v1.59.1
           skip-pkg-cache: true
+          args: --out-format=colored-line-number
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,9 @@ linters:
 
 linters-settings:
   errcheck:
+    # Individual function to be ignored one per line.
+    # see https://github.com/kisielk/errcheck#excluding-functions for details
     exclude-functions:
       - (net/http.ResponseWriter).Write
-      - (github.com/jrick/logrotate/rotator.Rotator).Write
-      - (github.com/crypto-power/cryptopower/logger).SetLogLevels
+      - (*github.com/jrick/logrotate/rotator.Rotator).Write
+      - ./logger.SetLogLevels

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,4 +29,3 @@ linters-settings:
     exclude-functions:
       - (net/http.ResponseWriter).Write
       - (*github.com/jrick/logrotate/rotator.Rotator).Write
-      - ./logger.SetLogLevels

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,13 @@
 run:
   deadline: 10m
-  skip-dirs:
+
+issues:
+  exclude-dirs:
     # foreign languages give false positives for misspell
     - ui/values/localizable
 
 output:
-  format: github-actions,colored-line-number
+  formats: github-actions,colored-line-number
 
 linters:
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,3 +26,5 @@ linters-settings:
   errcheck:
     exclude-functions:
       - (net/http.ResponseWriter).Write
+      - (github.com/jrick/logrotate/rotator.Rotator).Write
+      - (github.com/crypto-power/cryptopower/logger).SetLogLevels

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,3 +20,9 @@ linters:
     - revive
     - goimports
     - unparam
+    - errcheck
+
+linters-settings:
+  errcheck:
+    exclude-functions:
+      - (net/http.ResponseWriter).Write

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/dgraph-io/badger v1.6.2
 	github.com/gen2brain/beeep v0.0.0-20220402123239-6a3042f4b71a
 	github.com/gomarkdown/markdown v0.0.0-20230922105210-14b16010c2ee
-	github.com/gorilla/websocket v1.5.0
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/jrick/logrotate v1.0.0
 	github.com/kevinburke/nacl v0.0.0-20190829012316-f3ed23dbd7f8
@@ -149,6 +148,7 @@ require (
 	github.com/google/trillian v1.4.1 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/schema v1.1.0 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/h2non/go-is-svg v0.0.0-20160927212452-35e8c4b0612c // indirect
 	github.com/hashicorp/go-bexpr v0.1.10 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect

--- a/libwallet/assets/btc/sync.go
+++ b/libwallet/assets/btc/sync.go
@@ -280,7 +280,7 @@ func (asset *Asset) rescanFinished(height int32) {
 		// Update the assets birthday from genesis block to a date closer
 		// to when the privatekey was first used.
 		asset.updateAssetBirthday()
-		asset.MarkWalletAsDiscoveredAccounts()
+		_ = asset.MarkWalletAsDiscoveredAccounts()
 	}
 
 	asset.syncData.mu.Lock()
@@ -592,7 +592,7 @@ func (asset *Asset) reloadChainService() error {
 		asset.CancelSync()
 	}
 
-	asset.chainClient.CS.Stop()
+	_ = asset.chainClient.CS.Stop()
 	chainService, err := asset.loadChainService()
 	if err != nil {
 		return err

--- a/libwallet/assets/dcr/account_mixer.go
+++ b/libwallet/assets/dcr/account_mixer.go
@@ -228,7 +228,7 @@ func (asset *Asset) readCSPPConfig() *CSPPConfig {
 		csppTLSConfig.RootCAs = pool
 
 		dailer := new(net.Dialer)
-		dialCSPPServer = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		dialCSPPServer = func(_ context.Context, network, addr string) (net.Conn, error) {
 			conn, err := dailer.DialContext(context.Background(), network, addr)
 			if err != nil {
 				return nil, err

--- a/libwallet/assets/dcr/sync.go
+++ b/libwallet/assets/dcr/sync.go
@@ -229,12 +229,12 @@ func (asset *Asset) SyncInactiveForPeriod(totalInactiveSeconds int64) {
 
 func (asset *Asset) SetSpecificPeer(addresses string) {
 	asset.SaveUserConfigValue(sharedW.SpvPersistentPeerAddressesConfigKey, addresses)
-	asset.RestartSpvSync()
+	_ = asset.RestartSpvSync()
 }
 
 func (asset *Asset) RemovePeers() {
 	asset.SaveUserConfigValue(sharedW.SpvPersistentPeerAddressesConfigKey, "")
-	asset.RestartSpvSync()
+	_ = asset.RestartSpvSync()
 }
 
 func (asset *Asset) SpvSync() error {

--- a/libwallet/assets/dcr/syncnotification.go
+++ b/libwallet/assets/dcr/syncnotification.go
@@ -10,10 +10,10 @@ import (
 
 func (asset *Asset) spvSyncNotificationCallbacks() *spv.Notifications {
 	return &spv.Notifications{
-		PeerConnected: func(peerCount int32, addr string) {
+		PeerConnected: func(peerCount int32, _ string) {
 			asset.handlePeerCountUpdate(peerCount)
 		},
-		PeerDisconnected: func(peerCount int32, addr string) {
+		PeerDisconnected: func(peerCount int32, _ string) {
 			asset.handlePeerCountUpdate(peerCount)
 		},
 		Synced:                       asset.syncedWallet,

--- a/libwallet/assets/dcr/txparser.go
+++ b/libwallet/assets/dcr/txparser.go
@@ -103,7 +103,7 @@ func (asset *Asset) decodeTransactionWithTxSummary(txSummary *w.TransactionSumma
 
 		// update ticket with spender hash
 		ticketPurchaseTx.TicketSpender = decodedTx.Hash
-		asset.GetWalletDataDb().SaveOrUpdate(&sharedW.Transaction{}, ticketPurchaseTx)
+		_, _ = asset.GetWalletDataDb().SaveOrUpdate(&sharedW.Transaction{}, ticketPurchaseTx)
 	}
 
 	return decodedTx, nil

--- a/libwallet/assets/dcr/vsp.go
+++ b/libwallet/assets/dcr/vsp.go
@@ -106,7 +106,7 @@ type vspDbData struct {
 
 func (asset *Asset) getVSPDBData() *vspDbData {
 	vspDbData := new(vspDbData)
-	asset.ReadUserConfigValue(sharedW.KnownVSPsConfigKey, vspDbData)
+	_ = asset.ReadUserConfigValue(sharedW.KnownVSPsConfigKey, vspDbData)
 	return vspDbData
 }
 

--- a/libwallet/assets/ltc/sync.go
+++ b/libwallet/assets/ltc/sync.go
@@ -284,7 +284,7 @@ func (asset *Asset) rescanFinished(height int32) {
 		// Update the assets birthday from genesis block to a date closer
 		// to when the privatekey was first used.
 		asset.updateAssetBirthday()
-		asset.MarkWalletAsDiscoveredAccounts()
+		_ = asset.MarkWalletAsDiscoveredAccounts()
 	}
 
 	asset.syncData.mu.Lock()
@@ -605,7 +605,7 @@ func (asset *Asset) reloadChainService() error {
 		asset.CancelSync()
 	}
 
-	asset.chainClient.CS.Stop()
+	_ = asset.chainClient.CS.Stop()
 	chainService, err := asset.loadChainService()
 	if err != nil {
 		return err

--- a/libwallet/assets/wallet/wallet_shared.go
+++ b/libwallet/assets/wallet/wallet_shared.go
@@ -328,7 +328,7 @@ func (wallet *Wallet) SetBirthday(birthday time.Time) {
 	wallet.mu.Lock()
 	wallet.Birthday = birthday
 	// Triggers db update with the new birthday time.
-	wallet.db.Save(wallet)
+	_ = wallet.db.Save(wallet)
 	wallet.mu.Unlock()
 }
 

--- a/libwallet/assets/wallet/wallet_utils.go
+++ b/libwallet/assets/wallet/wallet_utils.go
@@ -57,7 +57,7 @@ var InvalidBlock = &BlockInfo{
 // a transaction needs to be consider as confirmed.
 func (wallet *Wallet) RequiredConfirmations() int32 {
 	var spendUnconfirmed bool
-	wallet.ReadUserConfigValue(SpendUnconfirmedConfigKey, &spendUnconfirmed)
+	_ = wallet.ReadUserConfigValue(SpendUnconfirmedConfigKey, &spendUnconfirmed)
 	if spendUnconfirmed {
 		return 0
 	}
@@ -105,7 +105,7 @@ func (wallet *Wallet) batchDbTransaction(dbOp func(node storm.Node) error) (err 
 	panicked := true
 	defer func() {
 		if panicked || err != nil {
-			dbTx.Rollback()
+			_ = dbTx.Rollback()
 			return
 		}
 

--- a/libwallet/assets/wallet/walletdata/save.go
+++ b/libwallet/assets/wallet/walletdata/save.go
@@ -28,7 +28,7 @@ func (db *DB) SaveOrUpdate(emptyTxPointer, record interface{}) (overwritten bool
 	if timestamp > 0 {
 		overwritten = true
 		// delete old record before saving new (if it exists)
-		db.walletDataDB.DeleteStruct(emptyTxPointer)
+		_ = db.walletDataDB.DeleteStruct(emptyTxPointer)
 	}
 
 	if txlabel != "" {

--- a/libwallet/badgerdb/bucket.go
+++ b/libwallet/badgerdb/bucket.go
@@ -57,7 +57,7 @@ func newBucket(tx *badger.Txn, badgerKey []byte, dbTx *transaction) (*Bucket, er
 		return nil, convertErr(err)
 	}
 	if item.UserMeta() != metaBucket {
-		errors.E(errors.Invalid, "key is not associated with a bucket")
+		return nil, errors.E(errors.Invalid, "key is not associated with a bucket")
 	}
 	return &Bucket{txn: tx, prefix: prefix, dbTransaction: dbTx}, nil
 }

--- a/libwallet/badgerdb/db.go
+++ b/libwallet/badgerdb/db.go
@@ -96,7 +96,7 @@ func (tx *transaction) DeleteTopLevelBucket(key []byte) error {
 		return errors.E(errors.Invalid)
 	}
 
-	tx.badgerTx.Delete(item.Key()[:])
+	_ = tx.badgerTx.Delete(item.Key()[:])
 
 	it := tx.badgerTx.NewIterator(badger.DefaultIteratorOptions)
 	defer it.Close()
@@ -108,7 +108,7 @@ func (tx *transaction) DeleteTopLevelBucket(key []byte) error {
 		}
 		prefixLength := int(val[0])
 		if bytes.Equal(item.Key()[:prefixLength], key) {
-			tx.badgerTx.Delete(item.Key()[:])
+			_ = tx.badgerTx.Delete(item.Key()[:])
 		}
 	}
 	for i := range tx.buckets {

--- a/libwallet/dex_wallets_loader.go
+++ b/libwallet/dex_wallets_loader.go
@@ -73,7 +73,7 @@ func prepareDexSupportForDCRWallet() {
 	// This function will be invoked when the DEX client needs to
 	// setup a dcr ExchangeWallet; it allows us to use an existing
 	// wallet instance for wallet operations instead of json-rpc.
-	var walletMaker = func(settings map[string]string, chainParams *dcrcfg.Params, logger dex.Logger) (dexDcr.Wallet, error) {
+	var walletMaker = func(settings map[string]string, chainParams *dcrcfg.Params, _ dex.Logger) (dexDcr.Wallet, error) {
 		walletIDStr := settings[dexc.WalletIDConfigKey]
 		walletID, err := strconv.Atoi(walletIDStr)
 		if err != nil || walletID < 0 {

--- a/libwallet/ext/ext_test.go
+++ b/libwallet/ext/ext_test.go
@@ -220,7 +220,7 @@ var (
 		UnconfirmedBalance: 0,
 		UnconfirmedTxs:     0,
 		Txs:                17,
-		TxIds: []string{
+		TxIDs: []string{
 			"bd1bf8897a5c1a53f3e90c26fc908d03624f8bd5d21da49ba8fa80cb99bae84d",
 			"335fc62ec6ebd8d29cef8dc98478807327ad2f2bc58a4ca6fb8a73411a38788f",
 			"88b4e3b7162667d0d5aec2e78663342721413a6fea280062444ab8d9f13065ac",
@@ -249,7 +249,7 @@ var (
 		UnconfirmedBalance: 0,
 		UnconfirmedTxs:     0,
 		Txs:                35,
-		TxIds: []string{
+		TxIDs: []string{
 			"bd1bf8897a5c1a53f3e90c26fc908d03624f8bd5d21da49ba8fa80cb99bae84d",
 			"335fc62ec6ebd8d29cef8dc98478807327ad2f2bc58a4ca6fb8a73411a38788f",
 			"88b4e3b7162667d0d5aec2e78663342721413a6fea280062444ab8d9f13065ac",
@@ -288,7 +288,7 @@ func TestGetBestBlock(t *testing.T) {
 	}{
 		{
 			name: "best block",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`681536`))
 			})),
@@ -319,7 +319,7 @@ func TestGetBestBlockTimeStamp(t *testing.T) {
 	}{
 		{
 			name: "bestblock timeStamp",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`{"height":681649,"size":22216,"hash":"0000000000000000109256ba6dab7e921c4d7e98d00357f51bff3b2d28ef345e",
 					"diff":3046219499.387013,"sdiff":227.59014758,"time":1659420872,"txlength":0,"ticket_pool":{"height":0,"size":41152,
@@ -354,7 +354,7 @@ func TestGetCurrentAgendaStatus(t *testing.T) {
 	}{
 		{
 			name: "current agenda status",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`{"currentheight":681658,"startheight":681472,"endheight":689535,"hash":"00000000000000008a66428f2b98ab0ed1a220cfe23013acc393801d5e480b40",
 					"voteversion":9,"quorum":4032,"totalvotes":931,"agendas":[{"id":"reverttreasurypolicy","description":"Change maximum treasury expenditure policy as defined in DCP0007",
@@ -395,7 +395,7 @@ func TestGetAgendas(t *testing.T) {
 	}{
 		{
 			name: "agendas list",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`[{"name":"reverttreasurypolicy","description":"Change maximum treasury expenditure policy as defined in DCP0007","status":"finished","votingStarted":0,"votingdone":649215,"activated":657280,"hardforked":0,"starttime":"2021-09-16T00:00:00Z","expiretime":"2023-09-16T00:00:00Z","voteversion":9,"mask":6},
 						{"name":"explicitverupgrades","description":"Enable explicit version upgrades as defined in DCP0008","status":"finished","votingStarted":0,"votingdone":649215,"activated":657280,"hardforked":0,"starttime":"2021-09-16T00:00:00Z","expiretime":"2023-09-16T00:00:00Z","voteversion":9,"mask":24},
@@ -431,7 +431,7 @@ func TestGetTreasuryBalance(t *testing.T) {
 	}{
 		{
 			name: "treasury balance",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`{"height":681712,"maturity_height":681456,"balance":75919531830200,"output_count":129283,
 						"add_count":13,"added":61780107690000,"spend_count":5,"spent":779373012698,"tbase_count":129265,
@@ -467,7 +467,7 @@ func TestGetExchangeRate(t *testing.T) {
 	}{
 		{
 			name: "exchange rate",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`{"btcIndex":"USD","dcrPrice":26.182965232480655,"btcPrice":22728.06395,
 					"exchanges":{
@@ -506,7 +506,7 @@ func TestGetTicketFeeRateSummary(t *testing.T) {
 	}{
 		{
 			name: "Ticket Fee rate summary",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`{"height":681734,"time":1659448720,"number":0,"min":0,"max":0,"mean":0,"median":0,"stddev":0,"lowest_mineable":0}`))
 			})),
@@ -540,7 +540,7 @@ func TestGetTicketFeeRate(t *testing.T) {
 	}{
 		{
 			name: "Ticket Fee rate",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`{"height":681741,"time":1659449708,"length":0,"total":0,"top_fees":[]}`))
 			})),
@@ -574,7 +574,7 @@ func TestGetAddress(t *testing.T) {
 	}{
 		{
 			name: "address state",
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`{"page":1,"totalPages":1,"itemsOnPage":1000,"address":"DsTxPUVFxXeNgu5fzozr4mTR4tqqMaKcvpY","balance":"0",
 					"totalReceived":"95645588","totalSent":"95645588","unconfirmedBalance":"0","unconfirmedTxs":0,"txs":17,

--- a/libwallet/ext/types.go
+++ b/libwallet/ext/types.go
@@ -77,7 +77,7 @@ type (
 		UnconfirmedBalance int64    `json:"unconfirmedBalance,string"`
 		UnconfirmedTxs     int64    `json:"unconfirmedTxs"`
 		Txs                int32    `json:"txs"`
-		TxIds              []string `json:"txids"`
+		TxIDs              []string `json:"txids"`
 	}
 
 	// XpubAddress models data about a specific xpub token.
@@ -100,7 +100,7 @@ type (
 		UnconfirmedBalance int64         `json:"unconfirmedBalance,string"`
 		UnconfirmedTxs     int64         `json:"unconfirmedTxs"`
 		Txs                int32         `json:"txs"`
-		TxIds              []string      `json:"txids"`
+		TxIDs              []string      `json:"txids"`
 		UsedTokens         int32         `json:"usedTokens"`
 		XpubAddress        []XpubAddress `json:"tokens"`
 	}

--- a/libwallet/instantswap/instantswap.go
+++ b/libwallet/instantswap/instantswap.go
@@ -89,7 +89,7 @@ func (instantSwap *InstantSwap) saveOrOverwriteOrder(order *Order) error {
 
 	if oldOrder.UUID != "" {
 		// delete old record before saving new (if it exists)
-		instantSwap.db.DeleteStruct(oldOrder)
+		_ = instantSwap.db.DeleteStruct(oldOrder)
 	}
 
 	return instantSwap.db.Save(order)
@@ -240,7 +240,7 @@ func (instantSwap *InstantSwap) CreateOrder(exchangeObject instantswap.IDExchang
 		ExtraID: res.ExtraID, // changenow.io requirement //changelly payinExtraId value
 	}
 
-	instantSwap.saveOrder(order)
+	_ = instantSwap.saveOrder(order)
 	instantSwap.publishOrderCreated(order)
 
 	return order, nil

--- a/libwallet/internal/politeia/politeia.go
+++ b/libwallet/internal/politeia/politeia.go
@@ -84,7 +84,7 @@ func (p *Politeia) saveOrOverwiteProposal(proposal *Proposal) error {
 
 	if oldProposal.Token != "" {
 		// delete old record before saving new (if it exists)
-		p.db.DeleteStruct(oldProposal)
+		_ = p.db.DeleteStruct(oldProposal)
 	}
 
 	return p.db.Save(proposal)

--- a/libwallet/internal/vsp/vsp.go
+++ b/libwallet/internal/vsp/vsp.go
@@ -85,7 +85,7 @@ func (c *Client) FeePercentage(ctx context.Context) (float64, error) {
 // any association with a VSP.
 func (c *Client) ProcessUnprocessedTickets(ctx context.Context, policy Policy) {
 	var wg sync.WaitGroup
-	c.Wallet.ForUnspentUnexpiredTickets(ctx, func(hash *chainhash.Hash) error {
+	_ = c.Wallet.ForUnspentUnexpiredTickets(ctx, func(hash *chainhash.Hash) error {
 		// Skip tickets which have a fee tx already associated with
 		// them; they are already processed by some vsp.
 		_, err := c.Wallet.VSPFeeHashForTicket(ctx, hash)

--- a/main.go
+++ b/main.go
@@ -64,9 +64,9 @@ func main() {
 		logDir := filepath.Join(cfg.LogDir, string(netType))
 		initLogRotator(logDir, cfg.MaxLogZips)
 		if cfg.DebugLevel == "" {
-			logger.SetLogLevels(utils.DefaultLogLevel)
+			_ = logger.SetLogLevels(utils.DefaultLogLevel)
 		} else {
-			logger.SetLogLevels(cfg.DebugLevel)
+			_ = logger.SetLogLevels(cfg.DebugLevel)
 		}
 
 		assetsManager, err := libwallet.NewAssetsManager(cfg.HomeDir, logDir, netType, cfg.DEXTestAddr)
@@ -78,7 +78,7 @@ func main() {
 		if cfg.DebugLevel != "" {
 			assetsManager.SetLogLevels(cfg.DebugLevel)
 		} else {
-			logger.SetLogLevels(assetsManager.GetLogLevels())
+			_ = logger.SetLogLevels(assetsManager.GetLogLevels())
 		}
 
 		return assetsManager, nil

--- a/ui/cryptomaterial/clickable_list.go
+++ b/ui/cryptomaterial/clickable_list.go
@@ -93,7 +93,7 @@ func (cl *ClickableList) row(gtx layout.Context, count int, i int, w layout.List
 	// add divider to all rows except last
 	if i < (count-1) && cl.DividerHeight > 0 {
 		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+			layout.Rigid(func(_ layout.Context) layout.Dimensions {
 				return row
 			}),
 			layout.Rigid(func(gtx layout.Context) layout.Dimensions {

--- a/ui/cryptomaterial/editor.go
+++ b/ui/cryptomaterial/editor.go
@@ -232,7 +232,7 @@ func (e *Editor) layout(gtx C) D {
 		e.LineColor, e.TitleLabel.Color = e.t.Color.Danger, e.t.Color.Danger
 	}
 
-	overLay := func(gtx C) D { return D{} }
+	overLay := func(_ C) D { return D{} }
 	if e.Editor.ReadOnly {
 		overLay = func(gtx C) D {
 			gtxCopy := gtx

--- a/ui/cryptomaterial/progressbar.go
+++ b/ui/cryptomaterial/progressbar.go
@@ -204,14 +204,14 @@ func (mp *MultiLayerProgressBar) progressBarLayout(gtx C) D {
 
 	// This takes only 2 layers
 	return layout.Flex{}.Layout(gtx,
-		layout.Rigid(func(gtx C) D {
+		layout.Rigid(func(_ C) D {
 			width := calProgressWidth(mp.items[0].Value)
 			if width == 0 {
 				return D{}
 			}
 			return pg(int(width), mp.items[0].Label, mp.items[0].Color)
 		}),
-		layout.Rigid(func(gtx C) D {
+		layout.Rigid(func(_ C) D {
 			width := calProgressWidth(mp.items[1].Value)
 			if width == 0 {
 				return D{}

--- a/ui/cryptomaterial/progressbar.go
+++ b/ui/cryptomaterial/progressbar.go
@@ -149,7 +149,7 @@ func (p ProgressBarStyle) Layout(gtx layout.Context) layout.Dimensions {
 
 	progressBarWidth := int(p.Width)
 	return layout.Stack{Alignment: layout.W}.Layout(gtx,
-		layout.Stacked(func(gtx layout.Context) layout.Dimensions {
+		layout.Stacked(func(_ layout.Context) layout.Dimensions {
 			return shader(progressBarWidth, p.TrackColor)
 		}),
 		layout.Stacked(func(gtx layout.Context) layout.Dimensions {

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -80,7 +80,7 @@ func NewCreatePasswordModal(l *load.Load) *CreatePasswordModal {
 
 	// Set the default click functions
 	cm.negativeButtonClicked = func() {}
-	cm.positiveButtonClicked = func(walletName, password string, m *CreatePasswordModal) bool { return true }
+	cm.positiveButtonClicked = func(_, _ string, _ *CreatePasswordModal) bool { return true }
 
 	cm.materialLoader = material.Loader(l.Theme.Base)
 

--- a/ui/modal/info_modal.go
+++ b/ui/modal/info_modal.go
@@ -87,7 +87,7 @@ func NewErrorModal(l *load.Load, title string, clicked ClickFunc) *InfoModal {
 // DefaultClickFunc returns the default click function satisfying the positive
 // btn click function.
 func DefaultClickFunc() ClickFunc {
-	return func(isChecked bool, in *InfoModal) bool {
+	return func(_ bool, in *InfoModal) bool {
 		return true
 	}
 }

--- a/ui/modal/info_modal.go
+++ b/ui/modal/info_modal.go
@@ -87,7 +87,7 @@ func NewErrorModal(l *load.Load, title string, clicked ClickFunc) *InfoModal {
 // DefaultClickFunc returns the default click function satisfying the positive
 // btn click function.
 func DefaultClickFunc() ClickFunc {
-	return func(_ bool, in *InfoModal) bool {
+	return func(_ bool, _ *InfoModal) bool {
 		return true
 	}
 }

--- a/ui/page/accounts/accounts_page.go
+++ b/ui/page/accounts/accounts_page.go
@@ -122,7 +122,7 @@ func (pg *Page) fetchExchangeRate() {
 // to be eventually drawn on screen.
 // Part of the load.Page interface.
 func (pg *Page) Layout(gtx C) D {
-	return pg.Theme.List(pg.container).Layout(gtx, 1, func(gtx C, i int) D {
+	return pg.Theme.List(pg.container).Layout(gtx, 1, func(gtx C, _ int) D {
 		return pg.Theme.Card().Layout(gtx, func(gtx C) D {
 			return components.HorizontalInset(values.MarginPadding16).Layout(gtx, func(gtx C) D {
 				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,

--- a/ui/page/accounts/btc_account_details_page.go
+++ b/ui/page/accounts/btc_account_details_page.go
@@ -184,7 +184,7 @@ func (pg *BTCAcctDetailsPage) layoutDesktop(gtx layout.Context, widgets []func(g
 				pg.ParentNavigator().CloseCurrentPage()
 			},
 			Body: func(gtx C) D {
-				return pg.Theme.List(pg.list).Layout(gtx, 1, func(gtx C, i int) D {
+				return pg.Theme.List(pg.list).Layout(gtx, 1, func(gtx C, _ int) D {
 					return layout.Inset{
 						Bottom: values.MarginPadding7,
 						Right:  values.MarginPadding2,
@@ -222,7 +222,7 @@ func (pg *BTCAcctDetailsPage) layoutMobile(gtx layout.Context, widgets []func(gt
 				pg.ParentNavigator().CloseCurrentPage()
 			},
 			Body: func(gtx C) D {
-				return pg.Theme.List(pg.list).Layout(gtx, 1, func(gtx C, i int) D {
+				return pg.Theme.List(pg.list).Layout(gtx, 1, func(gtx C, _ int) D {
 					return layout.Inset{
 						Bottom: values.MarginPadding7,
 						Right:  values.MarginPadding2,

--- a/ui/page/accounts/dcr_account_details_page.go
+++ b/ui/page/accounts/dcr_account_details_page.go
@@ -135,7 +135,7 @@ func (pg *AcctDetailsPage) layoutDesktop(gtx layout.Context, widgets []func(gtx 
 				pg.ParentNavigator().CloseCurrentPage()
 			},
 			Body: func(gtx C) D {
-				return pg.Theme.List(pg.list).Layout(gtx, 1, func(gtx C, i int) D {
+				return pg.Theme.List(pg.list).Layout(gtx, 1, func(gtx C, _ int) D {
 					return layout.Inset{
 						Bottom: values.MarginPadding7,
 						Right:  values.MarginPadding2,
@@ -173,7 +173,7 @@ func (pg *AcctDetailsPage) layoutMobile(gtx layout.Context, widgets []func(gtx C
 				pg.ParentNavigator().CloseCurrentPage()
 			},
 			Body: func(gtx C) D {
-				return pg.Theme.List(pg.list).Layout(gtx, 1, func(gtx C, i int) D {
+				return pg.Theme.List(pg.list).Layout(gtx, 1, func(gtx C, _ int) D {
 					return layout.Inset{
 						Bottom: values.MarginPadding7,
 						Right:  values.MarginPadding2,

--- a/ui/page/accounts/ltc_account_details_page.go
+++ b/ui/page/accounts/ltc_account_details_page.go
@@ -184,7 +184,7 @@ func (pg *LTCAcctDetailsPage) layoutDesktop(gtx layout.Context, widgets []func(g
 				pg.ParentNavigator().CloseCurrentPage()
 			},
 			Body: func(gtx C) D {
-				return pg.Theme.List(pg.list).Layout(gtx, 1, func(gtx C, i int) D {
+				return pg.Theme.List(pg.list).Layout(gtx, 1, func(gtx C, _ int) D {
 					return layout.Inset{
 						Bottom: values.MarginPadding7,
 						Right:  values.MarginPadding2,
@@ -219,7 +219,7 @@ func (pg *LTCAcctDetailsPage) layoutMobile(gtx layout.Context, widgets []func(gt
 				pg.ParentNavigator().CloseCurrentPage()
 			},
 			Body: func(gtx C) D {
-				return pg.Theme.List(pg.list).Layout(gtx, 1, func(gtx C, i int) D {
+				return pg.Theme.List(pg.list).Layout(gtx, 1, func(gtx C, _ int) D {
 					return layout.Inset{
 						Bottom: values.MarginPadding7,
 						Right:  values.MarginPadding2,

--- a/ui/page/components/coinformat.go
+++ b/ui/page/components/coinformat.go
@@ -63,13 +63,13 @@ func formatBalance(gtx C, l *load.Load, amount string, mainTextSize unit.Sp, col
 	}
 
 	return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Baseline}.Layout(gtx,
-		layout.Rigid(func(gtx C) D {
+		layout.Rigid(func(_ C) D {
 			return lblWidget(mainTextSize, mainText)
 		}),
-		layout.Rigid(func(gtx C) D {
+		layout.Rigid(func(_ C) D {
 			return lblWidget(subTextSize, subText)
 		}),
-		layout.Rigid(func(gtx C) D {
+		layout.Rigid(func(_ C) D {
 			if displayUnitText {
 				return lblWidget(mainTextSize, unitText)
 			}

--- a/ui/page/components/coinformat_test.go
+++ b/ui/page/components/coinformat_test.go
@@ -33,7 +33,7 @@ func TestFormatBalance(t *testing.T) {
 		amount: "DCR",
 	}}
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(test.name, func(_ *testing.T) {
 			formatBalance(gtx, ld, test.amount, 1, color.NRGBA{}, false, false)
 		})
 	}

--- a/ui/page/components/mixer_layout.go
+++ b/ui/page/components/mixer_layout.go
@@ -100,7 +100,7 @@ func (mc MixerComponent) bottomMixerLayout(gtx C) D {
 			Radius: cryptomaterial.Radius(8),
 		},
 	}.Layout(gtx,
-		layout.Rigid(func(gtc C) D {
+		layout.Rigid(func(gtx C) D {
 			lbl := mc.Theme.Body2(mc.WalletName)
 			lbl.Font.Weight = font.SemiBold
 			return lbl.Layout(gtx)

--- a/ui/page/components/mixer_layout.go
+++ b/ui/page/components/mixer_layout.go
@@ -82,7 +82,7 @@ func (mc MixerComponent) middleMixerLayout(gtx C) D {
 		},
 	}.Layout(gtx,
 		layout.Rigid(mc.Theme.Icons.Alert.Layout20dp),
-		layout.Rigid(func(gtc C) D {
+		layout.Rigid(func(gtx C) D {
 			lbl := mc.Theme.Body2(values.String(values.StrKeepAppOpen))
 			return layout.Inset{Left: values.MarginPadding6}.Layout(gtx, lbl.Layout)
 		}),

--- a/ui/page/components/restore_page.go
+++ b/ui/page/components/restore_page.go
@@ -346,7 +346,7 @@ func (pg *Restore) restoreFromSeedEditor() {
 		EnableName(false).
 		ShowWalletInfoTip(true).
 		SetParent(pg).
-		SetPositiveButtonCallback(func(walletName, password string, m *modal.CreatePasswordModal) bool {
+		SetPositiveButtonCallback(func(_, password string, m *modal.CreatePasswordModal) bool {
 			_, err := pg.AssetsManager.RestoreWallet(pg.walletType, pg.walletName, seedOrHex, password, sharedW.PassphraseTypePass, wordSeedType)
 			if err != nil {
 				errString := err.Error()

--- a/ui/page/components/seed_restore_page.go
+++ b/ui/page/components/seed_restore_page.go
@@ -526,7 +526,7 @@ func (pg *SeedRestore) HandleUserInteractions() {
 			EnableName(false).
 			ShowWalletInfoTip(true).
 			SetParent(pg).
-			SetPositiveButtonCallback(func(walletName, password string, m *modal.CreatePasswordModal) bool {
+			SetPositiveButtonCallback(func(_, password string, m *modal.CreatePasswordModal) bool {
 				_, err := pg.AssetsManager.RestoreWallet(pg.walletType, pg.walletName, pg.seedPhrase, password, sharedW.PassphraseTypePass, pg.getWordSeedType())
 				if err != nil {
 					errString := err.Error()

--- a/ui/page/components/votebar_widget.go
+++ b/ui/page/components/votebar_widget.go
@@ -162,18 +162,18 @@ func (v *VoteBar) votebarLayout(gtx C) D {
 	}
 
 	return layout.Stack{Alignment: layout.W}.Layout(gtx,
-		layout.Stacked(func(gtx layout.Context) layout.Dimensions {
+		layout.Stacked(func(_ layout.Context) layout.Dimensions {
 			return progressScale(progressBarWidth, v.Theme.Color.Gray2, 1)
 		}),
 		layout.Stacked(func(gtx layout.Context) layout.Dimensions {
 			return layout.Flex{}.Layout(gtx,
-				layout.Rigid(func(gtx C) D {
+				layout.Rigid(func(_ C) D {
 					if yesWidth == 0 {
 						return D{}
 					}
 					return progressScale(yesWidth, v.yesColor, 2)
 				}),
-				layout.Rigid(func(gtx C) D {
+				layout.Rigid(func(_ C) D {
 					if noWidth == 0 {
 						return D{}
 					}

--- a/ui/page/components/wallet_account_selector.go
+++ b/ui/page/components/wallet_account_selector.go
@@ -383,7 +383,7 @@ func (ws *WalletAndAccountSelector) setWalletLogo(gtx C) D {
 // when the page using this WalletAndAccountSelector widget is exited.
 func (ws *WalletAndAccountSelector) ListenForTxNotifications(window app.WindowNavigator) {
 	txAndBlockNotificationListener := &sharedW.TxAndBlockNotificationListener{
-		OnTransaction: func(walletID int, transaction *sharedW.Transaction) {
+		OnTransaction: func(_ int, _ *sharedW.Transaction) {
 			// refresh wallets/Accounts list when new transaction is received
 			if ws.selectorModal == nil {
 				return
@@ -395,7 +395,7 @@ func (ws *WalletAndAccountSelector) ListenForTxNotifications(window app.WindowNa
 			}
 			window.Reload()
 		},
-		OnBlockAttached: func(walletID int, blockHeight int32) {
+		OnBlockAttached: func(_ int, _ int32) {
 			// refresh wallet and account balance on every new block
 			// only if sync is completed.
 			if !ws.selectedWallet.IsSynced() || ws.selectorModal == nil {

--- a/ui/page/components/wallet_setup_page.go
+++ b/ui/page/components/wallet_setup_page.go
@@ -224,7 +224,7 @@ func (pg *CreateWallet) Layout(gtx C) D {
 						})
 					}),
 					layout.Rigid(func(gtx C) D {
-						return pg.Theme.List(pg.scrollContainer).Layout(gtx, 1, func(gtx C, i int) D {
+						return pg.Theme.List(pg.scrollContainer).Layout(gtx, 1, func(gtx C, _ int) D {
 							return layout.Inset{
 								Top:   values.MarginPadding26,
 								Right: values.MarginPadding20,

--- a/ui/page/components/wallet_sync_info.go
+++ b/ui/page/components/wallet_sync_info.go
@@ -595,7 +595,7 @@ func (wsi *WalletSyncInfo) ListenForNotifications() {
 		OnTransaction: func(_ int, _ *sharedW.Transaction) {
 			wsi.reload()
 		},
-		OnBlockAttached: func(_ int, /*blockHeight*/_ int32) {
+		OnBlockAttached: func(_ int, _ int32) {
 			wsi.reload()
 		},
 	}

--- a/ui/page/components/wallet_sync_info.go
+++ b/ui/page/components/wallet_sync_info.go
@@ -592,10 +592,10 @@ func (wsi *WalletSyncInfo) ListenForNotifications() {
 	}
 
 	txAndBlockNotificationListener := &sharedW.TxAndBlockNotificationListener{
-		OnTransaction: func(walletID int, transaction *sharedW.Transaction) {
+		OnTransaction: func(_ int, _ *sharedW.Transaction) {
 			wsi.reload()
 		},
-		OnBlockAttached: func(walletID int, blockHeight int32) {
+		OnBlockAttached: func(_ int, /*blockHeight*/_ int32) {
 			wsi.reload()
 		},
 	}
@@ -606,13 +606,13 @@ func (wsi *WalletSyncInfo) ListenForNotifications() {
 	}
 
 	blocksRescanProgressListener := &sharedW.BlocksRescanProgressListener{
-		OnBlocksRescanStarted: func(walletID int) {
+		OnBlocksRescanStarted: func(_ int) {
 			wsi.rescanUpdate = nil
 		},
 		OnBlocksRescanProgress: func(progress *sharedW.HeadersRescanProgressReport) {
 			wsi.rescanUpdate = progress
 		},
-		OnBlocksRescanEnded: func(walletID int, err error) {
+		OnBlocksRescanEnded: func(_ int, _ error) {
 			wsi.rescanUpdate = nil
 			wsi.reload()
 		},

--- a/ui/page/dcrdex/dcrdex_page.go
+++ b/ui/page/dcrdex/dcrdex_page.go
@@ -128,7 +128,7 @@ func (pg *DEXPage) Layout(gtx C) D {
 	}
 
 	if pg.showSplashPage || pg.dexIsLoading {
-		return pg.Theme.List(pg.splashPageContainer).Layout(gtx, 1, func(gtx C, i int) D {
+		return pg.Theme.List(pg.splashPageContainer).Layout(gtx, 1, func(gtx C, _ int) D {
 			return pg.splashPage(gtx)
 		})
 	}

--- a/ui/page/dcrdex/dex_onboarding_page.go
+++ b/ui/page/dcrdex/dex_onboarding_page.go
@@ -271,7 +271,7 @@ func (pg *DEXOnboarding) Layout(gtx C) D {
 		},
 		Alignment: layout.Middle,
 	}.Layout2(gtx, func(gtx C) D {
-		return pg.Theme.List(pg.scrollContainer).Layout(gtx, 1, func(gtx C, i int) D {
+		return pg.Theme.List(pg.scrollContainer).Layout(gtx, 1, func(gtx C, _ int) D {
 			return layout.Flex{Axis: vertical, Alignment: layout.Middle}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
 					txt := pg.Theme.Body1(values.String(values.StrDCRDEXWelcomeMessage))
@@ -1328,7 +1328,7 @@ func (pg *DEXOnboarding) waitForConfirmationAndListenForBlockNotifications() {
 	// OnNavigateFrom().
 	asset := pg.bondSourceAccountSelector.SelectedWallet()
 	asset.RemoveTxAndBlockNotificationListener(DEXOnboardingPageID)
-	asset.AddTxAndBlockNotificationListener(&sharedW.TxAndBlockNotificationListener{
+	_ = asset.AddTxAndBlockNotificationListener(&sharedW.TxAndBlockNotificationListener{
 		OnBlockAttached: func(_ int, _ int32) {
 			if pg.AssetsManager.DEXCInitialized() && !pg.AssetsManager.DexClient().IsLoggedIn() {
 				// Don't update conf if we are not yet logged in.

--- a/ui/page/dcrdex/dex_onboarding_page.go
+++ b/ui/page/dcrdex/dex_onboarding_page.go
@@ -1178,7 +1178,7 @@ func (pg *DEXOnboarding) connectServerAndPrepareForBonding() {
 		AccountValidator(func(a *sharedW.Account) bool {
 			return !a.IsWatchOnly && pg.validateBondWalletOrAccount(pg.bondSourceWalletSelector.SelectedWallet().GetAssetType(), dexc.WalletAccountNumberConfigKey, fmt.Sprint(a.AccountNumber))
 		}).
-		AccountSelected(func(a *sharedW.Account) {
+		AccountSelected(func(_ *sharedW.Account) {
 			pg.bondAccountHasEnough()
 		})
 	pg.bondSourceAccountSelector.HideLogo = true
@@ -1274,7 +1274,7 @@ func (pg *DEXOnboarding) postBond() {
 		SetNegativeButtonCallback(func() {
 			pg.isLoading = false
 		}).
-		SetPositiveButtonCallback(func(_, walletPass string, pm *modal.CreatePasswordModal) bool {
+		SetPositiveButtonCallback(func(_, walletPass string, _ *modal.CreatePasswordModal) bool {
 			if ok := addWalletFn(walletPass); ok {
 				postBondFn()
 			}

--- a/ui/page/dcrdex/market.go
+++ b/ui/page/dcrdex/market.go
@@ -574,7 +574,7 @@ func (pg *DEXMarketPage) Layout(gtx C) D {
 		},
 		Direction: layout.Center,
 	}.Layout2(gtx, func(gtx C) D {
-		return pg.Theme.List(pg.scrollContainer).Layout(gtx, 1, func(gtx C, index int) D {
+		return pg.Theme.List(pg.scrollContainer).Layout(gtx, 1, func(gtx C, _ int) D {
 			return layout.Stack{}.Layout(gtx,
 				layout.Expanded(func(gtx C) D {
 					return layout.Inset{Top: 110}.Layout(gtx, func(gtx C) D {

--- a/ui/page/dcrdex/market.go
+++ b/ui/page/dcrdex/market.go
@@ -960,7 +960,7 @@ func (pg *DEXMarketPage) orderForm(gtx C) D {
 		}
 
 		gtxCopy := gtx
-		overlay := func(gtx C) D {
+		overlay := func(_ C) D {
 			label := pg.Theme.Body1(overlayMsg)
 			label.Alignment = text.Middle
 			return cryptomaterial.DisableLayout(nil, gtxCopy,
@@ -1283,7 +1283,7 @@ func (pg *DEXMarketPage) openOrdersAndHistory(gtx C) D {
 			)
 		}),
 		layout.Rigid(func(gtx C) D {
-			return pg.Theme.List(pg.ordersTableHorizontalScroll).Layout(gtx, 1, func(gtx C, index int) D {
+			return pg.Theme.List(pg.ordersTableHorizontalScroll).Layout(gtx, 1, func(gtx C, _ int) D {
 				gtx.Constraints.Max.X = gtx.Dp(sectionWidth)
 				gtx.Constraints.Min.X = gtx.Constraints.Max.X
 				gtx.Constraints.Max.Y = sectionHeight
@@ -1809,7 +1809,7 @@ func (pg *DEXMarketPage) showSelectDEXWalletModal(missingWallet libutils.AssetTy
 			)
 		}).
 		SetPositiveButtonText(values.String(values.StrAddWallet)).
-		SetPositiveButtonCallback(func(isChecked bool, im *modal.InfoModal) bool {
+		SetPositiveButtonCallback(func(_ bool, _ *modal.InfoModal) bool {
 			pg.ParentWindow().ShowModal(dexPasswordModal)
 			return true
 		})

--- a/ui/page/exchange/confirm_order_modal.go
+++ b/ui/page/exchange/confirm_order_modal.go
@@ -138,7 +138,7 @@ func (com *confirmOrderModal) confirmOrder() {
 
 		err = com.constructTx(order.DepositAddress, order.InvoicedAmount)
 		if err != nil {
-			com.AssetsManager.InstantSwap.DeleteOrder(order)
+			_ = com.AssetsManager.InstantSwap.DeleteOrder(order)
 			com.SetError(err.Error())
 			return
 		}
@@ -146,7 +146,7 @@ func (com *confirmOrderModal) confirmOrder() {
 		// FOR DEVELOPMENT: Comment this block to prevent debit of account
 		_, err = com.sourceWalletSelector.SelectedWallet().Broadcast(password, "")
 		if err != nil {
-			com.AssetsManager.InstantSwap.DeleteOrder(order)
+			_ = com.AssetsManager.InstantSwap.DeleteOrder(order)
 			com.SetError(err.Error())
 			return
 		}
@@ -195,7 +195,7 @@ func (com *confirmOrderModal) Layout(gtx layout.Context) D {
 									})
 								}),
 								layout.Rigid(func(gtx C) D {
-									return com.Theme.List(com.pageContainer).Layout(gtx, 1, func(gtx C, i int) D {
+									return com.Theme.List(com.pageContainer).Layout(gtx, 1, func(gtx C, _ int) D {
 										return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 											layout.Rigid(func(gtx C) D {
 												return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,

--- a/ui/page/exchange/create_order_page.go
+++ b/ui/page/exchange/create_order_page.go
@@ -432,7 +432,7 @@ func (pg *CreateOrderPage) HandleUserInteractions() {
 		if pg.scheduler.IsChecked() {
 
 			orderSettingsModal := newOrderSettingsModalModal(pg.Load, pg.orderData).
-				OnSettingsSaved(func(params *callbackParams) {
+				OnSettingsSaved(func(_ *callbackParams) {
 					refundAddress, _ := pg.sourceWalletSelector.SelectedWallet().CurrentAddress(pg.sourceAccountSelector.SelectedAccount().Number)
 					destinationAddress, _ := pg.destinationWalletSelector.SelectedWallet().CurrentAddress(pg.destinationAccountSelector.SelectedAccount().Number)
 					pg.sourceWalletID = pg.sourceWalletSelector.SelectedWallet().GetWalletID()
@@ -1436,7 +1436,7 @@ func (pg *CreateOrderPage) listenForNotifications() {
 			pg.scroll.FetchScrollData(false, pg.ParentWindow(), false)
 			pg.ParentWindow().Reload()
 		},
-		OnOrderCreated: func(order *instantswap.Order) {
+		OnOrderCreated: func(_ *instantswap.Order) {
 			pg.scroll.FetchScrollData(false, pg.ParentWindow(), false)
 			pg.ParentWindow().Reload()
 		},

--- a/ui/page/exchange/create_order_page.go
+++ b/ui/page/exchange/create_order_page.go
@@ -705,7 +705,7 @@ func (pg *CreateOrderPage) isMultipleAssetTypeWalletAvailable() bool {
 
 func (pg *CreateOrderPage) Layout(gtx C) D {
 	if pg.isFirstVisit {
-		return pg.Theme.List(pg.splashPageContainer).Layout(gtx, 1, func(gtx C, i int) D {
+		return pg.Theme.List(pg.splashPageContainer).Layout(gtx, 1, func(gtx C, _ int) D {
 			return pg.splashPage(gtx)
 		})
 	}
@@ -763,10 +763,10 @@ func (pg *CreateOrderPage) Layout(gtx C) D {
 				Direction: layout.Center,
 				Padding:   layout.Inset{Top: values.MarginPadding0},
 			}.Layout2(gtx, func(gtx C) D {
-				overlay := layout.Stacked(func(gtx C) D { return D{} })
+				overlay := layout.Stacked(func(_ C) D { return D{} })
 				if overlaySet {
 					gtxCopy := gtx
-					overlay = layout.Stacked(func(gtx C) D {
+					overlay = layout.Stacked(func(_ C) D {
 						return components.DisablePageWithOverlay(pg.Load, nil, gtxCopy, msg, "", navBtn)
 					})
 					// Disable main page from receiving events.
@@ -1176,7 +1176,7 @@ func (pg *CreateOrderPage) layoutHistory(gtx C) D {
 	orderItems := pg.scroll.FetchedData()
 	return layout.Stack{}.Layout(gtx,
 		layout.Expanded(func(gtx C) D {
-			return pg.scroll.List().Layout(gtx, 1, func(gtx C, i int) D {
+			return pg.scroll.List().Layout(gtx, 1, func(gtx C, _ int) D {
 				return layout.Inset{Right: values.MarginPadding2}.Layout(gtx, func(gtx C) D {
 					return pg.ordersList.Layout(gtx, len(orderItems), func(gtx C, i int) D {
 						return cryptomaterial.LinearLayout{
@@ -1354,17 +1354,17 @@ func (pg *CreateOrderPage) loadOrderConfig() {
 		if _, err := sourceWallet.GetAccount(sourceAccount); err != nil {
 			log.Error(err)
 		} else {
-			pg.sourceAccountSelector.SelectAccount(sourceWallet, sourceAccount)
+			_ = pg.sourceAccountSelector.SelectAccount(sourceWallet, sourceAccount)
 		}
 	}
 
 	if pg.sourceAccountSelector.SelectedAccount() == nil {
 		isConfigUpdateRequired = true
-		pg.sourceAccountSelector.SelectFirstValidAccount(sourceWallet)
+		_ = pg.sourceAccountSelector.SelectFirstValidAccount(sourceWallet)
 	}
 
 	pg.sourceWalletSelector.WalletSelected(func(selectedWallet sharedW.Asset) {
-		pg.sourceAccountSelector.SelectFirstValidAccount(selectedWallet)
+		_ = pg.sourceAccountSelector.SelectFirstValidAccount(selectedWallet)
 	})
 
 	// Destination wallet picker
@@ -1390,17 +1390,17 @@ func (pg *CreateOrderPage) loadOrderConfig() {
 		if _, err := destinationWallet.GetAccount(destinationAccount); err != nil {
 			log.Error(err)
 		} else {
-			pg.destinationAccountSelector.SelectAccount(destinationWallet, destinationAccount)
+			_ = pg.destinationAccountSelector.SelectAccount(destinationWallet, destinationAccount)
 		}
 	}
 
 	if pg.destinationAccountSelector.SelectedAccount() == nil {
 		isConfigUpdateRequired = true
-		pg.destinationAccountSelector.SelectFirstValidAccount(destinationWallet)
+		_ = pg.destinationAccountSelector.SelectFirstValidAccount(destinationWallet)
 	}
 
 	pg.destinationWalletSelector.WalletSelected(func(selectedWallet sharedW.Asset) {
-		pg.destinationAccountSelector.SelectFirstValidAccount(selectedWallet)
+		_ = pg.destinationAccountSelector.SelectFirstValidAccount(selectedWallet)
 	})
 
 	if isConfigUpdateRequired {

--- a/ui/page/exchange/order_history_page.go
+++ b/ui/page/exchange/order_history_page.go
@@ -424,7 +424,7 @@ func (pg *OrderHistoryPage) layoutHistory(gtx C) D {
 	orderItems := pg.scroll.FetchedData()
 	return layout.Stack{}.Layout(gtx,
 		layout.Expanded(func(gtx C) D {
-			return pg.scroll.List().Layout(gtx, 1, func(gtx C, i int) D {
+			return pg.scroll.List().Layout(gtx, 1, func(gtx C, _ int) D {
 				return layout.Inset{Right: values.MarginPadding2}.Layout(gtx, func(gtx C) D {
 					return pg.ordersList.Layout(gtx, len(orderItems), func(gtx C, i int) D {
 						return cryptomaterial.LinearLayout{

--- a/ui/page/exchange/order_scheduler_modal.go
+++ b/ui/page/exchange/order_scheduler_modal.go
@@ -237,7 +237,7 @@ func (osm *orderSchedulerModal) Layout(gtx layout.Context) D {
 										})
 									}),
 									layout.Rigid(func(gtx C) D {
-										return osm.Theme.List(osm.pageContainer).Layout(gtx, 1, func(gtx C, i int) D {
+										return osm.Theme.List(osm.pageContainer).Layout(gtx, 1, func(gtx C, _ int) D {
 											return cryptomaterial.LinearLayout{
 												Width:     cryptomaterial.MatchParent,
 												Height:    cryptomaterial.WrapContent,
@@ -494,7 +494,9 @@ func (osm *orderSchedulerModal) startOrderScheduler() {
 			SpendingPassphrase: osm.passwordEditor.Editor.Text(),
 		}
 
-		go osm.AssetsManager.StartScheduler(context.Background(), params)
+		go func() {
+			_ = osm.AssetsManager.StartScheduler(context.Background(), params)
+		}()
 
 		osm.Dismiss()
 		osm.orderSchedulerStarted()

--- a/ui/page/exchange/order_settings_modal.go
+++ b/ui/page/exchange/order_settings_modal.go
@@ -111,7 +111,7 @@ func (osm *orderSettingsModal) OnResume() {
 	osm.ctx, osm.ctxCancel = context.WithCancel(context.TODO())
 
 	osm.sourceWalletSelector.WalletSelected(func(selectedWallet sharedW.Asset) {
-		osm.sourceAccountSelector.SelectFirstValidAccount(selectedWallet)
+		_ = osm.sourceAccountSelector.SelectFirstValidAccount(selectedWallet)
 	})
 
 	address, err := osm.destinationWalletSelector.SelectedWallet().CurrentAddress(osm.destinationAccountSelector.SelectedAccount().Number)
@@ -121,7 +121,7 @@ func (osm *orderSettingsModal) OnResume() {
 	osm.addressEditor.Editor.SetText(address)
 
 	osm.destinationWalletSelector.WalletSelected(func(selectedWallet sharedW.Asset) {
-		osm.destinationAccountSelector.SelectFirstValidAccount(selectedWallet)
+		_ = osm.destinationAccountSelector.SelectFirstValidAccount(selectedWallet)
 		address, err := osm.destinationWalletSelector.SelectedWallet().CurrentAddress(osm.destinationAccountSelector.SelectedAccount().Number)
 		if err != nil {
 			log.Error(err)
@@ -129,7 +129,7 @@ func (osm *orderSettingsModal) OnResume() {
 		osm.addressEditor.Editor.SetText(address)
 	})
 
-	osm.destinationAccountSelector.AccountSelected(func(selectedAccount *sharedW.Account) {
+	osm.destinationAccountSelector.AccountSelected(func(_ *sharedW.Account) {
 		address, err := osm.destinationWalletSelector.SelectedWallet().CurrentAddress(osm.destinationAccountSelector.SelectedAccount().Number)
 		if err != nil {
 			log.Error(err)
@@ -258,7 +258,7 @@ func (osm *orderSettingsModal) Layout(gtx layout.Context) D {
 										})
 									}),
 									layout.Rigid(func(gtx C) D {
-										return osm.Theme.List(osm.pageContainer).Layout(gtx, 1, func(gtx C, i int) D {
+										return osm.Theme.List(osm.pageContainer).Layout(gtx, 1, func(gtx C, _ int) D {
 											return cryptomaterial.LinearLayout{
 												Width:     cryptomaterial.MatchParent,
 												Height:    cryptomaterial.WrapContent,
@@ -481,10 +481,10 @@ func (osm *orderSettingsModal) initWalletSelectors() {
 					accountIsValid := account.Number != load.MaxInt32
 					return accountIsValid
 				})
-			osm.sourceAccountSelector.SelectAccount(osm.sourceWalletSelector.SelectedWallet(), exchangeConfig.SourceAccountNumber)
+			_ = osm.sourceAccountSelector.SelectAccount(osm.sourceWalletSelector.SelectedWallet(), exchangeConfig.SourceAccountNumber)
 
 			osm.sourceWalletSelector.WalletSelected(func(selectedWallet sharedW.Asset) {
-				osm.sourceAccountSelector.SelectFirstValidAccount(selectedWallet)
+				_ = osm.sourceAccountSelector.SelectFirstValidAccount(selectedWallet)
 			})
 		}
 
@@ -510,10 +510,10 @@ func (osm *orderSettingsModal) initWalletSelectors() {
 
 					return accountIsValid
 				})
-			osm.destinationAccountSelector.SelectAccount(osm.destinationWalletSelector.SelectedWallet(), exchangeConfig.DestinationAccountNumber)
+			_ = osm.destinationAccountSelector.SelectAccount(osm.destinationWalletSelector.SelectedWallet(), exchangeConfig.DestinationAccountNumber)
 
 			osm.destinationWalletSelector.WalletSelected(func(selectedWallet sharedW.Asset) {
-				osm.destinationAccountSelector.SelectFirstValidAccount(selectedWallet)
+				_ = osm.destinationAccountSelector.SelectFirstValidAccount(selectedWallet)
 			})
 		}
 	} else {
@@ -529,10 +529,10 @@ func (osm *orderSettingsModal) initWalletSelectors() {
 
 				return accountIsValid
 			})
-		osm.sourceAccountSelector.SelectFirstValidAccount(osm.sourceWalletSelector.SelectedWallet())
+		_ = osm.sourceAccountSelector.SelectFirstValidAccount(osm.sourceWalletSelector.SelectedWallet())
 
 		osm.sourceWalletSelector.WalletSelected(func(selectedWallet sharedW.Asset) {
-			osm.sourceAccountSelector.SelectFirstValidAccount(selectedWallet)
+			_ = osm.sourceAccountSelector.SelectFirstValidAccount(selectedWallet)
 		})
 
 		// Destination wallet picker
@@ -548,10 +548,10 @@ func (osm *orderSettingsModal) initWalletSelectors() {
 
 				return accountIsValid
 			})
-		osm.destinationAccountSelector.SelectFirstValidAccount(osm.destinationWalletSelector.SelectedWallet())
+		_ = osm.destinationAccountSelector.SelectFirstValidAccount(osm.destinationWalletSelector.SelectedWallet())
 
 		osm.destinationWalletSelector.WalletSelected(func(selectedWallet sharedW.Asset) {
-			osm.destinationAccountSelector.SelectFirstValidAccount(selectedWallet)
+			_ = osm.destinationAccountSelector.SelectFirstValidAccount(selectedWallet)
 		})
 	}
 }

--- a/ui/page/governance/agenda_vote_modal.go
+++ b/ui/page/governance/agenda_vote_modal.go
@@ -45,7 +45,7 @@ func newAgendaVoteModal(l *load.Load, dcrWallet *dcr.Asset, agenda *dcr.Agenda, 
 		AccountSelected(func(selectedAccount *sharedW.Account) {
 			avm.accountSelected = selectedAccount
 		}).
-		AccountValidator(func(account *sharedW.Account) bool {
+		AccountValidator(func(_ *sharedW.Account) bool {
 			return true
 		})
 

--- a/ui/page/governance/agenda_vote_modal.go
+++ b/ui/page/governance/agenda_vote_modal.go
@@ -53,7 +53,7 @@ func newAgendaVoteModal(l *load.Load, dcrWallet *dcr.Asset, agenda *dcr.Agenda, 
 }
 
 func (avm *agendaVoteModal) OnResume() {
-	avm.accountSelector.SelectFirstValidAccount(avm.dcrImpl)
+	_ = avm.accountSelector.SelectFirstValidAccount(avm.dcrImpl)
 }
 
 // - Layout

--- a/ui/page/governance/consensus_page.go
+++ b/ui/page/governance/consensus_page.go
@@ -174,7 +174,7 @@ func (pg *ConsensusPage) agendaVoteChoiceModal(agenda *dcr.Agenda) {
 		SetCancelable(true).
 		SetNegativeButtonText(values.String(values.StrCancel)).
 		SetPositiveButtonText(values.String(values.StrSave)).
-		SetPositiveButtonCallback(func(isChecked bool, im *modal.InfoModal) bool {
+		SetPositiveButtonCallback(func(_ bool, im *modal.InfoModal) bool {
 			im.Dismiss()
 			voteModal := newAgendaVoteModal(pg.Load, pg.selectedDCRWallet, agenda, radiogroupbtns.Value, func() {
 				pg.FetchAgendas() // re-fetch agendas when modal is dismissed
@@ -320,10 +320,10 @@ func (pg *ConsensusPage) FetchAgendas() {
 
 func (pg *ConsensusPage) Layout(gtx C) D {
 	// If Agendas API is not allowed, display the overlay with the message.
-	overlay := layout.Stacked(func(gtx C) D { return D{} })
+	overlay := layout.Stacked(func(_ C) D { return D{} })
 	if !pg.isAgendaAPIAllowed() {
 		gtxCopy := gtx
-		overlay = layout.Stacked(func(gtx C) D {
+		overlay = layout.Stacked(func(_ C) D {
 			str := values.StringF(values.StrNotAllowed, values.String(values.StrGovernance))
 			return components.DisablePageWithOverlay(pg.Load, nil, gtxCopy, str, "", &pg.navigateToSettingsBtn)
 		})
@@ -494,7 +494,7 @@ func (pg *ConsensusPage) layoutContent(gtx C) D {
 	return layout.Stack{}.Layout(gtx,
 		layout.Expanded(func(gtx C) D {
 			list := layout.List{Axis: layout.Vertical}
-			return pg.Theme.List(pg.listContainer).Layout(gtx, 1, func(gtx C, i int) D {
+			return pg.Theme.List(pg.listContainer).Layout(gtx, 1, func(gtx C, _ int) D {
 				return layout.Inset{Right: values.MarginPadding2}.Layout(gtx, func(gtx C) D {
 					return list.Layout(gtx, len(pg.consensusItems), func(gtx C, i int) D {
 						return cryptomaterial.LinearLayout{

--- a/ui/page/governance/proposal_details_page.go
+++ b/ui/page/governance/proposal_details_page.go
@@ -277,7 +277,7 @@ func (pg *ProposalDetails) HandleUserInteractions() {
 }
 
 func (pg *ProposalDetails) listenForSyncNotifications() {
-	proposalSyncCallback := func(propName string, status libutils.ProposalStatus) {
+	proposalSyncCallback := func(_ string, status libutils.ProposalStatus) {
 		if status == libutils.ProposalStatusSynced {
 			proposal, err := pg.AssetsManager.Politeia.GetProposalRaw(pg.proposal.Token)
 			if err == nil {
@@ -662,7 +662,7 @@ func (pg *ProposalDetails) layoutDescription(gtx C) D {
 	}
 
 	return pg.descriptionCard.Layout(gtx, func(gtx C) D {
-		return pg.Theme.List(pg.scrollbarList).Layout(gtx, 1, func(gtx C, i int) D {
+		return pg.Theme.List(pg.scrollbarList).Layout(gtx, 1, func(gtx C, _ int) D {
 			mpSize := values.MarginPadding16
 			if pg.IsMobileView() {
 				mpSize = values.MarginPadding12

--- a/ui/page/governance/proposal_vote_modal.go
+++ b/ui/page/governance/proposal_vote_modal.go
@@ -99,7 +99,7 @@ func newVoteModal(l *load.Load, proposal *libwallet.Proposal) *voteModal {
 }
 
 func (vm *voteModal) OnResume() {
-	vm.walletSelector.SelectFirstValidWallet()
+	_ = vm.walletSelector.SelectFirstValidWallet()
 }
 
 func (vm *voteModal) OnDismiss() {
@@ -160,7 +160,7 @@ func (vm *voteModal) sendVotes() {
 			vm.Dismiss()
 			infoModal := modal.NewSuccessModal(vm.Load, values.String(values.StrVoteSent), modal.DefaultClickFunc())
 			vm.ParentWindow().ShowModal(infoModal)
-			go vm.AssetsManager.Politeia.Sync(ctx)
+			go func() { _ = vm.AssetsManager.Politeia.Sync(ctx) }()
 			pm.Dismiss()
 
 			return true
@@ -242,7 +242,7 @@ func (vm *voteModal) Layout(gtx layout.Context) D {
 
 			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
-					return layout.Inset{Bottom: values.MarginPadding16}.Layout(gtx, func(gtc C) D {
+					return layout.Inset{Bottom: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
 						return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
 							layout.Rigid(func(gtx layout.Context) layout.Dimensions {
 								if voteDetails.YesVotes == 0 {

--- a/ui/page/governance/proposals_page.go
+++ b/ui/page/governance/proposals_page.go
@@ -139,7 +139,7 @@ func (pg *ProposalsPage) OnNavigatedTo() {
 }
 
 func (pg *ProposalsPage) syncAndUpdateProposals() {
-	go pg.AssetsManager.Politeia.Sync(context.Background())
+	go func() { _ = pg.AssetsManager.Politeia.Sync(context.Background()) }()
 	// Only proceed if allowed make Proposals API call.
 	pg.listenForSyncNotifications()
 	go pg.scroll.FetchScrollData(false, pg.ParentWindow(), false)
@@ -211,7 +211,7 @@ func (pg *ProposalsPage) HandleUserInteractions() {
 	}
 
 	for pg.syncButton.Clicked() {
-		go pg.AssetsManager.Politeia.Sync(context.Background())
+		go func() { _ = pg.AssetsManager.Politeia.Sync(context.Background()) }()
 		pg.isSyncing = true
 
 		// TODO: check after 1min if sync does not start, set isSyncing to false and cancel sync
@@ -402,7 +402,7 @@ func (pg *ProposalsPage) rightDropdown(gtx C) D {
 }
 
 func (pg *ProposalsPage) layoutContent(gtx C) D {
-	return pg.scroll.List().Layout(gtx, 1, func(gtx C, i int) D {
+	return pg.scroll.List().Layout(gtx, 1, func(gtx C, _ int) D {
 		return layout.Inset{Right: values.MarginPadding2}.Layout(gtx, func(gtx C) D {
 			if pg.scroll.ItemsCount() <= 0 {
 				isProposalSyncing := pg.AssetsManager.Politeia.IsSyncing()
@@ -470,7 +470,7 @@ func (pg *ProposalsPage) layoutSectionHeader(gtx C) D {
 }
 
 func (pg *ProposalsPage) listenForSyncNotifications() {
-	proposalSyncCallback := func(propName string, status libutils.ProposalStatus) {
+	proposalSyncCallback := func(_ string, status libutils.ProposalStatus) {
 		if status == libutils.ProposalStatusSynced {
 			pg.syncCompleted = true
 			pg.isSyncing = false

--- a/ui/page/governance/treasury_page.go
+++ b/ui/page/governance/treasury_page.go
@@ -203,10 +203,10 @@ func (pg *TreasuryPage) FetchPolicies() {
 
 func (pg *TreasuryPage) Layout(gtx C) D {
 	// If proposals API is not allowed, display the overlay with the message.
-	overlay := layout.Stacked(func(gtx C) D { return D{} })
+	overlay := layout.Stacked(func(_ C) D { return D{} })
 	if !pg.isTreasuryAPIAllowed() {
 		gtxCopy := gtx
-		overlay = layout.Stacked(func(gtx C) D {
+		overlay = layout.Stacked(func(_ C) D {
 			str := values.StringF(values.StrNotAllowed, values.String(values.StrGovernance))
 			return components.DisablePageWithOverlay(pg.Load, nil, gtxCopy, str, "", &pg.navigateToSettingsBtn)
 		})
@@ -298,7 +298,7 @@ func (pg *TreasuryPage) layoutVerifyGovernanceKeys(gtx C) D {
 func (pg *TreasuryPage) layoutContent(gtx C) D {
 	return layout.Inset{Top: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
 		list := layout.List{Axis: layout.Vertical}
-		return pg.Theme.List(pg.listContainer).Layout(gtx, 1, func(gtx C, i int) D {
+		return pg.Theme.List(pg.listContainer).Layout(gtx, 1, func(gtx C, _ int) D {
 			return list.Layout(gtx, len(pg.treasuryItems), func(gtx C, i int) D {
 				return layout.Inset{Top: values.MarginPadding16, Bottom: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
 					return layout.Flex{Axis: layout.Vertical}.Layout(gtx,

--- a/ui/page/governance/wallet_selector.go
+++ b/ui/page/governance/wallet_selector.go
@@ -242,7 +242,7 @@ func (asm *WalletSelectorModal) Layout(gtx layout.Context) layout.Dimensions {
 							Top:  values.MarginPadding20,
 							Left: values.MarginPaddingMinus75,
 						}
-						return inset.Layout(gtx, func(gtx C) D {
+						return inset.Layout(gtx, func(_ C) D {
 							// return page.walletInfoPopup(gtx)
 							return layout.Dimensions{}
 						})

--- a/ui/page/info/info_page.go
+++ b/ui/page/info/info_page.go
@@ -128,7 +128,7 @@ func (pg *WalletInfo) backup(wallet sharedW.Asset) {
 // Part of the load.Page interface.
 // Layout lays out the widgets for the main wallets pg.
 func (pg *WalletInfo) Layout(gtx C) D {
-	return pg.Theme.List(pg.container).Layout(gtx, 1, func(gtx C, i int) D {
+	return pg.Theme.List(pg.container).Layout(gtx, 1, func(gtx C, _ int) D {
 		items := []layout.FlexChild{layout.Rigid(pg.walletSyncInfo.WalletInfoLayout)}
 
 		items = append(items, layout.Rigid(layout.Spacer{Height: values.MarginPadding16}.Layout))
@@ -272,11 +272,11 @@ func (pg *WalletInfo) HandleUserInteractions() {
 
 func (pg *WalletInfo) listenForMixerNotifications() {
 	accountMixerNotificationListener := &dcr.AccountMixerNotificationListener{
-		OnAccountMixerStarted: func(walletID int) {
+		OnAccountMixerStarted: func(_ int) {
 			pg.reloadMixerBalances()
 			pg.ParentWindow().Reload()
 		},
-		OnAccountMixerEnded: func(walletID int) {
+		OnAccountMixerEnded: func(_ int) {
 			pg.reloadMixerBalances()
 			pg.ParentWindow().Reload()
 		},
@@ -289,7 +289,7 @@ func (pg *WalletInfo) listenForMixerNotifications() {
 
 	// this is needed to refresh the UI on every block
 	txAndBlockNotificationListener := &sharedW.TxAndBlockNotificationListener{
-		OnBlockAttached: func(walletID int, blockHeight int32) {
+		OnBlockAttached: func(_ int, _ int32) {
 			pg.reloadMixerBalances()
 			pg.ParentWindow().Reload()
 		},

--- a/ui/page/info/info_page.go
+++ b/ui/page/info/info_page.go
@@ -118,7 +118,7 @@ func (pg *WalletInfo) reload() {
 
 func (pg *WalletInfo) backup(wallet sharedW.Asset) {
 	currentPage := pg.ParentWindow().CurrentPageID()
-	pg.ParentWindow().Display(seedbackup.NewBackupInstructionsPage(pg.Load, wallet, func(load *load.Load, navigator app.WindowNavigator) {
+	pg.ParentWindow().Display(seedbackup.NewBackupInstructionsPage(pg.Load, wallet, func(_ *load.Load, navigator app.WindowNavigator) {
 		navigator.ClosePagesAfter(currentPage)
 	}))
 }

--- a/ui/page/privacy/account_mixer_page.go
+++ b/ui/page/privacy/account_mixer_page.go
@@ -204,7 +204,7 @@ func (pg *AccountMixerPage) mixerHeaderContent() layout.FlexChild {
 			}),
 			layout.Rigid(func(gtx C) D {
 				if !pg.dcrWallet.IsAccountMixerActive() {
-					return layout.Inset{Top: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
+					return layout.Inset{Top: values.MarginPadding16}.Layout(gtx, func(_ C) D {
 						return D{}
 					})
 				}
@@ -306,7 +306,7 @@ func (pg *AccountMixerPage) mixerPageLayout(gtx C) D {
 			})
 		}
 
-		return pg.pageContainer.Layout(gtx, 1, func(gtx C, i int) D {
+		return pg.pageContainer.Layout(gtx, 1, func(gtx C, _ int) D {
 			return wdg(gtx)
 		})
 	})
@@ -343,7 +343,7 @@ func (pg *AccountMixerPage) HandleUserInteractions() {
 				SetPositiveButtonText(values.String(values.StrYes)).
 				SetPositiveButtonCallback(func(_ bool, _ *modal.InfoModal) bool {
 					pg.toggleMixer.SetChecked(false)
-					go pg.dcrWallet.StopAccountMixer()
+					go func() { _ = pg.dcrWallet.StopAccountMixer() }()
 					return true
 				})
 			pg.ParentWindow().ShowModal(info)
@@ -481,12 +481,12 @@ func (pg *AccountMixerPage) showModalPasswordStartAccountMixer() {
 
 func (pg *AccountMixerPage) listenForMixerNotifications() {
 	accountMixerNotificationListener := &dcr.AccountMixerNotificationListener{
-		OnAccountMixerStarted: func(walletID int) {
+		OnAccountMixerStarted: func(_ int) {
 			pg.Toast.Notify(values.String(values.StrMixerStart))
 			pg.getMixerBalance()
 			pg.ParentWindow().Reload()
 		},
-		OnAccountMixerEnded: func(walletID int) {
+		OnAccountMixerEnded: func(_ int) {
 			pg.mixerCompleted = true
 			pg.getMixerBalance()
 			pg.ParentWindow().Reload()
@@ -500,7 +500,7 @@ func (pg *AccountMixerPage) listenForMixerNotifications() {
 
 	// this is needed to refresh the UI on every block
 	txAndBlockNotificationListener := &sharedW.TxAndBlockNotificationListener{
-		OnBlockAttached: func(walletID int, blockHeight int32) {
+		OnBlockAttached: func(_ int, _ int32) {
 			pg.getMixerBalance()
 			pg.ParentWindow().Reload()
 		},

--- a/ui/page/privacy/account_mixer_page.go
+++ b/ui/page/privacy/account_mixer_page.go
@@ -426,7 +426,7 @@ func (pg *AccountMixerPage) HandleUserInteractions() {
 		textModal := modal.NewTextInputModal(pg.Load).
 			Hint(values.String(values.StrCoordinationServer)).
 			PositiveButtonStyle(pg.Load.Theme.Color.Primary, pg.Load.Theme.Color.InvText).
-			SetPositiveButtonCallback(func(newName string, tim *modal.TextInputModal) bool {
+			SetPositiveButtonCallback(func(_ string, _ *modal.TextInputModal) bool {
 				// Todo - implement custom CSPP server
 				return true
 			})

--- a/ui/page/privacy/manual_mixer_setup_page.go
+++ b/ui/page/privacy/manual_mixer_setup_page.go
@@ -93,8 +93,8 @@ func NewManualMixerSetupPage(l *load.Load, dcrWallet *dcr.Asset) *ManualMixerSet
 			return true
 		})
 
-	pg.mixedAccountSelector.SelectFirstValidAccount(dcrWallet)
-	pg.unmixedAccountSelector.SelectFirstValidAccount(dcrWallet)
+	_ = pg.mixedAccountSelector.SelectFirstValidAccount(dcrWallet)
+	_ = pg.unmixedAccountSelector.SelectFirstValidAccount(dcrWallet)
 
 	_, pg.infoButton = components.SubpageHeaderButtons(l)
 	pg.backButton = components.GetBackButton(l)
@@ -107,8 +107,8 @@ func NewManualMixerSetupPage(l *load.Load, dcrWallet *dcr.Asset) *ManualMixerSet
 // the page is displayed.
 // Part of the load.Page interface.
 func (pg *ManualMixerSetupPage) OnNavigatedTo() {
-	pg.mixedAccountSelector.SelectFirstValidAccount(pg.dcrWallet)
-	pg.unmixedAccountSelector.SelectFirstValidAccount(pg.dcrWallet)
+	_ = pg.mixedAccountSelector.SelectFirstValidAccount(pg.dcrWallet)
+	_ = pg.unmixedAccountSelector.SelectFirstValidAccount(pg.dcrWallet)
 }
 
 // Layout draws the page UI components into the provided layout context

--- a/ui/page/privacy/manual_mixer_setup_page.go
+++ b/ui/page/privacy/manual_mixer_setup_page.go
@@ -50,7 +50,7 @@ func NewManualMixerSetupPage(l *load.Load, dcrWallet *dcr.Asset) *ManualMixerSet
 	// Mixed account picker
 	pg.mixedAccountSelector = components.NewWalletAndAccountSelector(l).
 		Title(values.String(values.StrMixedAccount)).
-		AccountSelected(func(selectedAccount *sharedW.Account) {}).
+		AccountSelected(func(_ *sharedW.Account) {}).
 		AccountValidator(func(account *sharedW.Account) bool {
 			wal := pg.Load.AssetsManager.WalletWithID(account.WalletID)
 
@@ -73,7 +73,7 @@ func NewManualMixerSetupPage(l *load.Load, dcrWallet *dcr.Asset) *ManualMixerSet
 	// Unmixed account picker
 	pg.unmixedAccountSelector = components.NewWalletAndAccountSelector(l).
 		Title(values.String(values.StrUnmixedAccount)).
-		AccountSelected(func(selectedAccount *sharedW.Account) {}).
+		AccountSelected(func(_ *sharedW.Account) {}).
 		AccountValidator(func(account *sharedW.Account) bool {
 			wal := pg.Load.AssetsManager.WalletWithID(account.WalletID)
 

--- a/ui/page/privacy/shared_modals.go
+++ b/ui/page/privacy/shared_modals.go
@@ -55,7 +55,7 @@ func showModalSetupMixerAcct(conf *sharedModalConfig, dcrWallet *dcr.Asset, move
 			info := modal.NewErrorModal(conf.Load, values.String(values.StrTakenAccount), modal.DefaultClickFunc()).
 				Body(values.String(values.StrMixerAccErrorMsg)).
 				SetPositiveButtonText(values.String(values.StrBackAndRename)).
-				SetPositiveButtonCallback(func(movefundsChecked bool, _ *modal.InfoModal) bool {
+				SetPositiveButtonCallback(func(_ bool, _ *modal.InfoModal) bool {
 					conf.pageNavigator.CloseCurrentPage()
 					return true
 				})

--- a/ui/page/receive/receive_page.go
+++ b/ui/page/receive/receive_page.go
@@ -136,7 +136,7 @@ func (pg *Page) initWalletSelectors() {
 		pg.generateQRForAddress()
 	})
 
-	pg.sourceAccountselector.AccountSelected(func(selectedAccount *sharedW.Account) {
+	pg.sourceAccountselector.AccountSelected(func(_ *sharedW.Account) {
 		pg.generateQRForAddress()
 	})
 
@@ -297,7 +297,7 @@ func (pg *Page) contentLayout(gtx C) D {
 									},
 									func(gtx C) D {
 										if pg.selectedWallet.IsSyncing() {
-											syncInfo := components.NewWalletSyncInfo(pg.Load, pg.selectedWallet, func() {}, func(a sharedW.Asset) {})
+											syncInfo := components.NewWalletSyncInfo(pg.Load, pg.selectedWallet, func() {}, func(_ sharedW.Asset) {})
 											blockHeightFetched := values.StringF(values.StrBlockHeaderFetchedCount, pg.selectedWallet.GetBestBlock().Height, syncInfo.FetchSyncProgress().HeadersToFetchOrScan)
 											text := fmt.Sprintf("%s "+blockHeightFetched, values.String(values.StrBlockHeaderFetched))
 											blockInfo := pg.Theme.Label(textSize16, text)

--- a/ui/page/receive/receive_page.go
+++ b/ui/page/receive/receive_page.go
@@ -108,7 +108,7 @@ func NewReceivePage(l *load.Load, wallet sharedW.Asset) *Page {
 				}
 				return false
 			})
-		pg.sourceAccountselector.SelectFirstValidAccount(pg.selectedWallet)
+		_ = pg.sourceAccountselector.SelectFirstValidAccount(pg.selectedWallet)
 	}
 
 	return pg
@@ -128,11 +128,11 @@ func (pg *Page) initWalletSelectors() {
 
 			return accountIsValid
 		})
-	pg.sourceAccountselector.SelectFirstValidAccount(pg.sourceWalletSelector.SelectedWallet())
+	_ = pg.sourceAccountselector.SelectFirstValidAccount(pg.sourceWalletSelector.SelectedWallet())
 
 	pg.sourceWalletSelector.WalletSelected(func(selectedWallet sharedW.Asset) {
 		pg.selectedWallet = selectedWallet
-		pg.sourceAccountselector.SelectFirstValidAccount(selectedWallet)
+		_ = pg.sourceAccountselector.SelectFirstValidAccount(selectedWallet)
 		pg.generateQRForAddress()
 	})
 
@@ -166,8 +166,8 @@ func (pg *Page) OnNavigatedTo() {
 		return
 	}
 
-	pg.sourceAccountselector.ListenForTxNotifications(pg.ParentWindow()) // listener is stopped in OnNavigatedFrom()
-	pg.sourceAccountselector.SelectFirstValidAccount(pg.selectedWallet)  // Want to reset the user's selection everytime this page appears?
+	pg.sourceAccountselector.ListenForTxNotifications(pg.ParentWindow())    // listener is stopped in OnNavigatedFrom()
+	_ = pg.sourceAccountselector.SelectFirstValidAccount(pg.selectedWallet) // Want to reset the user's selection everytime this page appears?
 	// might be better to track the last selection in a variable and reselect it.
 	currentAddress, err := pg.selectedWallet.CurrentAddress(pg.sourceAccountselector.SelectedAccount().Number)
 	if err != nil {
@@ -235,7 +235,7 @@ func (pg *Page) Layout(gtx C) D {
 func (pg *Page) contentLayout(gtx C) D {
 	pg.handleCopyEvent(gtx)
 	pg.pageBackdropLayout(gtx)
-	return pg.Theme.List(pg.scrollContainer).Layout(gtx, 1, func(gtx C, i int) D {
+	return pg.Theme.List(pg.scrollContainer).Layout(gtx, 1, func(gtx C, _ int) D {
 		textSize16 := values.TextSizeTransform(pg.IsMobileView(), values.TextSize16)
 		uniformSize := values.MarginPadding16
 		if pg.modalLayout != nil {

--- a/ui/page/root/home_page.go
+++ b/ui/page/root/home_page.go
@@ -172,7 +172,7 @@ func (hp *HomePage) OnNavigatedTo() {
 	allWallets := hp.AssetsManager.AllWallets()
 	for _, wallet := range allWallets {
 		if wallet.ReadBoolConfigValueForKey(sharedW.AutoSyncConfigKey, false) {
-			hp.startSyncing(wallet, func(isUnlock bool) {})
+			hp.startSyncing(wallet, func(_ bool) {})
 		}
 	}
 
@@ -240,7 +240,7 @@ func (hp *HomePage) initDEX() {
 				}).
 				SetNegativeButtonText(values.String(values.StrIWillLoginLater)).
 				SetPositiveButtonText(values.String(values.StrLogin)).
-				SetPositiveButtonCallback(func(isChecked bool, im *modal.InfoModal) bool {
+				SetPositiveButtonCallback(func(_ bool, _ *modal.InfoModal) bool {
 					dexPassEditor.SetError("")
 					err := dexClient.Login([]byte(dexPassEditor.Editor.Text()))
 					if err != nil {
@@ -305,7 +305,7 @@ func (hp *HomePage) initDEX() {
 			SetNegativeButtonText(values.String(values.StrIWillSyncLater)).
 			SetNegativeButtonCallback(showDEXLoginModal).
 			SetPositiveButtonText(values.String(values.StrOkaySync)).
-			SetPositiveButtonCallback(func(isChecked bool, im *modal.InfoModal) bool {
+			SetPositiveButtonCallback(func(_ bool, _ *modal.InfoModal) bool {
 				if !hp.isConnected.Load() {
 					hp.Toast.NotifyError(values.String(values.StrNotConnected))
 				} else {

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -309,7 +309,7 @@ func (pg *OverviewPage) reload() {
 
 func (pg *OverviewPage) backup(wallet sharedW.Asset) {
 	currentPage := pg.ParentWindow().CurrentPageID()
-	pg.ParentWindow().Display(seedbackup.NewBackupInstructionsPage(pg.Load, wallet, func(load *load.Load, navigator app.WindowNavigator) {
+	pg.ParentWindow().Display(seedbackup.NewBackupInstructionsPage(pg.Load, wallet, func(_ *load.Load, navigator app.WindowNavigator) {
 		navigator.ClosePagesAfter(currentPage)
 	}))
 }
@@ -335,7 +335,7 @@ func (pg *OverviewPage) layoutDesktop(gtx C) D {
 	}
 
 	return cryptomaterial.UniformPaddingWithTopInset(values.MarginPadding15, gtx, func(gtx C) D {
-		return pg.Theme.List(pg.scrollContainer).Layout(gtx, 1, func(gtx C, i int) D {
+		return pg.Theme.List(pg.scrollContainer).Layout(gtx, 1, func(gtx C, _ int) D {
 			return layout.Center.Layout(gtx, func(gtx C) D {
 				return layout.Inset{Right: values.MarginPadding2}.Layout(gtx, func(gtx C) D {
 					return pg.pageContainer.Layout(gtx, len(pageContent), func(gtx C, i int) D {
@@ -1183,7 +1183,7 @@ func (pg *OverviewPage) listenForMixerNotifications() {
 
 	// Reload wallets unmixed balance and reload UI on new blocks.
 	txAndBlockNotificationListener := &sharedW.TxAndBlockNotificationListener{
-		OnBlockAttached: func(walletID int, blockHeight int32) {
+		OnBlockAttached: func(_ int, _ int32) {
 			pg.reloadBalances()
 			pg.ParentWindow().Reload()
 		},

--- a/ui/page/root/wallet_list.go
+++ b/ui/page/root/wallet_list.go
@@ -74,7 +74,7 @@ func (pg *WalletSelectorPage) deleteBadWallet(badWalletID int) {
 		SetNegativeButtonText(values.String(values.StrCancel)).
 		PositiveButtonStyle(pg.Load.Theme.Color.Surface, pg.Load.Theme.Color.Danger).
 		SetPositiveButtonText(values.String(values.StrRemove)).
-		SetPositiveButtonCallback(func(_ bool, im *modal.InfoModal) bool {
+		SetPositiveButtonCallback(func(_ bool, _ *modal.InfoModal) bool {
 			err := pg.AssetsManager.DeleteBadWallet(badWalletID)
 			if err != nil {
 				errorModal := modal.NewErrorModal(pg.Load, err.Error(), modal.DefaultClickFunc())

--- a/ui/page/seedbackup/save_seed.go
+++ b/ui/page/seedbackup/save_seed.go
@@ -210,7 +210,7 @@ func (pg *SaveSeedPage) Layout(gtx C) D {
 			promptToExit(pg.Load, pg.ParentWindow(), pg.redirectCallback)
 		},
 		Body: func(gtx C) D {
-			return pg.Theme.List(pg.pageContainer).Layout(gtx, 1, func(gtx C, i int) D {
+			return pg.Theme.List(pg.pageContainer).Layout(gtx, 1, func(gtx C, _ int) D {
 				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 					layout.Rigid(func(gtx C) D {
 						label := pg.Theme.Label(values.TextSize16, values.StringF(values.String(values.StrWriteDownAllXWords), pg.wordSeedType.ToInt()))

--- a/ui/page/send/layout.go
+++ b/ui/page/send/layout.go
@@ -196,7 +196,7 @@ func (pg *Page) notSyncedLayout(gtx C) D {
 			},
 			func(gtx C) D {
 				if pg.selectedWallet.IsSyncing() {
-					syncInfo := components.NewWalletSyncInfo(pg.Load, pg.selectedWallet, func() {}, func(a sharedW.Asset) {})
+					syncInfo := components.NewWalletSyncInfo(pg.Load, pg.selectedWallet, func() {}, func(_ sharedW.Asset) {})
 					blockHeightFetched := values.StringF(values.StrBlockHeaderFetchedCount, pg.selectedWallet.GetBestBlock().Height, syncInfo.FetchSyncProgress().HeadersToFetchOrScan)
 					text := fmt.Sprintf("%s "+blockHeightFetched, values.String(values.StrBlockHeaderFetched))
 					blockInfo := pg.Theme.Label(textSize16, text)

--- a/ui/page/send/manual_coin_selection.go
+++ b/ui/page/send/manual_coin_selection.go
@@ -652,7 +652,7 @@ func (pg *ManualCoinSelectionPage) rowItemsSection(gtx C, components ...interfac
 			}
 		default:
 			// create an empty default placeholder for unsupported widgets.
-			widget = func(gtx C) D { return D{} }
+			widget = func(_ C) D { return D{} }
 		}
 		return widget
 	}

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -187,7 +187,8 @@ func (pg *Page) initModalWalletSelector() {
 	// Source wallet picker
 	pg.sourceWalletSelector.WalletSelected(func(selectedWallet sharedW.Asset) {
 		pg.selectedWallet = selectedWallet
-		go load.GetAPIFeeRate(pg.selectedWallet)
+		// TODO: @JustinDo Why was this go routine necessary.
+		//go load.GetAPIFeeRate(pg.selectedWallet)
 		go pg.feeRateSelector.UpdatedFeeRate(pg.selectedWallet)
 		pg.setAssetTypeForRecipients()
 		pg.initializeAccountSelectors()
@@ -223,7 +224,7 @@ func (pg *Page) initializeAccountSelectors() {
 		SetActionInfoText(values.String(values.StrTxConfModalInfoTxt))
 	// if a source account exists, don't overwrite it.
 	if pg.sourceAccountSelector.SelectedAccount() == nil {
-		pg.sourceAccountSelector.SelectFirstValidAccount(pg.selectedWallet)
+		_ = pg.sourceAccountSelector.SelectFirstValidAccount(pg.selectedWallet)
 	}
 }
 
@@ -274,7 +275,8 @@ func (pg *Page) OnNavigatedTo() {
 	if pg.selectedWallet.GetAssetType() == libUtil.BTCWalletAsset && pg.isFeerateAPIApproved() {
 		// This API call may take sometime to return. Call this before and cache
 		// results.
-		go load.GetAPIFeeRate(pg.selectedWallet)
+		// TODO: @Wisdom Why was this line necessary?
+		// go load.GetAPIFeeRate(pg.selectedWallet)
 		go pg.feeRateSelector.UpdatedFeeRate(pg.selectedWallet)
 	}
 }

--- a/ui/page/send/recipient.go
+++ b/ui/page/send/recipient.go
@@ -105,12 +105,12 @@ func (rp *recipient) initializeAccountSelectors(sourceAccount *sharedW.Account) 
 	})
 
 	rp.sendDestination.destinationWalletSelector.WalletSelected(func(selectedWallet sharedW.Asset) {
-		rp.sendDestination.destinationAccountSelector.SelectFirstValidAccount(selectedWallet)
+		_ = rp.sendDestination.destinationAccountSelector.SelectFirstValidAccount(selectedWallet)
 	})
 
 	// destinationAccountSelector does not have a default value,
 	// so assign it an initial value here
-	rp.sendDestination.destinationAccountSelector.SelectFirstValidAccount(rp.sendDestination.destinationWalletSelector.SelectedWallet())
+	_ = rp.sendDestination.destinationAccountSelector.SelectFirstValidAccount(rp.sendDestination.destinationWalletSelector.SelectedWallet())
 }
 
 func (rp *recipient) isShowSendToWallet() bool {

--- a/ui/page/send/recipient.go
+++ b/ui/page/send/recipient.go
@@ -100,7 +100,7 @@ func (rp *recipient) initializeAccountSelectors(sourceAccount *sharedW.Account) 
 		return rp.isAccountValid(sourceAccount, account)
 	})
 
-	rp.sendDestination.destinationAccountSelector.AccountSelected(func(selectedWallet *sharedW.Account) {
+	rp.sendDestination.destinationAccountSelector.AccountSelected(func(_ *sharedW.Account) {
 		rp.sendDestination.addressChanged()
 	})
 

--- a/ui/page/send/send_destination.go
+++ b/ui/page/send/send_destination.go
@@ -60,7 +60,7 @@ func (dst *destination) initDestinationWalletSelector(assetType libUtil.AssetTyp
 	dst.destinationAccountSelector = components.NewWalletAndAccountSelector(dst.Load).
 		EnableWatchOnlyWallets(true).
 		Title(values.String(values.StrAccount))
-	dst.destinationAccountSelector.SelectFirstValidAccount(dst.destinationWalletSelector.SelectedWallet())
+	_ = dst.destinationAccountSelector.SelectFirstValidAccount(dst.destinationWalletSelector.SelectedWallet())
 }
 
 // destinationAddress validates the destination address obtained from the provided

--- a/ui/page/settings/app_settings_page.go
+++ b/ui/page/settings/app_settings_page.go
@@ -588,7 +588,7 @@ func (pg *AppSettingsPage) HandleUserInteractions() {
 			sharedW.LogLevelConfigKey, libutils.DefaultLogLevel, preference.LogOptions).
 			Title(values.StrLogLevel).
 			UpdateValues(func(val string) {
-				logger.SetLogLevels(val)
+				_ = logger.SetLogLevels(val)
 			})
 		pg.ParentWindow().ShowModal(logLevelSelector)
 		break
@@ -642,7 +642,7 @@ func (pg *AppSettingsPage) HandleUserInteractions() {
 					EnableName(false).
 					PasswordHint(values.String(values.StrNewStartupPass)).
 					ConfirmPasswordHint(values.String(values.StrConfirmNewStartupPass)).
-					SetPositiveButtonCallback(func(walletName, newPassword string, m *modal.CreatePasswordModal) bool {
+					SetPositiveButtonCallback(func(_, newPassword string, m *modal.CreatePasswordModal) bool {
 						if !utils.StringNotEmpty(newPassword) {
 							m.SetError(values.String(values.StrErrPassEmpty))
 							return false
@@ -671,7 +671,7 @@ func (pg *AppSettingsPage) HandleUserInteractions() {
 				SetCancelable(false).
 				PasswordHint(values.String(values.StrStartupPassword)).
 				ConfirmPasswordHint(values.String(values.StrConfirmStartupPass)).
-				SetPositiveButtonCallback(func(walletName, password string, m *modal.CreatePasswordModal) bool {
+				SetPositiveButtonCallback(func(_, password string, m *modal.CreatePasswordModal) bool {
 					if !utils.StringNotEmpty(password) {
 						m.SetError(values.String(values.StrErrPassEmpty))
 						return false

--- a/ui/page/settings/app_settings_page.go
+++ b/ui/page/settings/app_settings_page.go
@@ -605,7 +605,7 @@ func (pg *AppSettingsPage) HandleUserInteractions() {
 			Body(values.String(values.StrResetDEXDataWarning)).
 			SetNegativeButtonText(values.String(values.StrCancel)).
 			SetPositiveButtonText(values.String(values.StrReset)).
-			SetPositiveButtonCallback(func(_ bool, in *modal.InfoModal) bool {
+			SetPositiveButtonCallback(func(_ bool, _ *modal.InfoModal) bool {
 				if pg.AssetsManager.DEXCInitialized() {
 					if err := pg.AssetsManager.DeleteDEXData(); err != nil {
 						return false
@@ -762,7 +762,7 @@ func (pg *AppSettingsPage) showDEXSeedModal() {
 				layout.Rigid(pg.copyDEXSeed.Layout),
 			)
 		}).
-		SetPositiveButtonCallback(func(isChecked bool, im *modal.InfoModal) bool {
+		SetPositiveButtonCallback(func(_ bool, _ *modal.InfoModal) bool {
 			utils.ZeroBytes(pg.dexSeed)
 			return true
 		})
@@ -795,7 +795,7 @@ func ChangeNetworkType(load *load.Load, windowNav app.WindowNavigator, newNetTyp
 		SetCancelable(true).
 		SetPositiveButtonText(values.String(values.StrYes)).
 		SetNegativeButtonText(values.String(values.StrCancel)).
-		SetPositiveButtonCallback(func(isChecked bool, confirmModal *modal.InfoModal) bool {
+		SetPositiveButtonCallback(func(_ bool, _ *modal.InfoModal) bool {
 			newAssetsManager, err := load.ChangeAssetsManagerNetwork(libutils.ToNetworkType(newNetType))
 			if err != nil {
 				errorModal := modal.NewErrorModal(load, err.Error(), modal.DefaultClickFunc())

--- a/ui/page/settings/license_page.go
+++ b/ui/page/settings/license_page.go
@@ -84,7 +84,7 @@ func (pg *LicensePage) layoutMobile(gtx layout.Context) layout.Dimensions {
 				pg.ParentNavigator().CloseCurrentPage()
 			},
 			Body: func(gtx C) D {
-				return pg.Theme.List(pg.pageContainer).Layout(gtx, 1, func(gtx C, i int) D {
+				return pg.Theme.List(pg.pageContainer).Layout(gtx, 1, func(gtx C, _ int) D {
 					return pg.Theme.Card().Layout(gtx, func(gtx C) D {
 						return layout.UniformInset(values.MarginPadding25).Layout(gtx, func(gtx C) D {
 							licenseText := pg.Theme.Body1(license)
@@ -126,7 +126,7 @@ func (pg *LicensePage) pageContentLayout(gtx layout.Context) layout.Dimensions {
 		gtx.Constraints.Min.X = gtx.Dp(unit.Dp(560))
 		gtx.Constraints.Max.X = gtx.Constraints.Min.X
 		gtx.Constraints.Min.Y = gtx.Constraints.Max.Y
-		return pg.Theme.List(pg.pageContainer).Layout(gtx, 1, func(gtx C, i int) D {
+		return pg.Theme.List(pg.pageContainer).Layout(gtx, 1, func(gtx C, _ int) D {
 			return pg.Theme.Card().Layout(gtx, func(gtx C) D {
 				return layout.UniformInset(values.MarginPadding16).Layout(gtx, func(gtx C) D {
 					licenseText := pg.Theme.Body1(license)

--- a/ui/page/settings/log_page.go
+++ b/ui/page/settings/log_page.go
@@ -145,7 +145,7 @@ func (pg *LogPage) layoutDesktop(gtx layout.Context) layout.Dimensions {
 			Body: func(gtx C) D {
 				gtx.Constraints.Min.X = gtx.Constraints.Max.X
 				gtx.Constraints.Min.Y = gtx.Constraints.Max.Y
-				return pg.Theme.List(pg.logList).Layout(gtx, 1, func(gtx C, index int) D {
+				return pg.Theme.List(pg.logList).Layout(gtx, 1, func(gtx C, _ int) D {
 					return layout.Inset{Right: values.MarginPadding2}.Layout(gtx, func(gtx C) D {
 						return pg.Theme.Card().Layout(gtx, func(gtx C) D {
 							return layout.UniformInset(values.MarginPadding15).Layout(gtx, func(gtx C) D {
@@ -190,7 +190,7 @@ func (pg *LogPage) layoutMobile(gtx layout.Context) layout.Dimensions {
 			Body: func(gtx C) D {
 				gtx.Constraints.Min.X = gtx.Constraints.Max.X
 				gtx.Constraints.Min.Y = gtx.Constraints.Max.Y
-				return pg.Theme.List(pg.logList).Layout(gtx, 1, func(gtx C, index int) D {
+				return pg.Theme.List(pg.logList).Layout(gtx, 1, func(gtx C, _ int) D {
 					return layout.Inset{Right: values.MarginPadding2}.Layout(gtx, func(gtx C) D {
 						return pg.Theme.Card().Layout(gtx, func(gtx C) D {
 							return layout.UniformInset(values.MarginPadding15).Layout(gtx, func(gtx C) D {

--- a/ui/page/settings/log_page.go
+++ b/ui/page/settings/log_page.go
@@ -222,6 +222,6 @@ func (pg *LogPage) HandleUserInteractions() {}
 // Part of the load.Page interface.
 func (pg *LogPage) OnNavigatedFrom() {
 	if pg.tail != nil {
-		pg.tail.Stop()
+		_ = pg.tail.Stop()
 	}
 }

--- a/ui/page/settings/statistics_page.go
+++ b/ui/page/settings/statistics_page.go
@@ -151,7 +151,7 @@ func (pg *StatPage) layoutStats(gtx C) D {
 		item(values.String(values.StrAccount)+"s", fmt.Sprintf("%d", len(pg.accounts.Accounts))),
 	}
 
-	return pg.Theme.List(pg.scrollbarList).Layout(gtx, 1, func(gtx C, i int) D {
+	return pg.Theme.List(pg.scrollbarList).Layout(gtx, 1, func(gtx C, _ int) D {
 		return layout.Inset{Right: values.MarginPadding2}.Layout(gtx, func(gtx C) D {
 			return card.Layout(gtx, func(gtx C) D {
 				return layout.Inset{Left: values.MarginPadding16}.Layout(gtx, func(gtx C) D {

--- a/ui/page/staking/stake_list.go
+++ b/ui/page/staking/stake_list.go
@@ -17,10 +17,10 @@ func (pg *Page) initTicketList() {
 
 func (pg *Page) listenForTxNotifications() {
 	txAndBlockNotificationListener := &sharedW.TxAndBlockNotificationListener{
-		OnTransaction: func(walletID int, transaction *sharedW.Transaction) {
+		OnTransaction: func(_ int, _ *sharedW.Transaction) {
 			pg.ParentWindow().Reload()
 		},
-		OnBlockAttached: func(walletID int, blockHeight int32) {
+		OnBlockAttached: func(_ int, _ int32) {
 			pg.ParentWindow().Reload()
 		},
 	}
@@ -56,7 +56,7 @@ func (pg *Page) ticketListLayout(gtx C) D {
 	margin24 := values.MarginPaddingTransform(pg.IsMobileView(), values.MarginPadding24)
 	textSize16 := values.TextSizeTransform(isMobile, values.TextSize16)
 	return pg.Theme.Card().Layout(gtx, func(gtx C) D {
-		return pg.scroll.List().Layout(gtx, 1, func(gtx C, i int) D {
+		return pg.scroll.List().Layout(gtx, 1, func(gtx C, _ int) D {
 			gtx.Constraints.Max.Y = ticketHeight
 			return layout.Inset{
 				Bottom: values.MarginPadding8,

--- a/ui/page/staking/stake_modal.go
+++ b/ui/page/staking/stake_modal.go
@@ -181,7 +181,7 @@ func (tb *ticketBuyerModal) canSave() bool {
 func (tb *ticketBuyerModal) initializeAccountSelector() {
 	tb.accountSelector = components.NewWalletAndAccountSelector(tb.Load).
 		Title(values.String(values.StrPurchasingAcct)).
-		AccountSelected(func(selectedAccount *sharedW.Account) {}).
+		AccountSelected(func(_ *sharedW.Account) {}).
 		AccountValidator(func(account *sharedW.Account) bool {
 			// Imported and watch only wallet accounts are invalid for sending
 			accountIsValid := account.Number != dcr.ImportedAccountNumber && !tb.dcrImpl.IsWatchingOnlyWallet()
@@ -194,7 +194,7 @@ func (tb *ticketBuyerModal) initializeAccountSelector() {
 
 			return accountIsValid
 		})
-	tb.accountSelector.SelectFirstValidAccount(tb.dcrImpl)
+	_ = tb.accountSelector.SelectFirstValidAccount(tb.dcrImpl)
 }
 
 func (tb *ticketBuyerModal) OnDismiss() {

--- a/ui/page/staking/stake_overview.go
+++ b/ui/page/staking/stake_overview.go
@@ -176,10 +176,10 @@ func (pg *Page) isTicketsPurchaseAllowed() bool {
 func (pg *Page) Layout(gtx C) D {
 	// If Tickets Purchase API is not allowed, display the overlay with the message.
 	isSyncingOrRescanning := !pg.dcrWallet.IsSynced() || pg.dcrWallet.IsRescanning()
-	overlay := layout.Stacked(func(gtx C) D { return D{} })
+	overlay := layout.Stacked(func(_ C) D { return D{} })
 	if !pg.isTicketsPurchaseAllowed() && !isSyncingOrRescanning {
 		gtxCopy := gtx
-		overlay = layout.Stacked(func(gtx C) D {
+		overlay = layout.Stacked(func(_ C) D {
 			str := values.StringF(values.StrNotAllowed, values.String(values.StrVsp))
 			return components.DisablePageWithOverlay(pg.Load, nil, gtxCopy, str, "", &pg.navToSettingsBtn)
 		})
@@ -189,7 +189,7 @@ func (pg *Page) Layout(gtx C) D {
 
 	mainChild := layout.Expanded(func(gtx C) D {
 		pg.scroll.OnScrollChangeListener(pg.ParentWindow())
-		return pg.Theme.List(pg.scrollContainer).Layout(gtx, 1, func(gtx C, i int) D {
+		return pg.Theme.List(pg.scrollContainer).Layout(gtx, 1, func(gtx C, _ int) D {
 			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 				layout.Rigid(pg.stakePriceSection),
 				layout.Rigid(pg.stakeStatisticsSection),
@@ -243,7 +243,7 @@ func (pg *Page) HandleUserInteractions() {
 				pg.ticketBuyerSettingsModal()
 			}
 		} else {
-			pg.dcrWallet.StopAutoTicketsPurchase()
+			_ = pg.dcrWallet.StopAutoTicketsPurchase()
 		}
 	}
 

--- a/ui/page/staking/utils.go
+++ b/ui/page/staking/utils.go
@@ -239,7 +239,7 @@ func ticketListLayout(gtx C, l *load.Load, wallet *dcr.Asset, ticket *transactio
 
 						return layout.Inset{
 							Right: values.MarginPadding16,
-						}.Layout(gtx, func(gtx C) D {
+						}.Layout(gtx, func(_ C) D {
 							return dims
 						})
 					}),

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -140,7 +140,7 @@ func (sp *startPage) OnNavigatedTo() {
 			sp.unlock()
 		} else {
 			sp.loading = true
-			go sp.openWalletsAndDisplayHomePage("")
+			go func() { _ = sp.openWalletsAndDisplayHomePage("") }()
 		}
 	} else {
 		sp.loading = false
@@ -506,7 +506,7 @@ func (sp *startPage) onBoardingScreensLayout(gtx C) D {
 												titleLabel.Font.Weight = font.Bold
 												return layout.Inset{Bottom: values.MarginPadding40}.Layout(gtx, titleLabel.Layout)
 											}),
-											layout.Rigid(func(gtc C) D {
+											layout.Rigid(func(gtx C) D {
 												gtx.Constraints.Max.Y = gtx.Dp(values.MarginPadding48)
 												return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
 													layout.Rigid(func(gtx C) D {

--- a/ui/page/transaction/transactions_page.go
+++ b/ui/page/transaction/transactions_page.go
@@ -499,7 +499,7 @@ func (pg *TransactionsPage) txListLayout(gtx C) D {
 						return layout.Center.Layout(gtx, pg.materialLoader.Layout)
 					}
 
-					return pg.scroll.List().Layout(gtx, 1, func(gtx C, i int) D {
+					return pg.scroll.List().Layout(gtx, 1, func(gtx C, _ int) D {
 						return layout.Inset{Right: values.MarginPadding2}.Layout(gtx, func(gtx C) D {
 							return card.Layout(gtx, func(gtx C) D {
 								padding := values.MarginPaddingTransform(pg.IsMobileView(), values.MarginPadding16)
@@ -626,7 +626,7 @@ func (pg *TransactionsPage) HandleUserInteractions() {
 			Body(values.String(values.StrExportTransactionsMsg)).
 			SetNegativeButtonText(values.String(values.StrCancel)).
 			SetPositiveButtonText(values.String(values.StrExport)).
-			SetPositiveButtonCallback(func(_ bool, im *modal.InfoModal) bool {
+			SetPositiveButtonCallback(func(_ bool, _ *modal.InfoModal) bool {
 				assets := []sharedW.Asset{pg.selectedWallet}
 				if pg.selectedWallet == nil {
 					assets = pg.assetWallets

--- a/ui/page/transaction/transactions_page.go
+++ b/ui/page/transaction/transactions_page.go
@@ -722,7 +722,7 @@ func exportTxs(assets []sharedW.Asset, fileName string) error {
 
 func (pg *TransactionsPage) listenForTxNotifications() {
 	txAndBlockNotificationListener := &sharedW.TxAndBlockNotificationListener{
-		OnTransaction: func(walletID int, transaction *sharedW.Transaction) {
+		OnTransaction: func(walletID int, _ *sharedW.Transaction) {
 			// Listen for all new txs but ignore ntfns if the wallet sending the
 			// ntfn is not the currently selected wallet.
 			if pg.selectedWallet != nil && pg.selectedWallet.GetWalletID() != walletID {

--- a/ui/page/wallet/single_wallet_main_page.go
+++ b/ui/page/wallet/single_wallet_main_page.go
@@ -792,8 +792,8 @@ func (swmp *SingleWalletMasterPage) showBackupInfo() {
 		}).
 		PositiveButtonStyle(swmp.Load.Theme.Color.Primary, swmp.Load.Theme.Color.InvText).
 		SetPositiveButtonText(values.String(values.StrBackupNow)).
-		SetPositiveButtonCallback(func(_ bool, m *modal.InfoModal) bool {
-			swmp.ParentNavigator().Display(seedbackup.NewBackupInstructionsPage(swmp.Load, swmp.selectedWallet, func(load *load.Load, navigator app.WindowNavigator) {
+		SetPositiveButtonCallback(func(_ bool, _ *modal.InfoModal) bool {
+			swmp.ParentNavigator().Display(seedbackup.NewBackupInstructionsPage(swmp.Load, swmp.selectedWallet, func(_ *load.Load, navigator app.WindowNavigator) {
 				swmp.selectedWallet.SaveUserConfigValue(sharedW.SeedBackupNotificationConfigKey, true)
 				swmp.ParentNavigator().ClosePagesAfter(MainPageID)
 			}))

--- a/ui/page/wallet/single_wallet_main_page.go
+++ b/ui/page/wallet/single_wallet_main_page.go
@@ -153,7 +153,9 @@ func (swmp *SingleWalletMasterPage) OnNavigatedTo() {
 			if swmp.AssetsManager.Politeia.IsSyncing() {
 				return
 			}
-			go swmp.AssetsManager.Politeia.Sync(context.TODO()) // TODO: Politeia should be given a ctx when initialized.
+			go func() {
+				_ = swmp.AssetsManager.Politeia.Sync(context.TODO()) // TODO: Politeia should be given a ctx when initialized.
+			}()
 		}
 	}
 }
@@ -438,7 +440,7 @@ func (swmp *SingleWalletMasterPage) Layout(gtx C) D {
 								privacy.SetupPrivacyPageID, accounts.AccountsPageID:
 								// Disable page functionality if a page is not synced or rescanning is in progress.
 								if swmp.selectedWallet.IsSyncing() {
-									syncInfo := components.NewWalletSyncInfo(swmp.Load, swmp.selectedWallet, func() {}, func(a sharedW.Asset) {})
+									syncInfo := components.NewWalletSyncInfo(swmp.Load, swmp.selectedWallet, func() {}, func(_ sharedW.Asset) {})
 									blockHeightFetched := values.StringF(values.StrBlockHeaderFetchedCount, swmp.selectedWallet.GetBestBlock().Height, syncInfo.FetchSyncProgress().HeadersToFetchOrScan)
 									title := values.String(values.StrFunctionUnavailable)
 									subTitle := fmt.Sprintf("%s "+blockHeightFetched, values.String(values.StrBlockHeaderFetched))
@@ -723,7 +725,7 @@ func (swmp *SingleWalletMasterPage) listenForNotifications() {
 	}
 
 	txAndBlockNotificationListener := &sharedW.TxAndBlockNotificationListener{
-		OnTransaction: func(walletID int, transaction *sharedW.Transaction) {
+		OnTransaction: func(_ int, transaction *sharedW.Transaction) {
 			swmp.updateBalance()
 			if swmp.AssetsManager.IsTransactionNotificationsOn() {
 				// TODO: SPV wallets only receive mempool tx ntfn for txs that
@@ -737,7 +739,7 @@ func (swmp *SingleWalletMasterPage) listenForNotifications() {
 		// OnBlockAttached is also called whenever OnTransactionConfirmed is
 		// called, so use OnBlockAttached. Also, OnTransactionConfirmed may be
 		// called multiple times whereas OnBlockAttached is only called once.
-		OnBlockAttached: func(walletID int, blockHeight int32) {
+		OnBlockAttached: func(_ int, _ int32) {
 			beep := swmp.selectedWallet.ReadBoolConfigValueForKey(sharedW.BeepNewBlocksConfigKey, false)
 			if beep {
 				err := beeep.Beep(5, 1)
@@ -793,7 +795,7 @@ func (swmp *SingleWalletMasterPage) showBackupInfo() {
 		PositiveButtonStyle(swmp.Load.Theme.Color.Primary, swmp.Load.Theme.Color.InvText).
 		SetPositiveButtonText(values.String(values.StrBackupNow)).
 		SetPositiveButtonCallback(func(_ bool, _ *modal.InfoModal) bool {
-			swmp.ParentNavigator().Display(seedbackup.NewBackupInstructionsPage(swmp.Load, swmp.selectedWallet, func(_ *load.Load, navigator app.WindowNavigator) {
+			swmp.ParentNavigator().Display(seedbackup.NewBackupInstructionsPage(swmp.Load, swmp.selectedWallet, func(_ *load.Load, _ app.WindowNavigator) {
 				swmp.selectedWallet.SaveUserConfigValue(sharedW.SeedBackupNotificationConfigKey, true)
 				swmp.ParentNavigator().ClosePagesAfter(MainPageID)
 			}))

--- a/ui/page/wallet/wallet_settings_page.go
+++ b/ui/page/wallet/wallet_settings_page.go
@@ -661,7 +661,7 @@ func (pg *SettingsPage) HandleUserInteractions() {
 
 	for pg.viewSeed.Clicked() {
 		currentPage := pg.ParentWindow().CurrentPageID()
-		pg.ParentWindow().Display(seedbackup.NewBackupInstructionsPage(pg.Load, pg.wallet, func(load *load.Load, navigator app.WindowNavigator) {
+		pg.ParentWindow().Display(seedbackup.NewBackupInstructionsPage(pg.Load, pg.wallet, func(_ *load.Load, navigator app.WindowNavigator) {
 			navigator.ClosePagesAfter(currentPage)
 		}))
 	}

--- a/ui/page/wallet/wallet_settings_page.go
+++ b/ui/page/wallet/wallet_settings_page.go
@@ -377,7 +377,7 @@ func (pg *SettingsPage) changeSpendingPasswordModal() {
 		EnableName(false).
 		PasswordHint(values.String(values.StrNewSpendingPassword)).
 		ConfirmPasswordHint(values.String(values.StrConfirmNewSpendingPassword)).
-		SetPositiveButtonCallback(func(walletName, newPassword string, m *modal.CreatePasswordModal) bool {
+		SetPositiveButtonCallback(func(_, newPassword string, m *modal.CreatePasswordModal) bool {
 			err := pg.wallet.ChangePrivatePassphraseForWallet(currentPassword,
 				newPassword, sharedW.PassphraseTypePass)
 			if err != nil {
@@ -637,7 +637,7 @@ func (pg *SettingsPage) showWarningModalDialog(title, msg string) {
 		SetNegativeButtonText(values.String(values.StrCancel)).
 		PositiveButtonStyle(pg.Theme.Color.Surface, pg.Theme.Color.Danger).
 		SetPositiveButtonText(values.String(values.StrRemove)).
-		SetPositiveButtonCallback(func(isChecked bool, im *modal.InfoModal) bool {
+		SetPositiveButtonCallback(func(_ bool, _ *modal.InfoModal) bool {
 			// TODO: Check if deletion happened successfully
 			// Since only one peer is available at time, the single peer key can
 			// be set to empty string to delete its entry..

--- a/ui/renderers/color.go
+++ b/ui/renderers/color.go
@@ -55,12 +55,12 @@ func parseHex(colorCode string) (color.NRGBA, bool) {
 
 	var r, g, b uint8
 	if len(colorCode) == 4 {
-		fmt.Sscanf(colorCode, hexShortFormat, &r, &g, &b)
+		_, _ = fmt.Sscanf(colorCode, hexShortFormat, &r, &g, &b)
 		r *= hexToRGBFactor
 		g *= hexToRGBFactor
 		b *= hexToRGBFactor
 	} else {
-		fmt.Sscanf(colorCode, hexFormat, &r, &g, &b)
+		_, _ = fmt.Sscanf(colorCode, hexFormat, &r, &g, &b)
 	}
 
 	return color.NRGBA{R: r, G: g, B: b, A: 255}, true


### PR DESCRIPTION
Due to caching the golangci linter is failing during the environment preparation phase:

```
  Error: /usr/bin/tar: ../../../go/pkg/mod/github.com/h2non/go-is-svg@v0.0.0-20160927212452-35e8c4b0612c/svg.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/github.com/pkg/errors@v0.9.1/format_test.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/github.com/pkg/errors@v0.9.1/json_test.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/github.com/pkg/errors@v0.9.1/example_test.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/github.com/pkg/errors@v0.9.1/errors.go: Cannot open: File exists
  Error: /usr/bin/tar: ../../../go/pkg/mod/github.com/pkg/errors@v0.9.1/go113.go: Cannot open: File exists
...
```

The solution adapted here has been copied from: https://github.com/thought-machine/please/pull/3162