### PR TITLE
Fix Inaccurate Sync Progress Report Tracking

### DIFF
--- a/libwallet/assets/btc/rescan.go
+++ b/libwallet/assets/btc/rescan.go
@@ -2,7 +2,6 @@ package btc
 
 import (
 	"fmt"
-	"math"
 	"sync/atomic"
 	"time"
 
@@ -355,16 +354,16 @@ func (asset *Asset) updateRescanProgress(height int32) {
 		WalletID:            asset.ID,
 	}
 
-	elapsedRescanTime := time.Now().Unix() - asset.syncData.rescanStartTime.Unix()
+	elapsedRescanTime := time.Since(asset.syncData.rescanStartTime)
 	rescanRate := headersFetchedSoFar / float64(rescanProgressReport.TotalHeadersToScan)
 
 	rescanProgressReport.RescanProgress = int32((headersFetchedSoFar * 100) / allHeadersToFetch)
-	estimatedTotalRescanTime := int64(math.Round(float64(elapsedRescanTime) / rescanRate))
-	rescanProgressReport.RescanTimeRemaining = estimatedTotalRescanTime - elapsedRescanTime
+	estimatedTotalRescanTime := float64(elapsedRescanTime) / rescanRate
+	rescanProgressReport.RescanTimeRemaining = secondsToDuration(estimatedTotalRescanTime) - elapsedRescanTime
 
 	rescanProgressReport.GeneralSyncProgress = &sharedW.GeneralSyncProgress{
-		TotalSyncProgress:         rescanProgressReport.RescanProgress,
-		TotalTimeRemainingSeconds: rescanProgressReport.RescanTimeRemaining,
+		TotalSyncProgress:  rescanProgressReport.RescanProgress,
+		TotalTimeRemaining: rescanProgressReport.RescanTimeRemaining,
 	}
 
 	if asset.blocksRescanProgressListener != nil {

--- a/libwallet/assets/btc/sync.go
+++ b/libwallet/assets/btc/sync.go
@@ -32,11 +32,19 @@ type SyncData struct {
 	syncstarted         uint32
 	chainServiceStopped bool
 
-	syncing           bool
-	synced            bool
-	isRescan          bool
-	rescanStartTime   time.Time
-	rescanStartHeight *int32
+	syncing  bool
+	synced   bool
+	isRescan bool
+
+	// Syncing fields
+	syncStartTime   time.Time // syncStartTime tracks the time when syncing starts.
+	syncStartHeight *int32    // syncStartHeight tracks the height when syncing starts.
+
+	// Rescanning fields
+	// NB: Rescanning and syncing can happen simultaneously thus the need to
+	// have separated fields
+	rescanStartTime   time.Time // rescanStartTime tracks the time when syncing starts.
+	rescanStartHeight *int32    // rescanStartHeight tracks the height when syncing starts.
 
 	wg sync.WaitGroup
 
@@ -49,11 +57,6 @@ type SyncData struct {
 // reading/writing of properties of this struct are protected by syncData.mu.
 type activeSyncData struct {
 	syncStage utils.SyncStage
-
-	cfiltersFetchProgress    sharedW.CFiltersFetchProgressReport
-	headersFetchProgress     sharedW.HeadersFetchProgressReport
-	addressDiscoveryProgress sharedW.AddressDiscoveryProgressReport
-	headersRescanProgress    sharedW.HeadersRescanProgressReport
 }
 
 const (
@@ -70,33 +73,10 @@ const (
 )
 
 func (asset *Asset) initSyncProgressData() {
-	cfiltersFetchProgress := sharedW.CFiltersFetchProgressReport{
-		GeneralSyncProgress:       &sharedW.GeneralSyncProgress{},
-		StartCFiltersHeight:       -1,
-		CfiltersFetchTimeSpent:    0,
-		TotalFetchedCFiltersCount: 0,
-	}
-
-	headersFetchProgress := sharedW.HeadersFetchProgressReport{
-		GeneralSyncProgress:   &sharedW.GeneralSyncProgress{},
-		HeadersFetchTimeSpent: -1,
-	}
-
-	addressDiscoveryProgress := sharedW.AddressDiscoveryProgressReport{
-		GeneralSyncProgress:     &sharedW.GeneralSyncProgress{},
-		TotalDiscoveryTimeSpent: -1,
-	}
-
-	headersRescanProgress := sharedW.HeadersRescanProgressReport{}
-	headersRescanProgress.GeneralSyncProgress = &sharedW.GeneralSyncProgress{}
-
 	asset.syncData.mu.Lock()
-	asset.syncData.activeSyncData = &activeSyncData{
-		cfiltersFetchProgress:    cfiltersFetchProgress,
-		headersFetchProgress:     headersFetchProgress,
-		addressDiscoveryProgress: addressDiscoveryProgress,
-		headersRescanProgress:    headersRescanProgress,
-	}
+	asset.syncData.activeSyncData = &activeSyncData{}
+	asset.syncData.syncStartHeight = nil
+	asset.syncData.syncStartTime = time.Time{}
 	asset.syncData.mu.Unlock()
 }
 
@@ -148,10 +128,10 @@ func (asset *Asset) updateSyncProgress(rawBlockHeight int32) {
 	asset.bestServerPeerBlockHeight()
 
 	// initial set up when sync begins.
-	if asset.syncData.headersFetchProgress.StartHeaderHeight == nil {
+	if asset.syncData.syncStartHeight == nil {
 		asset.syncData.syncStage = utils.HeadersFetchSyncStage
-		asset.syncData.headersFetchProgress.BeginFetchTimeStamp = time.Now()
-		asset.syncData.headersFetchProgress.StartHeaderHeight = &rawBlockHeight
+		asset.syncData.syncStartTime = time.Now()
+		asset.syncData.syncStartHeight = &rawBlockHeight
 
 		if asset.syncData.bestBlockheight != rawBlockHeight {
 			asset.syncData.mu.Unlock()
@@ -159,14 +139,20 @@ func (asset *Asset) updateSyncProgress(rawBlockHeight int32) {
 			return
 		}
 	}
-	log.Infof("Current sync progress update is on block %v, target sync block is %v", rawBlockHeight, asset.syncData.bestBlockheight)
 
-	timeSpentSoFar := time.Since(asset.syncData.headersFetchProgress.BeginFetchTimeStamp).Seconds()
+	startTime := asset.syncData.syncStartTime
+	startheight := *asset.syncData.syncStartHeight
+	asset.syncData.mu.Unlock()
+
+	log.Infof("Current sync progress update is on block %v, target sync block is %v",
+		rawBlockHeight, asset.syncData.bestBlockheight)
+
+	timeSpentSoFar := time.Since(startTime).Seconds()
 	if timeSpentSoFar < 1 {
 		timeSpentSoFar = 1
 	}
 
-	headersFetchedSoFar := float64(rawBlockHeight - *asset.syncData.headersFetchProgress.StartHeaderHeight)
+	headersFetchedSoFar := float64(rawBlockHeight - startheight)
 	if headersFetchedSoFar < 1 {
 		headersFetchedSoFar = 1
 	}
@@ -178,21 +164,23 @@ func (asset *Asset) updateSyncProgress(rawBlockHeight int32) {
 
 	allHeadersToFetch := headersFetchedSoFar + remainingHeaders
 	timeRemaining := secondsToDuration(((timeSpentSoFar * remainingHeaders) / headersFetchedSoFar))
+	syncProgress := int32((headersFetchedSoFar * 100) / allHeadersToFetch)
 
-	asset.syncData.headersFetchProgress.TotalHeadersToFetch = asset.syncData.bestBlockheight
-	asset.syncData.headersFetchProgress.HeadersFetchProgress = int32((headersFetchedSoFar * 100) / allHeadersToFetch)
-	asset.syncData.headersFetchProgress.TotalSyncProgress = asset.syncData.headersFetchProgress.HeadersFetchProgress
-	asset.syncData.headersFetchProgress.TotalTimeRemaining = timeRemaining
-	asset.syncData.mu.Unlock()
+	headersFetchProgress := &sharedW.HeadersFetchProgressReport{
+		GeneralSyncProgress: &sharedW.GeneralSyncProgress{
+			TotalSyncProgress:  syncProgress,
+			TotalTimeRemaining: timeRemaining,
+		},
+	}
+	headersFetchProgress.TotalHeadersToFetch = asset.syncData.bestBlockheight
+	headersFetchProgress.HeadersFetchProgress = syncProgress
 
 	// publish the sync progress results to all listeners.
-	asset.syncData.mu.RLock()
 	for _, listener := range asset.syncData.syncProgressListeners {
 		if listener.OnHeadersFetchProgress != nil {
-			listener.OnHeadersFetchProgress(&asset.syncData.headersFetchProgress)
+			listener.OnHeadersFetchProgress(headersFetchProgress)
 		}
 	}
-	asset.syncData.mu.RUnlock()
 }
 
 func (asset *Asset) publishHeadersFetchComplete() {

--- a/libwallet/assets/btc/sync.go
+++ b/libwallet/assets/btc/sync.go
@@ -71,11 +71,10 @@ const (
 
 func (asset *Asset) initSyncProgressData() {
 	cfiltersFetchProgress := sharedW.CFiltersFetchProgressReport{
-		GeneralSyncProgress:         &sharedW.GeneralSyncProgress{},
-		BeginFetchCFiltersTimeStamp: 0,
-		StartCFiltersHeight:         -1,
-		CfiltersFetchTimeSpent:      0,
-		TotalFetchedCFiltersCount:   0,
+		GeneralSyncProgress:       &sharedW.GeneralSyncProgress{},
+		StartCFiltersHeight:       -1,
+		CfiltersFetchTimeSpent:    0,
+		TotalFetchedCFiltersCount: 0,
 	}
 
 	headersFetchProgress := sharedW.HeadersFetchProgressReport{
@@ -84,9 +83,8 @@ func (asset *Asset) initSyncProgressData() {
 	}
 
 	addressDiscoveryProgress := sharedW.AddressDiscoveryProgressReport{
-		GeneralSyncProgress:       &sharedW.GeneralSyncProgress{},
-		AddressDiscoveryStartTime: -1,
-		TotalDiscoveryTimeSpent:   -1,
+		GeneralSyncProgress:     &sharedW.GeneralSyncProgress{},
+		TotalDiscoveryTimeSpent: -1,
 	}
 
 	headersRescanProgress := sharedW.HeadersRescanProgressReport{}
@@ -179,11 +177,12 @@ func (asset *Asset) updateSyncProgress(rawBlockHeight int32) {
 	}
 
 	allHeadersToFetch := headersFetchedSoFar + remainingHeaders
+	timeRemaining := secondsToDuration(((timeSpentSoFar * remainingHeaders) / headersFetchedSoFar))
 
 	asset.syncData.headersFetchProgress.TotalHeadersToFetch = asset.syncData.bestBlockheight
 	asset.syncData.headersFetchProgress.HeadersFetchProgress = int32((headersFetchedSoFar * 100) / allHeadersToFetch)
-	asset.syncData.headersFetchProgress.GeneralSyncProgress.TotalSyncProgress = asset.syncData.headersFetchProgress.HeadersFetchProgress
-	asset.syncData.headersFetchProgress.GeneralSyncProgress.TotalTimeRemainingSeconds = int64((timeSpentSoFar * remainingHeaders) / headersFetchedSoFar)
+	asset.syncData.headersFetchProgress.TotalSyncProgress = asset.syncData.headersFetchProgress.HeadersFetchProgress
+	asset.syncData.headersFetchProgress.TotalTimeRemaining = timeRemaining
 	asset.syncData.mu.Unlock()
 
 	// publish the sync progress results to all listeners.

--- a/libwallet/assets/btc/sync.go
+++ b/libwallet/assets/btc/sync.go
@@ -354,6 +354,8 @@ func (asset *Asset) CancelSync() {
 	asset.syncData.wg.Add(1)
 	go asset.stopSync()
 
+	asset.syncData.wg.Wait() // Wait until the stopSync() goroutine ends.
+
 	// Indicate that the sync shutdown process is fully complete.
 	asset.EndSyncShuttingDown()
 

--- a/libwallet/assets/btc/sync.go
+++ b/libwallet/assets/btc/sync.go
@@ -171,9 +171,9 @@ func (asset *Asset) updateSyncProgress(rawBlockHeight int32) {
 			TotalSyncProgress:  syncProgress,
 			TotalTimeRemaining: timeRemaining,
 		},
+		TotalHeadersToFetch:  asset.syncData.bestBlockheight,
+		HeadersFetchProgress: syncProgress,
 	}
-	headersFetchProgress.TotalHeadersToFetch = asset.syncData.bestBlockheight
-	headersFetchProgress.HeadersFetchProgress = syncProgress
 
 	// publish the sync progress results to all listeners.
 	for _, listener := range asset.syncData.syncProgressListeners {

--- a/libwallet/assets/btc/sync.go
+++ b/libwallet/assets/btc/sync.go
@@ -32,12 +32,11 @@ type SyncData struct {
 	syncstarted         uint32
 	chainServiceStopped bool
 
-	syncing            bool
-	synced             bool
-	isRescan           bool
-	rescanStartTime    time.Time
-	rescanStartHeight  *int32
-	isSyncShuttingDown bool
+	syncing           bool
+	synced            bool
+	isRescan          bool
+	rescanStartTime   time.Time
+	rescanStartHeight *int32
 
 	wg sync.WaitGroup
 
@@ -368,6 +367,9 @@ func (asset *Asset) CancelSync() {
 	asset.syncData.wg.Add(1)
 	go asset.stopSync()
 
+	// Indicate that the sync shutdown process is fully complete.
+	asset.EndSyncShuttingDown()
+
 	log.Infof("(%v) SPV wallet closed", asset.GetWalletName())
 }
 
@@ -375,12 +377,10 @@ func (asset *Asset) CancelSync() {
 // It does not stop the chain service which is intentionally left out since once
 // stopped it can't be restarted easily.
 func (asset *Asset) stopSync() {
-	asset.syncData.isSyncShuttingDown = true
 	loadedAsset := asset.Internal().BTC
 	if asset.WalletOpened() {
 		// If wallet shutdown is in progress ignore the current request to shutdown.
 		if loadedAsset.ShuttingDown() {
-			asset.syncData.isSyncShuttingDown = false
 			asset.syncData.wg.Done()
 			return
 		}
@@ -417,7 +417,6 @@ func (asset *Asset) stopSync() {
 	// context but we do it early to avoid panics that happen after db has been
 	// closed but some goroutines still interact with the db.
 	asset.cancelSync()
-	asset.syncData.isSyncShuttingDown = false
 
 	log.Infof("Stopping (%s) wallet and its neutrino interface", asset.GetWalletName())
 

--- a/libwallet/assets/btc/utils.go
+++ b/libwallet/assets/btc/utils.go
@@ -3,6 +3,7 @@ package btc
 import (
 	"encoding/binary"
 	"fmt"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
@@ -138,4 +139,8 @@ func decodeAddress(s string, params *chaincfg.Params) (btcutil.Address, error) {
 			addr, params.Name)
 	}
 	return addr, nil
+}
+
+func secondsToDuration(secs float64) time.Duration {
+	return time.Duration(secs) * time.Second
 }

--- a/libwallet/assets/btc/wallet.go
+++ b/libwallet/assets/btc/wallet.go
@@ -318,14 +318,6 @@ func (asset *Asset) IsSyncing() bool {
 	return asset.syncData.syncing
 }
 
-// IsSyncShuttingDown returns true if the wallet is shutting down.
-func (asset *Asset) IsSyncShuttingDown() bool {
-	asset.syncData.mu.RLock()
-	defer asset.syncData.mu.RUnlock()
-
-	return asset.syncData.isSyncShuttingDown
-}
-
 // ConnectedPeers returns the number of connected peers.
 func (asset *Asset) ConnectedPeers() int32 {
 	// Calling CS.ConnectedCount() before the first sync is

--- a/libwallet/assets/dcr/rescan.go
+++ b/libwallet/assets/dcr/rescan.go
@@ -49,7 +49,7 @@ func (asset *Asset) RescanBlocksFromHeight(startHeight int32) error {
 
 		rescanStartTime := time.Now()
 
-		for p := range progress {
+		for p := range progress { // listen to the progress channel
 			if p.Err != nil {
 				log.Error(p.Err)
 				if asset.blocksRescanProgressListener != nil {
@@ -68,12 +68,12 @@ func (asset *Asset) RescanBlocksFromHeight(startHeight int32) error {
 			rescanRate := float64(p.ScannedThrough) / float64(rescanProgressReport.TotalHeadersToScan)
 
 			rescanProgressReport.RescanProgress = int32(math.Round(rescanRate * 100))
-			estimatedTotalRescanTime := int64(math.Round(elapsedRescanTime / rescanRate))
-			rescanProgressReport.RescanTimeRemaining = estimatedTotalRescanTime - int64(elapsedRescanTime)
+			estimatedTotalRescanTime := elapsedRescanTime / rescanRate
+			rescanProgressReport.RescanTimeRemaining = secondsToDuration(estimatedTotalRescanTime - elapsedRescanTime)
 
 			rescanProgressReport.GeneralSyncProgress = &sharedW.GeneralSyncProgress{
-				TotalSyncProgress:         rescanProgressReport.RescanProgress,
-				TotalTimeRemainingSeconds: rescanProgressReport.RescanTimeRemaining,
+				TotalSyncProgress:  rescanProgressReport.RescanProgress,
+				TotalTimeRemaining: rescanProgressReport.RescanTimeRemaining,
 			}
 
 			if asset.blocksRescanProgressListener != nil {

--- a/libwallet/assets/dcr/rescan.go
+++ b/libwallet/assets/dcr/rescan.go
@@ -47,7 +47,7 @@ func (asset *Asset) RescanBlocksFromHeight(startHeight int32) error {
 		progress := make(chan w.RescanProgress, 1)
 		go asset.Internal().DCR.RescanProgressFromHeight(ctx, netBackend, startHeight, progress)
 
-		rescanStartTime := time.Now().Unix()
+		rescanStartTime := time.Now()
 
 		for p := range progress {
 			if p.Err != nil {
@@ -64,12 +64,12 @@ func (asset *Asset) RescanBlocksFromHeight(startHeight int32) error {
 				WalletID:            asset.ID,
 			}
 
-			elapsedRescanTime := time.Now().Unix() - rescanStartTime
+			elapsedRescanTime := time.Since(rescanStartTime).Seconds()
 			rescanRate := float64(p.ScannedThrough) / float64(rescanProgressReport.TotalHeadersToScan)
 
 			rescanProgressReport.RescanProgress = int32(math.Round(rescanRate * 100))
-			estimatedTotalRescanTime := int64(math.Round(float64(elapsedRescanTime) / rescanRate))
-			rescanProgressReport.RescanTimeRemaining = estimatedTotalRescanTime - elapsedRescanTime
+			estimatedTotalRescanTime := int64(math.Round(elapsedRescanTime / rescanRate))
+			rescanProgressReport.RescanTimeRemaining = estimatedTotalRescanTime - int64(elapsedRescanTime)
 
 			rescanProgressReport.GeneralSyncProgress = &sharedW.GeneralSyncProgress{
 				TotalSyncProgress:         rescanProgressReport.RescanProgress,

--- a/libwallet/assets/dcr/sync.go
+++ b/libwallet/assets/dcr/sync.go
@@ -81,9 +81,9 @@ type activeSyncData struct {
 	// genSyncProgress tracks progress of the current sync running.
 	genSyncProgress *sharedW.GeneralSyncProgress
 
-	totalInactiveSeconds time.Duration
-	isRescanning         bool
-	isAddressDiscovery   bool
+	totalInactiveDuration time.Duration
+	isRescanning          bool
+	isAddressDiscovery    bool
 }
 
 const (
@@ -147,7 +147,7 @@ func (asset *Asset) EnableSyncLogs() {
 	asset.syncData.mu.Unlock()
 }
 
-func (asset *Asset) SyncInactiveForPeriod(totalInactiveSeconds time.Duration) {
+func (asset *Asset) SyncInactiveForPeriod(totalInactiveDuration time.Duration) {
 	asset.syncData.mu.Lock()
 	defer asset.syncData.mu.Unlock()
 
@@ -156,10 +156,10 @@ func (asset *Asset) SyncInactiveForPeriod(totalInactiveSeconds time.Duration) {
 		return
 	}
 
-	asset.syncData.totalInactiveSeconds += totalInactiveSeconds
+	asset.syncData.totalInactiveDuration += totalInactiveDuration
 	if asset.syncData.numOfConnectedPeers == 0 {
 		// assume it would take another 60 seconds to reconnect to peers
-		asset.syncData.totalInactiveSeconds += secondsToDuration(60.0)
+		asset.syncData.totalInactiveDuration += secondsToDuration(60.0)
 	}
 }
 

--- a/libwallet/assets/dcr/sync.go
+++ b/libwallet/assets/dcr/sync.go
@@ -325,7 +325,7 @@ func (asset *Asset) CancelSync() {
 	asset.syncData.mu.RUnlock()
 
 	if cancelSync != nil {
-		log.Info("Canceling sync. May take a while for sync to fully cancel.")
+		log.Info("Cancelling sync. May take a while for sync to fully cancel.")
 
 		// Stop running cspp mixers
 		if asset.IsAccountMixerActive() {
@@ -343,9 +343,12 @@ func (asset *Asset) CancelSync() {
 
 		// When sync terminates and syncer.Run returns, we will get notified on this channel.
 		<-asset.syncData.syncCanceled
-
-		log.Info("Sync fully canceled.")
 	}
+
+	// Indicate that the sync shutdown process is fully complete.
+	asset.EndSyncShuttingDown()
+
+	log.Info("Sync fully cancelled.")
 }
 
 func (asset *Asset) IsWaiting() bool {
@@ -366,11 +369,6 @@ func (asset *Asset) IsConnectedToDecredNetwork() bool {
 
 func (asset *Asset) IsSynced() bool {
 	return asset.syncData.isSynced()
-}
-
-func (asset *Asset) IsSyncShuttingDown() bool {
-	// TODO: implement for DCR if synchronous shutdown takes a long time
-	return false
 }
 
 func (asset *Asset) CurrentSyncStage() utils.SyncStage {

--- a/libwallet/assets/dcr/sync.go
+++ b/libwallet/assets/dcr/sync.go
@@ -210,8 +210,6 @@ func (asset *Asset) SpvSync() error {
 		syncer.SetPersistentPeers(validPeerAddresses)
 	}
 
-	syncer.GetRemotePeers()
-
 	ctx, cancel := asset.ShutdownContextWithCancel()
 
 	asset.syncData.mu.Lock()

--- a/libwallet/assets/dcr/syncnotification.go
+++ b/libwallet/assets/dcr/syncnotification.go
@@ -64,7 +64,7 @@ func (asset *Asset) fetchCFiltersStarted() {
 	asset.syncData.mu.Unlock()
 
 	if showLogs {
-		log.Infof("Step 1 of 3 - fetching %d block headers.")
+		log.Info("Step 1 of 3 - fetching fetchCFiltersStarted.")
 	}
 }
 
@@ -205,7 +205,7 @@ func (asset *Asset) fetchHeadersProgress(lastFetchedHeaderHeight int32, _ int64)
 		return
 	}
 
-	// If the last fetchec block is greater than the current best preset best
+	// If the last fetched block is greater than the current best preset best
 	// block, the previous attempt failed. Make another attempt now!
 	if lastFetchedHeaderHeight > peersBestBlock {
 		ctx, _ := asset.ShutdownContextWithCancel()
@@ -305,7 +305,7 @@ func (asset *Asset) discoverAddressesStarted() {
 	}
 
 	asset.syncData.mu.RLock()
-	addressDiscoveryAlreadyStarted := asset.syncData.scanStartTime.IsZero()
+	addressDiscoveryAlreadyStarted := !asset.syncData.scanStartTime.IsZero()
 	asset.syncData.mu.RUnlock()
 
 	if addressDiscoveryAlreadyStarted {
@@ -327,8 +327,9 @@ func (asset *Asset) discoverAddressesStarted() {
 }
 
 func (asset *Asset) updateAddressDiscoveryProgress() {
-	// use ticker to calculate and broadcast address discovery progress every second
-	everySecondTicker := time.NewTicker(1 * time.Second)
+	// use ticker to calculate and broadcast address discovery progress
+	// every 5 seconds.
+	everySecondTicker := time.NewTicker(5 * time.Second)
 
 	asset.syncData.mu.Lock()
 	totalHeadersFetchTime := asset.syncData.headersScanTimeSpent.Seconds()

--- a/libwallet/assets/dcr/utils.go
+++ b/libwallet/assets/dcr/utils.go
@@ -3,6 +3,7 @@ package dcr
 import (
 	"fmt"
 	"math"
+	"time"
 
 	sharedW "github.com/crypto-power/cryptopower/libwallet/assets/wallet"
 	"github.com/decred/dcrd/dcrutil/v4"
@@ -38,12 +39,16 @@ func AmountAtom(f float64) int64 {
 	return int64(amount)
 }
 
-func calculateTotalTimeRemaining(timeRemainingInSeconds int64) string {
+func calculateTotalTimeRemaining(timeRemainingInSeconds time.Duration) string {
 	minutes := timeRemainingInSeconds / 60
 	if minutes > 0 {
 		return fmt.Sprintf("%d min", minutes)
 	}
 	return fmt.Sprintf("%d sec", timeRemainingInSeconds)
+}
+
+func secondsToDuration(secs float64) time.Duration {
+	return time.Duration(secs) * time.Second
 }
 
 func roundUp(n float64) int32 {

--- a/libwallet/assets/ltc/rescan.go
+++ b/libwallet/assets/ltc/rescan.go
@@ -2,7 +2,6 @@ package ltc
 
 import (
 	"fmt"
-	"math"
 	"sync/atomic"
 	"time"
 
@@ -310,16 +309,16 @@ func (asset *Asset) updateRescanProgress(height int32) {
 		WalletID:            asset.ID,
 	}
 
-	elapsedRescanTime := time.Now().Unix() - asset.syncData.rescanStartTime.Unix()
+	elapsedRescanTime := time.Since(asset.syncData.rescanStartTime).Seconds()
 	rescanRate := headersFetchedSoFar / float64(rescanProgressReport.TotalHeadersToScan)
 
 	rescanProgressReport.RescanProgress = int32((headersFetchedSoFar * 100) / allHeadersToFetch)
-	estimatedTotalRescanTime := int64(math.Round(float64(elapsedRescanTime) / rescanRate))
-	rescanProgressReport.RescanTimeRemaining = estimatedTotalRescanTime - elapsedRescanTime
+	estimatedTotalRescanTime := elapsedRescanTime / rescanRate
+	rescanProgressReport.RescanTimeRemaining = secondsToDuration(estimatedTotalRescanTime - elapsedRescanTime)
 
 	rescanProgressReport.GeneralSyncProgress = &sharedW.GeneralSyncProgress{
-		TotalSyncProgress:         rescanProgressReport.RescanProgress,
-		TotalTimeRemainingSeconds: rescanProgressReport.RescanTimeRemaining,
+		TotalSyncProgress:  rescanProgressReport.RescanProgress,
+		TotalTimeRemaining: rescanProgressReport.RescanTimeRemaining,
 	}
 
 	if asset.blocksRescanProgressListener != nil {

--- a/libwallet/assets/ltc/sync.go
+++ b/libwallet/assets/ltc/sync.go
@@ -375,6 +375,8 @@ func (asset *Asset) CancelSync() {
 	asset.syncData.wg.Add(1)
 	go asset.stopSync()
 
+	asset.syncData.wg.Wait() // Wait until the stopSync() goroutine ends.
+
 	// Indicate that the sync shutdown process is fully complete.
 	asset.EndSyncShuttingDown()
 

--- a/libwallet/assets/ltc/sync.go
+++ b/libwallet/assets/ltc/sync.go
@@ -77,11 +77,10 @@ const (
 
 func (asset *Asset) initSyncProgressData() {
 	cfiltersFetchProgress := sharedW.CFiltersFetchProgressReport{
-		GeneralSyncProgress:         &sharedW.GeneralSyncProgress{},
-		BeginFetchCFiltersTimeStamp: 0,
-		StartCFiltersHeight:         -1,
-		CfiltersFetchTimeSpent:      0,
-		TotalFetchedCFiltersCount:   0,
+		GeneralSyncProgress:       &sharedW.GeneralSyncProgress{},
+		StartCFiltersHeight:       -1,
+		CfiltersFetchTimeSpent:    0,
+		TotalFetchedCFiltersCount: 0,
 	}
 
 	headersFetchProgress := sharedW.HeadersFetchProgressReport{
@@ -90,9 +89,8 @@ func (asset *Asset) initSyncProgressData() {
 	}
 
 	addressDiscoveryProgress := sharedW.AddressDiscoveryProgressReport{
-		GeneralSyncProgress:       &sharedW.GeneralSyncProgress{},
-		AddressDiscoveryStartTime: -1,
-		TotalDiscoveryTimeSpent:   -1,
+		GeneralSyncProgress:     &sharedW.GeneralSyncProgress{},
+		TotalDiscoveryTimeSpent: -1,
 	}
 
 	headersRescanProgress := sharedW.HeadersRescanProgressReport{}
@@ -185,11 +183,12 @@ func (asset *Asset) updateSyncProgress(rawBlockHeight int32) {
 	}
 
 	allHeadersToFetch := headersFetchedSoFar + remainingHeaders
+	timeRemaining := secondsToDuration(((timeSpentSoFar * remainingHeaders) / headersFetchedSoFar))
 
 	asset.syncData.headersFetchProgress.TotalHeadersToFetch = asset.syncData.bestBlockHeight
 	asset.syncData.headersFetchProgress.HeadersFetchProgress = int32((headersFetchedSoFar * 100) / allHeadersToFetch)
-	asset.syncData.headersFetchProgress.GeneralSyncProgress.TotalSyncProgress = asset.syncData.headersFetchProgress.HeadersFetchProgress
-	asset.syncData.headersFetchProgress.GeneralSyncProgress.TotalTimeRemainingSeconds = int64((timeSpentSoFar * remainingHeaders) / headersFetchedSoFar)
+	asset.syncData.headersFetchProgress.TotalSyncProgress = asset.syncData.headersFetchProgress.HeadersFetchProgress
+	asset.syncData.headersFetchProgress.TotalTimeRemaining = timeRemaining
 	asset.syncData.mu.Unlock()
 
 	// publish the sync progress results to all listeners.

--- a/libwallet/assets/ltc/sync.go
+++ b/libwallet/assets/ltc/sync.go
@@ -36,11 +36,20 @@ type SyncData struct {
 	syncstarted         uint32
 	chainServiceStopped bool
 
-	syncing           bool
-	synced            bool
-	isRescan          bool
-	rescanStartTime   time.Time
-	rescanStartHeight *int32
+	syncing  bool
+	synced   bool
+	isRescan bool
+
+	// Syncing fields
+	syncStartTime   time.Time // syncStartTime tracks the time when syncing starts.
+	syncStartHeight *int32    // syncStartHeight tracks the height when syncing starts.
+
+	// Rescanning fields
+	// NB: Rescanning and syncing can happen simultaneously thus the need to
+	// have separated fields
+	rescanStartTime   time.Time // rescanStartTime tracks the time when syncing starts.
+	rescanStartHeight *int32    // rescanStartHeight tracks the height when syncing starts.
+
 	// forcedRescanActive is set to true if forcedRescan is activated.
 	forcedRescanActive bool
 
@@ -55,11 +64,6 @@ type SyncData struct {
 // reading/writing of properties of this struct are protected by syncData.mu.
 type activeSyncData struct {
 	syncStage utils.SyncStage
-
-	cfiltersFetchProgress    sharedW.CFiltersFetchProgressReport
-	headersFetchProgress     sharedW.HeadersFetchProgressReport
-	addressDiscoveryProgress sharedW.AddressDiscoveryProgressReport
-	headersRescanProgress    sharedW.HeadersRescanProgressReport
 }
 
 const (
@@ -76,33 +80,10 @@ const (
 )
 
 func (asset *Asset) initSyncProgressData() {
-	cfiltersFetchProgress := sharedW.CFiltersFetchProgressReport{
-		GeneralSyncProgress:       &sharedW.GeneralSyncProgress{},
-		StartCFiltersHeight:       -1,
-		CfiltersFetchTimeSpent:    0,
-		TotalFetchedCFiltersCount: 0,
-	}
-
-	headersFetchProgress := sharedW.HeadersFetchProgressReport{
-		GeneralSyncProgress:   &sharedW.GeneralSyncProgress{},
-		HeadersFetchTimeSpent: -1,
-	}
-
-	addressDiscoveryProgress := sharedW.AddressDiscoveryProgressReport{
-		GeneralSyncProgress:     &sharedW.GeneralSyncProgress{},
-		TotalDiscoveryTimeSpent: -1,
-	}
-
-	headersRescanProgress := sharedW.HeadersRescanProgressReport{}
-	headersRescanProgress.GeneralSyncProgress = &sharedW.GeneralSyncProgress{}
-
 	asset.syncData.mu.Lock()
-	asset.syncData.activeSyncData = &activeSyncData{
-		cfiltersFetchProgress:    cfiltersFetchProgress,
-		headersFetchProgress:     headersFetchProgress,
-		addressDiscoveryProgress: addressDiscoveryProgress,
-		headersRescanProgress:    headersRescanProgress,
-	}
+	asset.syncData.activeSyncData = &activeSyncData{}
+	asset.syncData.syncStartHeight = nil
+	asset.syncData.syncStartTime = time.Time{}
 	asset.syncData.mu.Unlock()
 }
 
@@ -154,10 +135,10 @@ func (asset *Asset) updateSyncProgress(rawBlockHeight int32) {
 	asset.bestServerPeerBlockHeight()
 
 	// initial set up when sync begins.
-	if asset.syncData.headersFetchProgress.StartHeaderHeight == nil {
+	if asset.syncData.syncStartHeight == nil {
 		asset.syncData.syncStage = utils.HeadersFetchSyncStage
-		asset.syncData.headersFetchProgress.BeginFetchTimeStamp = time.Now()
-		asset.syncData.headersFetchProgress.StartHeaderHeight = &rawBlockHeight
+		asset.syncData.syncStartTime = time.Now()
+		asset.syncData.syncStartHeight = &rawBlockHeight
 
 		if asset.syncData.bestBlockHeight != rawBlockHeight {
 			asset.syncData.mu.Unlock()
@@ -165,14 +146,20 @@ func (asset *Asset) updateSyncProgress(rawBlockHeight int32) {
 			return
 		}
 	}
-	log.Infof("Current sync progress update is on block %v, target sync block is %v", rawBlockHeight, asset.syncData.bestBlockHeight)
 
-	timeSpentSoFar := time.Since(asset.syncData.headersFetchProgress.BeginFetchTimeStamp).Seconds()
+	startTime := asset.syncData.syncStartTime
+	startheight := *asset.syncData.syncStartHeight
+	asset.syncData.mu.Unlock()
+
+	log.Infof("Current sync progress update is on block %v, target sync block is %v",
+		rawBlockHeight, asset.syncData.bestBlockHeight)
+
+	timeSpentSoFar := time.Since(startTime).Seconds()
 	if timeSpentSoFar < 1 {
 		timeSpentSoFar = 1
 	}
 
-	headersFetchedSoFar := float64(rawBlockHeight - *asset.syncData.headersFetchProgress.StartHeaderHeight)
+	headersFetchedSoFar := float64(rawBlockHeight - startheight)
 	if headersFetchedSoFar < 1 {
 		headersFetchedSoFar = 1
 	}
@@ -184,18 +171,22 @@ func (asset *Asset) updateSyncProgress(rawBlockHeight int32) {
 
 	allHeadersToFetch := headersFetchedSoFar + remainingHeaders
 	timeRemaining := secondsToDuration(((timeSpentSoFar * remainingHeaders) / headersFetchedSoFar))
+	syncProgess := int32((headersFetchedSoFar * 100) / allHeadersToFetch)
 
-	asset.syncData.headersFetchProgress.TotalHeadersToFetch = asset.syncData.bestBlockHeight
-	asset.syncData.headersFetchProgress.HeadersFetchProgress = int32((headersFetchedSoFar * 100) / allHeadersToFetch)
-	asset.syncData.headersFetchProgress.TotalSyncProgress = asset.syncData.headersFetchProgress.HeadersFetchProgress
-	asset.syncData.headersFetchProgress.TotalTimeRemaining = timeRemaining
-	asset.syncData.mu.Unlock()
+	headersFetchProgress := &sharedW.HeadersFetchProgressReport{
+		GeneralSyncProgress: &sharedW.GeneralSyncProgress{
+			TotalSyncProgress:  syncProgess,
+			TotalTimeRemaining: timeRemaining,
+		},
+	}
+	headersFetchProgress.TotalHeadersToFetch = asset.syncData.bestBlockHeight
+	headersFetchProgress.HeadersFetchProgress = syncProgess
 
 	// publish the sync progress results to all listeners.
 	asset.syncData.mu.RLock()
 	for _, listener := range asset.syncData.syncProgressListeners {
 		if listener.OnHeadersFetchProgress != nil {
-			listener.OnHeadersFetchProgress(&asset.syncData.headersFetchProgress)
+			listener.OnHeadersFetchProgress(headersFetchProgress)
 		}
 	}
 	asset.syncData.mu.RUnlock()
@@ -205,6 +196,11 @@ func (asset *Asset) publishHeadersFetchComplete() {
 	asset.syncData.mu.Lock()
 	asset.syncData.synced = true
 	asset.syncData.syncing = false
+
+	// Clean up the shared data fields
+	asset.syncData.syncStartTime = time.Time{}
+	asset.syncData.syncStartHeight = nil
+
 	asset.syncData.mu.Unlock()
 
 	asset.handleSyncUIUpdate()

--- a/libwallet/assets/ltc/utils.go
+++ b/libwallet/assets/ltc/utils.go
@@ -2,6 +2,7 @@ package ltc
 
 import (
 	"encoding/binary"
+	"time"
 
 	sharedW "github.com/crypto-power/cryptopower/libwallet/assets/wallet"
 	"github.com/crypto-power/cryptopower/libwallet/utils"
@@ -125,4 +126,8 @@ func (asset *Asset) DeriveAccountXpub(seedMnemonic string, wordSeedType sharedW.
 
 func hardenedKey(key uint32) uint32 {
 	return key + hdkeychain.HardenedKeyStart
+}
+
+func secondsToDuration(secs float64) time.Duration {
+	return time.Duration(secs) * time.Second
 }

--- a/libwallet/assets/ltc/wallet.go
+++ b/libwallet/assets/ltc/wallet.go
@@ -333,14 +333,6 @@ func (asset *Asset) IsSyncing() bool {
 	return asset.syncData.syncing
 }
 
-// IsSyncShuttingDown returns true if the wallet is shutting down.
-func (asset *Asset) IsSyncShuttingDown() bool {
-	asset.syncData.mu.RLock()
-	defer asset.syncData.mu.RUnlock()
-
-	return asset.syncData.isSyncShuttingDown
-}
-
 // ConnectedPeers returns the number of connected peers.
 func (asset *Asset) ConnectedPeers() int32 {
 	// Calling CS.ConnectedCount() before the first sync is

--- a/libwallet/assets/wallet/asset_interface.go
+++ b/libwallet/assets/wallet/asset_interface.go
@@ -22,6 +22,8 @@ type Asset interface {
 	SetSpecificPeer(address string)
 	GetExtendedPubKey(account int32) (string, error)
 	IsSyncShuttingDown() bool
+	EnableSyncShuttingDown()
+	EndSyncShuttingDown()
 
 	LockWallet()
 	IsLocked() bool

--- a/libwallet/assets/wallet/types.go
+++ b/libwallet/assets/wallet/types.go
@@ -246,26 +246,23 @@ type GeneralSyncProgress struct {
 type CFiltersFetchProgressReport struct {
 	*GeneralSyncProgress
 	BeginFetchCFiltersTimeStamp time.Time
-	// StartCFiltersHeight         int32
-	CfiltersFetchTimeSpent    time.Duration
-	TotalFetchedCFiltersCount int32
-	TotalCFiltersToFetch      int32 `json:"totalCFiltersToFetch"`
-	CurrentCFilterHeight      int32 `json:"currentCFilterHeight"`
-	CFiltersFetchProgress     int32 `json:"headersFetchProgress"`
+	CfiltersFetchTimeSpent      time.Duration
+	TotalFetchedCFiltersCount   int32
+	TotalCFiltersToFetch        int32 `json:"totalCFiltersToFetch"`
+	CurrentCFilterHeight        int32 `json:"currentCFilterHeight"`
+	CFiltersFetchProgress       int32 `json:"headersFetchProgress"`
 }
 
 type HeadersFetchProgressReport struct {
 	*GeneralSyncProgress
 	HeadersFetchTimeSpent time.Duration
-	// BeginFetchTimeStamp   time.Time
-	StartHeaderHeight    *int32
-	TotalHeadersToFetch  int32 `json:"totalHeadersToFetch"`
-	HeadersFetchProgress int32 `json:"headersFetchProgress"`
+	StartHeaderHeight     *int32
+	TotalHeadersToFetch   int32 `json:"totalHeadersToFetch"`
+	HeadersFetchProgress  int32 `json:"headersFetchProgress"`
 }
 
 type AddressDiscoveryProgressReport struct {
 	*GeneralSyncProgress
-	// AddressDiscoveryStartTime time.Time
 	TotalDiscoveryTimeSpent  time.Duration
 	AddressDiscoveryProgress int32 `json:"addressDiscoveryProgress"`
 }

--- a/libwallet/assets/wallet/types.go
+++ b/libwallet/assets/wallet/types.go
@@ -246,28 +246,28 @@ type GeneralSyncProgress struct {
 type CFiltersFetchProgressReport struct {
 	*GeneralSyncProgress
 	BeginFetchCFiltersTimeStamp time.Time
-	StartCFiltersHeight         int32
-	CfiltersFetchTimeSpent      time.Duration
-	TotalFetchedCFiltersCount   int32
-	TotalCFiltersToFetch        int32 `json:"totalCFiltersToFetch"`
-	CurrentCFilterHeight        int32 `json:"currentCFilterHeight"`
-	CFiltersFetchProgress       int32 `json:"headersFetchProgress"`
+	// StartCFiltersHeight         int32
+	CfiltersFetchTimeSpent    time.Duration
+	TotalFetchedCFiltersCount int32
+	TotalCFiltersToFetch      int32 `json:"totalCFiltersToFetch"`
+	CurrentCFilterHeight      int32 `json:"currentCFilterHeight"`
+	CFiltersFetchProgress     int32 `json:"headersFetchProgress"`
 }
 
 type HeadersFetchProgressReport struct {
 	*GeneralSyncProgress
 	HeadersFetchTimeSpent time.Duration
-	BeginFetchTimeStamp   time.Time
-	StartHeaderHeight     *int32
-	TotalHeadersToFetch   int32 `json:"totalHeadersToFetch"`
-	HeadersFetchProgress  int32 `json:"headersFetchProgress"`
+	// BeginFetchTimeStamp   time.Time
+	StartHeaderHeight    *int32
+	TotalHeadersToFetch  int32 `json:"totalHeadersToFetch"`
+	HeadersFetchProgress int32 `json:"headersFetchProgress"`
 }
 
 type AddressDiscoveryProgressReport struct {
 	*GeneralSyncProgress
-	AddressDiscoveryStartTime time.Time
-	TotalDiscoveryTimeSpent   time.Duration
-	AddressDiscoveryProgress  int32 `json:"addressDiscoveryProgress"`
+	// AddressDiscoveryStartTime time.Time
+	TotalDiscoveryTimeSpent  time.Duration
+	AddressDiscoveryProgress int32 `json:"addressDiscoveryProgress"`
 }
 
 type HeadersRescanProgressReport struct {

--- a/libwallet/assets/wallet/types.go
+++ b/libwallet/assets/wallet/types.go
@@ -239,15 +239,15 @@ type SyncProgressListener struct {
 }
 
 type GeneralSyncProgress struct {
-	TotalSyncProgress         int32 `json:"totalSyncProgress"`
-	TotalTimeRemainingSeconds int64 `json:"totalTimeRemainingSeconds"`
+	TotalSyncProgress  int32         `json:"totalSyncProgress"`
+	TotalTimeRemaining time.Duration `json:"totalTimeRemainingSeconds"`
 }
 
 type CFiltersFetchProgressReport struct {
 	*GeneralSyncProgress
-	BeginFetchCFiltersTimeStamp int64
+	BeginFetchCFiltersTimeStamp time.Time
 	StartCFiltersHeight         int32
-	CfiltersFetchTimeSpent      int64
+	CfiltersFetchTimeSpent      time.Duration
 	TotalFetchedCFiltersCount   int32
 	TotalCFiltersToFetch        int32 `json:"totalCFiltersToFetch"`
 	CurrentCFilterHeight        int32 `json:"currentCFilterHeight"`
@@ -256,7 +256,7 @@ type CFiltersFetchProgressReport struct {
 
 type HeadersFetchProgressReport struct {
 	*GeneralSyncProgress
-	HeadersFetchTimeSpent int64
+	HeadersFetchTimeSpent time.Duration
 	BeginFetchTimeStamp   time.Time
 	StartHeaderHeight     *int32
 	TotalHeadersToFetch   int32 `json:"totalHeadersToFetch"`
@@ -265,18 +265,18 @@ type HeadersFetchProgressReport struct {
 
 type AddressDiscoveryProgressReport struct {
 	*GeneralSyncProgress
-	AddressDiscoveryStartTime int64
-	TotalDiscoveryTimeSpent   int64
+	AddressDiscoveryStartTime time.Time
+	TotalDiscoveryTimeSpent   time.Duration
 	AddressDiscoveryProgress  int32 `json:"addressDiscoveryProgress"`
 }
 
 type HeadersRescanProgressReport struct {
 	*GeneralSyncProgress
-	TotalHeadersToScan  int32 `json:"totalHeadersToScan"`
-	CurrentRescanHeight int32 `json:"currentRescanHeight"`
-	RescanProgress      int32 `json:"rescanProgress"`
-	RescanTimeRemaining int64 `json:"rescanTimeRemaining"`
-	WalletID            int   `json:"walletID"`
+	TotalHeadersToScan  int32         `json:"totalHeadersToScan"`
+	CurrentRescanHeight int32         `json:"currentRescanHeight"`
+	RescanProgress      int32         `json:"rescanProgress"`
+	RescanTimeRemaining time.Duration `json:"rescanTimeRemaining"`
+	WalletID            int           `json:"walletID"`
 }
 
 /** end sync-related types */

--- a/libwallet/assets/wallet/wallet_shared.go
+++ b/libwallet/assets/wallet/wallet_shared.go
@@ -39,8 +39,9 @@ type Wallet struct {
 	loader       loader.AssetLoader
 	walletDataDB *walletdata.DB
 
-	// isSyncShuttingDown is used to indicate the period between when the sync
-	// signal is first detected and when the sync shutdown actually happens.
+	// isSyncShuttingDown tracks the transition from sync ON to OFF. During
+	// this transition, the wallet status displays "Cancelling..." and the
+	// sync switch is disabled from receiving more user clicks until its over.
 	isSyncShuttingDown atomic.Bool
 
 	// Birthday holds the timestamp of the birthday block from where wallet

--- a/libwallet/assets/wallet/wallet_shared.go
+++ b/libwallet/assets/wallet/wallet_shared.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"decred.org/dcrwallet/v4/errors"
@@ -38,6 +39,10 @@ type Wallet struct {
 	loader       loader.AssetLoader
 	walletDataDB *walletdata.DB
 
+	// isSyncShuttingDown is used to indicate the period between when the sync
+	// signal is first detected and when the sync shutdown actually happens.
+	isSyncShuttingDown atomic.Bool
+
 	// Birthday holds the timestamp of the birthday block from where wallet
 	// restoration begins from. CreatedAt is available for audit purposes
 	// in relation to how long the wallet has been in existence.
@@ -51,6 +56,7 @@ type Wallet struct {
 	networkCancel func()
 
 	shuttingDown chan bool
+	isCancelDone chan struct{} // waits until all cancelFuncs functions run.
 	cancelFuncs  []context.CancelFunc
 
 	mu sync.RWMutex
@@ -129,11 +135,16 @@ func (wallet *Wallet) prepare() (err error) {
 	// operations and start go routine to listen for shutdown signal
 	wallet.cancelFuncs = make([]context.CancelFunc, 0)
 	wallet.shuttingDown = make(chan bool)
+	wallet.isCancelDone = make(chan struct{})
+
 	go func() {
 		<-wallet.shuttingDown
 		for _, cancel := range wallet.cancelFuncs {
 			cancel()
 		}
+
+		// Indicate completion of canceling all active contexts
+		wallet.isCancelDone <- struct{}{}
 	}()
 
 	return nil
@@ -164,6 +175,9 @@ func (wallet *Wallet) Shutdown() {
 			log.Errorf("tx db closed with error: %v", err)
 		}
 	}
+
+	// Ensure that all cancelFuncs are Run.
+	<-wallet.isCancelDone
 
 	log.Infof("(%s) full network shutdown protocols completed.", wallet.Name)
 }
@@ -333,6 +347,22 @@ func (wallet *Wallet) SetBirthday(birthday time.Time) {
 	// Triggers db update with the new birthday time.
 	_ = wallet.db.Save(wallet)
 	wallet.mu.Unlock()
+}
+
+// IsSyncShuttingDown returns true if the wallet sync shutdownn signal has been
+// recieved and remains true until the sync processes completely shutdown.
+func (wallet *Wallet) IsSyncShuttingDown() bool {
+	return wallet.isSyncShuttingDown.Load()
+}
+
+// EnableSyncShuttingDown marks the start of the sync shutdown process.
+func (wallet *Wallet) EnableSyncShuttingDown() {
+	wallet.isSyncShuttingDown.Store(true)
+}
+
+// EnableSyncShuttingDown marks the end of the sync shutdown process.
+func (wallet *Wallet) EndSyncShuttingDown() {
+	wallet.isSyncShuttingDown.Store(false)
 }
 
 func CreateNewWallet(pass *AuthInfo, loader loader.AssetLoader,

--- a/ui/page/components/components.go
+++ b/ui/page/components/components.go
@@ -22,7 +22,6 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 
-	"github.com/ararog/timeago"
 	"github.com/crypto-power/cryptopower/app"
 	"github.com/crypto-power/cryptopower/libwallet/assets/dcr"
 	sharedW "github.com/crypto-power/cryptopower/libwallet/assets/wallet"
@@ -32,6 +31,7 @@ import (
 	libutils "github.com/crypto-power/cryptopower/libwallet/utils"
 	"github.com/crypto-power/cryptopower/ui/cryptomaterial"
 	"github.com/crypto-power/cryptopower/ui/load"
+	pageutils "github.com/crypto-power/cryptopower/ui/utils"
 	"github.com/crypto-power/cryptopower/ui/values"
 )
 
@@ -493,7 +493,7 @@ func txStakingStatus(gtx C, l *load.Load, wal sharedW.Asset, tx *sharedW.Transac
 		durationPrefix = values.String(values.StrRevoked)
 	}
 
-	durationTxt := TimeAgo(tx.Timestamp)
+	durationTxt := pageutils.TimeAgo(tx.Timestamp)
 	durationTxt = fmt.Sprintf("%s %s", durationPrefix, durationTxt)
 	lbl := l.Theme.Label(values.TextSize14, durationTxt)
 	lbl.Color = l.Theme.Color.GrayText2
@@ -534,32 +534,6 @@ func TxConfirmations(wallet sharedW.Asset, transaction *sharedW.Transaction) int
 	return 0
 }
 
-func FormatDateOrTime(timestamp int64) string {
-	utcTime := time.Unix(timestamp, 0).UTC()
-	currentTime := time.Now().UTC()
-
-	if strconv.Itoa(currentTime.Year()) == strconv.Itoa(utcTime.Year()) && currentTime.Month().String() == utcTime.Month().String() {
-		if strconv.Itoa(currentTime.Day()) == strconv.Itoa(utcTime.Day()) {
-			if strconv.Itoa(currentTime.Hour()) == strconv.Itoa(utcTime.Hour()) {
-				return TimeAgo(timestamp)
-			}
-
-			return TimeAgo(timestamp)
-		} else if currentTime.Day()-1 == utcTime.Day() {
-			yesterday := values.String(values.StrYesterday)
-			return yesterday
-		}
-	}
-
-	t := strings.Split(utcTime.Format(time.UnixDate), " ")
-	t2 := t[2]
-	year := strconv.Itoa(utcTime.Year())
-	if t[2] == "" {
-		t2 = t[3]
-	}
-	return fmt.Sprintf("%s %s, %s", t[1], t2, year)
-}
-
 // EndToEndRow layouts out its content on both ends of its horizontal layout.
 func EndToEndRow(gtx C, leftWidget, rightWidget func(C) D) D {
 	return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,
@@ -568,11 +542,6 @@ func EndToEndRow(gtx C, leftWidget, rightWidget func(C) D) D {
 			return layout.E.Layout(gtx, rightWidget)
 		}),
 	)
-}
-
-func TimeAgo(timestamp int64) string {
-	timeAgo, _ := timeago.TimeAgoWithTime(time.Now(), time.Unix(timestamp, 0))
-	return timeAgo
 }
 
 func TruncateString(str string, num int) string {
@@ -602,38 +571,6 @@ func GoToURL(url string) {
 	if err != nil {
 		fmt.Println(err.Error())
 	}
-}
-
-func TimeFormat(secs int, long bool) string {
-	var val string
-	if secs > 86399 {
-		val = "d"
-		if long {
-			val = " " + values.String(values.StrDays)
-		}
-		days := secs / 86400
-		return fmt.Sprintf("%d%s", days, val)
-	} else if secs > 3599 {
-		val = "h"
-		if long {
-			val = " " + values.String(values.StrHours)
-		}
-		hours := secs / 3600
-		return fmt.Sprintf("%d%s", hours, val)
-	} else if secs > 59 {
-		val = "s"
-		if long {
-			val = " " + values.String(values.StrMinutes)
-		}
-		mins := secs / 60
-		return fmt.Sprintf("%d%s", mins, val)
-	}
-
-	val = "s"
-	if long {
-		val = " " + values.String(values.StrSeconds)
-	}
-	return fmt.Sprintf("%d %s", secs, val)
 }
 
 // TxPageDropDownFields returns the fields for the required drop down with the
@@ -808,23 +745,6 @@ func CalculateTotalWalletsBalance(wallet sharedW.Asset) (*CummulativeWalletsBala
 	}
 
 	return cumm, nil
-}
-
-// SecondsToDays takes time in seconds and returns its string equivalent in the format ddhhmm.
-func SecondsToDays(totalTimeLeft int64) string {
-	q, r := divMod(totalTimeLeft, 24*60*60)
-	timeLeft := time.Duration(r) * time.Second
-	if q > 0 {
-		return fmt.Sprintf("%dd%s", q, timeLeft.String())
-	}
-	return timeLeft.String()
-}
-
-// divMod divides a numerator by a denominator and returns its quotient and remainder.
-func divMod(numerator, denominator int64) (quotient, remainder int64) {
-	quotient = numerator / denominator // integer division, decimals are truncated
-	remainder = numerator % denominator
-	return
 }
 
 func BrowserURLWidget(gtx C, l *load.Load, url string, copyRedirect *cryptomaterial.Clickable) D {

--- a/ui/page/components/proposal_list.go
+++ b/ui/page/components/proposal_list.go
@@ -10,6 +10,7 @@ import (
 	"github.com/crypto-power/cryptopower/libwallet"
 	"github.com/crypto-power/cryptopower/ui/cryptomaterial"
 	"github.com/crypto-power/cryptopower/ui/load"
+	pageutils "github.com/crypto-power/cryptopower/ui/utils"
 	"github.com/crypto-power/cryptopower/ui/values"
 )
 
@@ -68,7 +69,7 @@ func layoutTitleAndDate(gtx C, l *load.Load, item *ProposalItem) D {
 
 	stateLabel := getStateLabel(l, proposal)
 
-	timeAgoLabel := l.Theme.Body2(TimeAgo(proposal.Timestamp))
+	timeAgoLabel := l.Theme.Body2(pageutils.TimeAgo(proposal.Timestamp))
 	timeAgoLabel.Color = grayCol
 
 	var categoryLabel cryptomaterial.Label
@@ -218,7 +219,7 @@ func layoutAuthor(gtx C, l *load.Load, item *ProposalItem) D {
 
 	stateLabel := getStateLabel(l, proposal)
 
-	timeAgoLabel := l.Theme.Body2(TimeAgo(proposal.Timestamp))
+	timeAgoLabel := l.Theme.Body2(pageutils.TimeAgo(proposal.Timestamp))
 	timeAgoLabel.Color = grayCol
 
 	versionLabel := l.Theme.Body2(values.String(values.StrVersion) + " " + proposal.Version)

--- a/ui/page/components/wallet_sync_info.go
+++ b/ui/page/components/wallet_sync_info.go
@@ -560,7 +560,7 @@ func (wsi *WalletSyncInfo) syncStatusIcon(gtx C) D {
 // ensure that the StopListeningForNotifications() method is called whenever the
 // the page or modal using these notifications is closed.
 func (wsi *WalletSyncInfo) ListenForNotifications() {
-	updateSyncProgress := func(timeRemaining int64, headersFetched int32,
+	updateSyncProgress := func(timeRemaining time.Duration, headersFetched int32,
 		stepFetchProgress int32, totalSyncProgress int32) {
 		// Update sync progress fields which will be displayed
 		// when the next UI invalidation occurs.
@@ -581,15 +581,15 @@ func (wsi *WalletSyncInfo) ListenForNotifications() {
 
 	syncProgressListener := &sharedW.SyncProgressListener{
 		OnHeadersFetchProgress: func(t *sharedW.HeadersFetchProgressReport) {
-			updateSyncProgress(t.TotalTimeRemainingSeconds, t.TotalHeadersToFetch,
+			updateSyncProgress(t.TotalTimeRemaining, t.TotalHeadersToFetch,
 				t.HeadersFetchProgress, t.TotalSyncProgress)
 		},
 		OnAddressDiscoveryProgress: func(t *sharedW.AddressDiscoveryProgressReport) {
-			updateSyncProgress(t.TotalTimeRemainingSeconds, t.AddressDiscoveryProgress,
+			updateSyncProgress(t.TotalTimeRemaining, t.AddressDiscoveryProgress,
 				t.AddressDiscoveryProgress, t.TotalSyncProgress)
 		},
 		OnHeadersRescanProgress: func(t *sharedW.HeadersRescanProgressReport) {
-			updateSyncProgress(t.TotalTimeRemainingSeconds, t.TotalHeadersToScan,
+			updateSyncProgress(t.TotalTimeRemaining, t.TotalHeadersToScan,
 				t.RescanProgress, t.TotalSyncProgress)
 		},
 		OnSyncCompleted: func() {

--- a/ui/page/components/wallet_sync_info.go
+++ b/ui/page/components/wallet_sync_info.go
@@ -494,7 +494,7 @@ func (wsi *WalletSyncInfo) progressStatusDetails() (progress int, timeLeft strin
 	headersToScan := int(sp.HeadersToFetchOrScan())
 
 	if rescanUpdate := wsi.FetchRescanUpdate(); rescanUpdate != nil {
-		progress = int(rescanUpdate.RescanProgress)
+		progress = int(rescanUpdate.CurrentRescanHeight)
 		headersToScan = int(rescanUpdate.TotalHeadersToScan)
 	}
 

--- a/ui/page/components/wallet_sync_info.go
+++ b/ui/page/components/wallet_sync_info.go
@@ -685,7 +685,7 @@ func (wsi *WalletSyncInfo) HandleUserInteractions(gtx C) {
 			wsi.wallet.CancelRescan()
 		}
 
-		// Toggle switch states is handled in the layout() method.
+		// Toggling switch states is handled in the layout() method.
 		go func() {
 			wsi.ToggleSync(wsi.wallet, func(b bool) {
 				wsi.wallet.SaveUserConfigValue(sharedW.AutoSyncConfigKey, b)
@@ -694,7 +694,7 @@ func (wsi *WalletSyncInfo) HandleUserInteractions(gtx C) {
 		}()
 	}
 
-	// Manage the Disabled sync toggle button during sync shutdown process.
+	// Manage the sync toggle switch during the sync shutdown process.
 	isSyncShuttingDown := wsi.wallet.IsSyncShuttingDown()
 	if isSyncShuttingDown {
 		wsi.switchEnabled.Store(true)

--- a/ui/page/dcrdex/market.go
+++ b/ui/page/dcrdex/market.go
@@ -32,7 +32,7 @@ import (
 	"github.com/crypto-power/cryptopower/ui/load"
 	"github.com/crypto-power/cryptopower/ui/modal"
 	"github.com/crypto-power/cryptopower/ui/page/components"
-	"github.com/crypto-power/cryptopower/ui/utils"
+	pageutils "github.com/crypto-power/cryptopower/ui/utils"
 	"github.com/crypto-power/cryptopower/ui/values"
 )
 
@@ -633,7 +633,7 @@ func (pg *DEXMarketPage) priceAndVolumeDetail(gtx C) D {
 		if ticker == nil {
 			marketRate = pg.Printer.Sprintf("%f", rate)
 		} else {
-			marketRate = pg.Printer.Sprintf("%f (~ %s)", rate, utils.FormatAsUSDString(pg.Printer, rate*ticker.LastTradePrice))
+			marketRate = pg.Printer.Sprintf("%f (~ %s)", rate, pageutils.FormatAsUSDString(pg.Printer, rate*ticker.LastTradePrice))
 		}
 
 		change24 = mkt.SpotPrice.Change24
@@ -1180,7 +1180,7 @@ func (pg *DEXMarketPage) orderbook(gtx C) D {
 								marketRate := mkt.MsgRateToConventional(mkt.SpotPrice.Rate)
 								marketRateStr = fmt.Sprintf("%f %s", marketRate, quoteAsset)
 								if ticker := pg.selectedMarketUSDRateTicker(); ticker != nil {
-									marketRateStr = fmt.Sprintf("%f %s (~ %s)", marketRate, quoteAsset, utils.FormatAsUSDString(pg.Printer, marketRate*ticker.LastTradePrice))
+									marketRateStr = fmt.Sprintf("%f %s (~ %s)", marketRate, quoteAsset, pageutils.FormatAsUSDString(pg.Printer, marketRate*ticker.LastTradePrice))
 								}
 							}
 							lb := pg.Theme.Label(values.TextSize16, marketRateStr)
@@ -1318,7 +1318,7 @@ func (pg *DEXMarketPage) openOrdersAndHistory(gtx C) D {
 									return layout.Flex{Axis: horizontal, Spacing: layout.SpaceBetween, Alignment: layout.Middle}.Layout(gtx,
 										pg.orderColumn(false, fmt.Sprintf("%s %s", values.String(ord.Type.String()), values.String(orderReader.SideString())), columnWidth, index),
 										pg.orderColumn(false, ord.MarketID, columnWidth, index),
-										pg.orderColumn(false, components.TimeAgo(int64(ord.SubmitTime/1000)), columnWidth, index),
+										pg.orderColumn(false, pageutils.TimeAgo(int64(ord.SubmitTime/1000)), columnWidth, index),
 										pg.orderColumn(false, orderReader.RateString(), columnWidth, index),
 										pg.orderColumn(false, fmt.Sprintf("%s %s", orderReader.BaseQtyString(), strings.ToTitle(orderReader.BaseSymbol)), columnWidth, index),
 										pg.orderColumn(false, fmt.Sprintf("%s%%", orderReader.FilledPercent()), columnWidth, index),

--- a/ui/page/exchange/create_order_page.go
+++ b/ui/page/exchange/create_order_page.go
@@ -22,6 +22,7 @@ import (
 	"github.com/crypto-power/cryptopower/ui/page/components"
 	"github.com/crypto-power/cryptopower/ui/page/settings"
 	"github.com/crypto-power/cryptopower/ui/values"
+	pageutils "github.com/crypto-power/cryptopower/ui/utils"
 
 	api "github.com/crypto-power/instantswap/instantswap"
 )
@@ -1016,7 +1017,7 @@ func (pg *CreateOrderPage) layoutDesktop(gtx C) D {
 													if pg.AssetsManager.InstantSwap.IsSyncing() {
 														text = values.String(values.StrSyncingState)
 													} else {
-														text = values.String(values.StrUpdated) + " " + components.TimeAgo(pg.AssetsManager.InstantSwap.GetLastSyncedTimeStamp())
+														text = values.String(values.StrUpdated) + " " + pageutils.TimeAgo(pg.AssetsManager.InstantSwap.GetLastSyncedTimeStamp())
 
 														if pg.AssetsManager.InstantSwap.GetLastSyncedTimeStamp() == 0 {
 															text = values.String(values.StrNeverSynced)

--- a/ui/page/exchange/create_order_page.go
+++ b/ui/page/exchange/create_order_page.go
@@ -21,8 +21,8 @@ import (
 	"github.com/crypto-power/cryptopower/ui/modal"
 	"github.com/crypto-power/cryptopower/ui/page/components"
 	"github.com/crypto-power/cryptopower/ui/page/settings"
-	"github.com/crypto-power/cryptopower/ui/values"
 	pageutils "github.com/crypto-power/cryptopower/ui/utils"
+	"github.com/crypto-power/cryptopower/ui/values"
 
 	api "github.com/crypto-power/instantswap/instantswap"
 )

--- a/ui/page/exchange/order_history_page.go
+++ b/ui/page/exchange/order_history_page.go
@@ -12,6 +12,7 @@ import (
 	"github.com/crypto-power/cryptopower/ui/cryptomaterial"
 	"github.com/crypto-power/cryptopower/ui/load"
 	"github.com/crypto-power/cryptopower/ui/page/components"
+	pageutils "github.com/crypto-power/cryptopower/ui/utils"
 	"github.com/crypto-power/cryptopower/ui/values"
 
 	api "github.com/crypto-power/instantswap/instantswap"
@@ -270,7 +271,7 @@ func (pg *OrderHistoryPage) layoutSectionHeader(gtx C) D {
 						if pg.AssetsManager.InstantSwap.IsSyncing() {
 							text = values.String(values.StrSyncingState)
 						} else {
-							text = values.String(values.StrUpdated) + " " + components.TimeAgo(pg.AssetsManager.InstantSwap.GetLastSyncedTimeStamp())
+							text = values.String(values.StrUpdated) + " " + pageutils.TimeAgo(pg.AssetsManager.InstantSwap.GetLastSyncedTimeStamp())
 
 							if pg.AssetsManager.InstantSwap.GetLastSyncedTimeStamp() == 0 {
 								text = values.String(values.StrNeverSynced)

--- a/ui/page/governance/proposal_details_page.go
+++ b/ui/page/governance/proposal_details_page.go
@@ -22,6 +22,7 @@ import (
 	"github.com/crypto-power/cryptopower/ui/modal"
 	"github.com/crypto-power/cryptopower/ui/page/components"
 	"github.com/crypto-power/cryptopower/ui/renderers"
+	pageutils "github.com/crypto-power/cryptopower/ui/utils"
 	"github.com/crypto-power/cryptopower/ui/values"
 )
 
@@ -333,7 +334,7 @@ func (pg *ProposalDetails) layoutProposalVoteBar(gtx C) D {
 
 func (pg *ProposalDetails) statusAndTimeLayout(gtx C) D {
 	grayCol := pg.Load.Theme.Color.GrayText2
-	timeAgoLabel := pg.Load.Theme.Body2(components.TimeAgo(pg.proposal.Timestamp))
+	timeAgoLabel := pg.Load.Theme.Body2(pageutils.TimeAgo(pg.proposal.Timestamp))
 	timeAgoLabel.Color = grayCol
 
 	dotLabel := pg.Load.Theme.H4(" . ")
@@ -599,10 +600,10 @@ func (pg *ProposalDetails) layoutDescription(gtx C) D {
 	versionLabel := pg.Theme.Body2(values.String(values.StrVersion) + " " + proposal.Version)
 	versionLabel.Color = grayCol
 
-	publishedLabel := pg.Theme.Body2(values.String(values.StrPublished2) + " " + components.TimeAgo(proposal.PublishedAt))
+	publishedLabel := pg.Theme.Body2(values.String(values.StrPublished2) + " " + pageutils.TimeAgo(proposal.PublishedAt))
 	publishedLabel.Color = grayCol
 
-	updatedLabel := pg.Theme.Body2(values.String(values.StrUpdated) + " " + components.TimeAgo(proposal.Timestamp))
+	updatedLabel := pg.Theme.Body2(values.String(values.StrUpdated) + " " + pageutils.TimeAgo(proposal.Timestamp))
 	updatedLabel.Color = grayCol
 
 	userLabel.TextSize = pg.ConvertTextSize(values.TextSize14)

--- a/ui/page/governance/proposals_page.go
+++ b/ui/page/governance/proposals_page.go
@@ -17,6 +17,7 @@ import (
 	"github.com/crypto-power/cryptopower/ui/load"
 	"github.com/crypto-power/cryptopower/ui/modal"
 	"github.com/crypto-power/cryptopower/ui/page/components"
+	pageutils "github.com/crypto-power/cryptopower/ui/utils"
 	"github.com/crypto-power/cryptopower/ui/values"
 )
 
@@ -450,7 +451,7 @@ func (pg *ProposalsPage) layoutSectionHeader(gtx C) D {
 						} else if pg.syncCompleted {
 							text = values.String(values.StrUpdated)
 						} else {
-							text = values.String(values.StrUpdated) + " " + components.TimeAgo(pg.AssetsManager.Politeia.GetLastSyncedTimeStamp())
+							text = values.String(values.StrUpdated) + " " + pageutils.TimeAgo(pg.AssetsManager.Politeia.GetLastSyncedTimeStamp())
 						}
 
 						lastUpdatedInfo := pg.Theme.Label(pg.ConvertTextSize(values.TextSize10), text)

--- a/ui/page/info/info_page.go
+++ b/ui/page/info/info_page.go
@@ -248,6 +248,9 @@ func (pg *WalletInfo) walletTxWrapper(gtx C, tx *sharedW.Transaction, isHiddenSe
 // displayed.
 // Part of the load.Page interface.
 func (pg *WalletInfo) HandleUserInteractions(gtx C) {
+	// Process subpage events too.
+	pg.walletSyncInfo.HandleUserInteractions(gtx)
+
 	if clicked, selectedItem := pg.recentTransactions.ItemClicked(); clicked {
 		pg.ParentNavigator().Display(transaction.NewTransactionDetailsPage(pg.Load, pg.wallet, pg.transactions[selectedItem]))
 	}

--- a/ui/page/root/home_page.go
+++ b/ui/page/root/home_page.go
@@ -101,7 +101,9 @@ func NewHomePage(dexCtx context.Context, l *load.Load) *HomePage {
 		if wallet == nil {
 			return
 		}
-		if wallet.IsConnectedToNetwork() {
+		if wallet.IsConnectedToNetwork() { // True if asset is synced or already synced.
+			wallet.EnableSyncShuttingDown() // Initiate sync shutdown process
+
 			go wallet.CancelSync()
 			unlock(false)
 		} else {

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -271,6 +271,9 @@ func (pg *OverviewPage) HandleUserInteractions(gtx C) {
 	}
 
 	for _, info := range pg.listInfoWallets {
+		// Process subpage events too.
+		info.HandleUserInteractions(gtx)
+
 		if info.ForwardButton.Button.Clicked(gtx) {
 			pg.showNavigationFunc(true)
 			callback := func() {

--- a/ui/page/root/overview_page.go
+++ b/ui/page/root/overview_page.go
@@ -31,7 +31,7 @@ import (
 	"github.com/crypto-power/cryptopower/ui/page/seedbackup"
 	"github.com/crypto-power/cryptopower/ui/page/transaction"
 	"github.com/crypto-power/cryptopower/ui/page/wallet"
-	"github.com/crypto-power/cryptopower/ui/utils"
+	pageutils "github.com/crypto-power/cryptopower/ui/utils"
 	"github.com/crypto-power/cryptopower/ui/values"
 )
 
@@ -379,7 +379,7 @@ func (pg *OverviewPage) initInfoWallets() {
 	wallets := pg.AssetsManager.AllWallets()
 	for _, wal := range wallets {
 		infoSync := components.NewWalletSyncInfo(pg.Load, wal, pg.reload, pg.backup)
-		infoSync.IsSlider = true
+		infoSync.SetSliderOn()
 		pg.listInfoWallets = append(pg.listInfoWallets, infoSync)
 	}
 }
@@ -466,7 +466,7 @@ func (pg *OverviewPage) assetBalanceSliderLayout(gtx C, rowHeigh int) D {
 
 func (pg *OverviewPage) assetBalanceItemLayout(item *assetBalanceSliderItem, rowHeigh int) layout.Widget {
 	return func(gtx C) D {
-		return utils.RadiusLayout(gtx, 8, func(gtx C) D {
+		return pageutils.RadiusLayout(gtx, 8, func(gtx C) D {
 			size := pg.contentSliderLayout(item)(gtx).Size
 			if size.Y < rowHeigh {
 				size.Y = rowHeigh
@@ -748,7 +748,7 @@ func (pg *OverviewPage) mobileMarketOverview(gtx C) D {
 									}),
 									layout.Rigid(func(gtx C) D {
 										return layout.Inset{Bottom: values.MarginPadding8}.Layout(gtx, func(gtx C) D {
-											txt := pg.Theme.Label(values.TextSize16, utils.FormatAsUSDString(pg.Printer, rate.LastTradePrice))
+											txt := pg.Theme.Label(values.TextSize16, pageutils.FormatAsUSDString(pg.Printer, rate.LastTradePrice))
 											txt.Color = pg.Theme.Color.Text
 											return txt.Layout(gtx)
 										})
@@ -865,7 +865,7 @@ func (pg *OverviewPage) marketTableRows(gtx C, asset assetMarketData, rate *ext.
 			Alignment: layout.Middle,
 		}.Layout(gtx,
 			layout.Flexed(.785, func(gtx C) D {
-				return layout.E.Layout(gtx, pg.assetTableLabel(utils.FormatAsUSDString(pg.Printer, rate.LastTradePrice), pg.Theme.Color.Text))
+				return layout.E.Layout(gtx, pg.assetTableLabel(pageutils.FormatAsUSDString(pg.Printer, rate.LastTradePrice), pg.Theme.Color.Text))
 			}),
 			layout.Flexed(.215, func(gtx C) D {
 				hasRateChange := rate.PriceChangePercent != nil
@@ -1067,7 +1067,7 @@ func (pg *OverviewPage) updateAssetsUSDBalance() {
 		}
 
 		toUSDString := func(balance float64) string {
-			return utils.FormatAsUSDString(pg.Printer, balance)
+			return pageutils.FormatAsUSDString(pg.Printer, balance)
 		}
 
 		for assetType, balance := range assetsTotalUSDBalance {
@@ -1300,7 +1300,7 @@ func (pg *OverviewPage) ratesRefreshComponent() func(gtx C) D {
 					text = values.String(values.StrRefreshState)
 				} else {
 					lastUpdatedTimestamp := pg.AssetsManager.RateSource.LastUpdate().Unix()
-					text = values.String(values.StrUpdated) + " " + components.TimeAgo(lastUpdatedTimestamp)
+					text = values.String(values.StrUpdated) + " " + pageutils.TimeAgo(lastUpdatedTimestamp)
 				}
 				lastUpdatedInfo := pg.Theme.Label(values.TextSize14, text)
 				lastUpdatedInfo.Color = pg.Theme.Color.GrayText2

--- a/ui/page/settings/statistics_page.go
+++ b/ui/page/settings/statistics_page.go
@@ -17,6 +17,7 @@ import (
 	"github.com/crypto-power/cryptopower/ui/cryptomaterial"
 	"github.com/crypto-power/cryptopower/ui/load"
 	"github.com/crypto-power/cryptopower/ui/page/components"
+	pageutils "github.com/crypto-power/cryptopower/ui/utils"
 	"github.com/crypto-power/cryptopower/ui/values"
 )
 
@@ -140,7 +141,7 @@ func (pg *StatPage) layoutStats(gtx C) D {
 		line.Layout,
 		item(values.String(values.StrBestBlockTimestamp), bestBlockTime.Format("2006-01-02 03:04:05 -0700")),
 		line.Layout,
-		item(values.String(values.StrBestBlockAge), components.SecondsToDays(secondsSinceBestBlock)),
+		item(values.String(values.StrBestBlockAge), pageutils.SecondsToDays(secondsSinceBestBlock)),
 		line.Layout,
 		item(values.String(values.StrWalletDirectory), pg.wallet.DataDir()),
 		line.Layout,

--- a/ui/page/staking/utils.go
+++ b/ui/page/staking/utils.go
@@ -13,6 +13,7 @@ import (
 	"github.com/crypto-power/cryptopower/ui/cryptomaterial"
 	"github.com/crypto-power/cryptopower/ui/load"
 	"github.com/crypto-power/cryptopower/ui/page/components"
+	pageutils "github.com/crypto-power/cryptopower/ui/utils"
 	"github.com/crypto-power/cryptopower/ui/values"
 )
 
@@ -76,7 +77,7 @@ func (pg *Page) stakeToTransactionItems(txs []*sharedW.Transaction, newestFirst 
 			txStatus.TicketStatus == dcr.TicketStatusLive {
 
 			ticketAgeDuration := time.Since(time.Unix(tx.Timestamp, 0)).Seconds()
-			ticketAge = components.TimeFormat(int(ticketAgeDuration), true)
+			ticketAge = pageutils.TimeFormat(int(ticketAgeDuration), true)
 		}
 
 		showTime := showProgress && txStatus.TicketStatus != dcr.TicketStatusLive
@@ -147,7 +148,7 @@ func TicketStatusDetails(gtx C, l *load.Load, dcrWallet *dcr.Asset, tx *transact
 
 	switch tx.status.TicketStatus {
 	case dcr.TicketStatusUnmined:
-		lbl := l.Theme.Label(textSize16, values.StringF(values.StrUnminedInfo, components.TimeAgo(tx.transaction.Timestamp)))
+		lbl := l.Theme.Label(textSize16, values.StringF(values.StrUnminedInfo, pageutils.TimeAgo(tx.transaction.Timestamp)))
 		lbl.Color = col
 		return lbl.Layout(gtx)
 	case dcr.TicketStatusImmature:
@@ -181,13 +182,13 @@ func TicketStatusDetails(gtx C, l *load.Load, dcrWallet *dcr.Asset, tx *transact
 		return lbl.Layout(gtx)
 	case dcr.TicketStatusVotedOrRevoked:
 		if tx.ticketSpender.Type == dcr.TxTypeVote {
-			return multiContent(gtx, l, dateTime, fmt.Sprintf("%s %v", values.String(values.StrVoted), components.TimeAgo(tx.transaction.Timestamp)))
+			return multiContent(gtx, l, dateTime, fmt.Sprintf("%s %v", values.String(values.StrVoted), pageutils.TimeAgo(tx.transaction.Timestamp)))
 		}
 		lbl := l.Theme.Label(textSize16, dateTime)
 		lbl.Color = col
 		return lbl.Layout(gtx)
 	case dcr.TicketStatusExpired:
-		return multiContent(gtx, l, dateTime, fmt.Sprintf("%s %v", values.String(values.StrExpired), components.TimeAgo(tx.transaction.Timestamp)))
+		return multiContent(gtx, l, dateTime, fmt.Sprintf("%s %v", values.String(values.StrExpired), pageutils.TimeAgo(tx.transaction.Timestamp)))
 	default:
 		return D{}
 	}

--- a/ui/page/transaction/transaction_details_page.go
+++ b/ui/page/transaction/transaction_details_page.go
@@ -23,7 +23,7 @@ import (
 	"github.com/crypto-power/cryptopower/ui/load"
 	"github.com/crypto-power/cryptopower/ui/modal"
 	"github.com/crypto-power/cryptopower/ui/page/components"
-	"github.com/crypto-power/cryptopower/ui/utils"
+	pageutils "github.com/crypto-power/cryptopower/ui/utils"
 	"github.com/crypto-power/cryptopower/ui/values"
 )
 
@@ -606,7 +606,7 @@ func (pg *TxDetailsPage) txnTypeAndID(gtx C) D {
 			if pg.transaction.Type == txhelper.TxTypeRegular || pg.transaction.Type == txhelper.TxTypeMixed {
 				dim := func(gtx C) D {
 					if pg.transaction.Direction == txhelper.TxDirectionReceived {
-						lbl := pg.Theme.Label(values.TextSize14, utils.SplitSingleString(pg.txDestinationAddresses[0], 0))
+						lbl := pg.Theme.Label(values.TextSize14, pageutils.SplitSingleString(pg.txDestinationAddresses[0], 0))
 						return lbl.Layout(gtx)
 					}
 					flexChilds := make([]layout.FlexChild, 0)
@@ -619,7 +619,7 @@ func (pg *TxDetailsPage) txnTypeAndID(gtx C) D {
 								gtx.Execute(clipboard.WriteCmd{Data: io.NopCloser(strings.NewReader(address))})
 								pg.Toast.Notify(values.String(values.StrTxHashCopied))
 							}
-							lbl := pg.Theme.Label(values.TextSize14, utils.SplitSingleString(address, 0))
+							lbl := pg.Theme.Label(values.TextSize14, pageutils.SplitSingleString(address, 0))
 							lbl.Color = pg.Theme.Color.Primary
 							return clickable.Layout(gtx, lbl.Layout)
 						}))
@@ -774,7 +774,7 @@ func (pg *TxDetailsPage) txnTypeAndID(gtx C) D {
 		}),
 		layout.Rigid(func(gtx C) D {
 			dim := func(gtx C) D {
-				lbl := pg.Theme.Label(values.TextSize14, utils.SplitSingleString(transaction.Hash, 30))
+				lbl := pg.Theme.Label(values.TextSize14, pageutils.SplitSingleString(transaction.Hash, 30))
 				lbl.Color = pg.Theme.Color.Primary
 
 				// copy transaction hash
@@ -808,7 +808,7 @@ func (pg *TxDetailsPage) txnInputs(gtx C) D {
 	collapsibleBody := func(gtx C) D {
 		return pg.transactionInputsContainer.Layout(gtx, len(transaction.Inputs), func(gtx C, i int) D {
 			input := transaction.Inputs[i]
-			addr := utils.SplitSingleString(input.PreviousOutpoint, 20)
+			addr := pageutils.SplitSingleString(input.PreviousOutpoint, 20)
 			return pg.txnIORow(gtx, input.Amount, input.AccountNumber, addr, i)
 		})
 	}
@@ -1009,7 +1009,7 @@ func (pg *TxDetailsPage) initTxnWidgets() transactionWdg {
 	txn.wallet = pg.Theme.Body2(pg.wallet.GetWalletName())
 
 	if components.TxConfirmations(pg.wallet, pg.transaction) >= pg.wallet.RequiredConfirmations() {
-		txn.status.Text = components.FormatDateOrTime(pg.transaction.Timestamp)
+		txn.status.Text = pageutils.FormatDateOrTime(pg.transaction.Timestamp)
 		txn.confirmationIcons = pg.Theme.Icons.ConfirmIcon
 	} else {
 		txn.status.Text = values.String(values.StrPending)

--- a/ui/utils/sync_utils.go
+++ b/ui/utils/sync_utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"sync"
+	"time"
 
 	sharedW "github.com/crypto-power/cryptopower/libwallet/assets/wallet"
 )
@@ -70,11 +71,11 @@ func (si *SyncInfo) GetSyncProgress(wallet sharedW.Asset) ProgressInfo {
 }
 
 // SetSyncProgress creates a new sync progress instance and stores a copy of it.
-func (si *SyncInfo) SetSyncProgress(wallet sharedW.Asset, timeRemaining int64,
+func (si *SyncInfo) SetSyncProgress(wallet sharedW.Asset, timeRemaining time.Duration,
 	headersFetched, stepFetchProgress, totalSyncProgress int32) ProgressInfo {
 
 	progress := ProgressInfo{
-		remainingSyncTime:    TimeFormat(int(timeRemaining), true),
+		remainingSyncTime:    TimeFormat(int(timeRemaining.Seconds()), true),
 		headersToFetchOrScan: headersFetched,
 		stepFetchProgress:    stepFetchProgress,
 		syncProgress:         int(totalSyncProgress),

--- a/ui/utils/sync_utils.go
+++ b/ui/utils/sync_utils.go
@@ -60,7 +60,7 @@ func (si *SyncInfo) IsSyncProgressSet(wallet sharedW.Asset) bool {
 // asset type.
 func (si *SyncInfo) GetSyncProgress(wallet sharedW.Asset) ProgressInfo {
 	si.syncInfoMu.RLock()
-	data, _ := si.progressInfo[wallet]
+	data := si.progressInfo[wallet]
 	si.syncInfoMu.RUnlock()
 
 	if data == nil {
@@ -109,7 +109,7 @@ func (si *SyncInfo) IsRescanProgressSet(wallet sharedW.Asset) bool {
 // asset type.
 func (si *SyncInfo) GetRescanProgress(wallet sharedW.Asset) *sharedW.HeadersRescanProgressReport {
 	si.syncInfoMu.RLock()
-	data, _ := si.rescanInfo[wallet]
+	data := si.rescanInfo[wallet]
 	si.syncInfoMu.RUnlock()
 
 	return data

--- a/ui/utils/sync_utils.go
+++ b/ui/utils/sync_utils.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"sync"
+
+	sharedW "github.com/crypto-power/cryptopower/libwallet/assets/wallet"
+)
+
+// File holds implementation needed to manage the UI sync progess.
+
+type ProgressInfo struct {
+	remainingSyncTime    string
+	headersToFetchOrScan int32
+	stepFetchProgress    int32
+	syncProgress         int
+}
+
+type SyncInfo struct {
+	progressInfo sync.Map //map[sharedW.Asset]*ProgressInfo
+	rescanUpdate *sharedW.HeadersRescanProgressReport
+	syncInfoMu   sync.RWMutex
+}
+
+// This methods prevent the direct access of the mutex protected syncProgressInfo
+// SyncInfo instance.
+
+func (si *SyncInfo) IsSyncProgressSet(wallet sharedW.Asset) bool {
+	defer si.syncInfoMu.RUnlock()
+	si.syncInfoMu.RLock()
+	_, ok := si.progressInfo[wallet]
+	return ok
+}
+
+func (si *SyncInfo) GetSyncProgress(wallet sharedW.Asset) ProgressInfo {
+	defer si.syncInfoMu.RUnlock()
+	si.syncInfoMu.RLock()
+	data, _ := si.progressInfo[wallet]
+	if data == nil {
+		return ProgressInfo{}
+	}
+	return *data
+}
+
+// setSyncProgress creates a new sync progress instance and stores a copy of it.
+func (si *SyncInfo) setSyncProgress(wallet sharedW.Asset, timeRemaining int64,
+	headersRemaining, stepFetchProgress, totalSyncProgress int32) ProgressInfo {
+
+	progress := ProgressInfo{
+		remainingSyncTime:    TimeFormat(int(timeRemaining), true),
+		headersToFetchOrScan: 0,
+		stepFetchProgress:    0,
+		syncProgress:         0,
+	}
+
+	si.syncInfoMu.Lock()
+	si.progressInfo[wallet] = &progress
+	si.syncInfoMu.Unlock()
+
+	return progress
+}

--- a/ui/utils/sync_utils.go
+++ b/ui/utils/sync_utils.go
@@ -37,6 +37,15 @@ type SyncInfo struct {
 	syncInfoMu   sync.RWMutex
 }
 
+// NewSyncProgressInfo returns an instance of the SyncInfo with the respective
+// maps initialized.
+func NewSyncProgressInfo() *SyncInfo {
+	return &SyncInfo{
+		progressInfo: make(map[sharedW.Asset]*ProgressInfo),
+		rescanInfo:   make(map[sharedW.Asset]*sharedW.HeadersRescanProgressReport),
+	}
+}
+
 // IsSyncProgressSet returns true if a sync progress instance of the provided wallet
 // exists.
 func (si *SyncInfo) IsSyncProgressSet(wallet sharedW.Asset) bool {

--- a/ui/utils/sync_utils.go
+++ b/ui/utils/sync_utils.go
@@ -50,7 +50,6 @@ func NewSyncProgressInfo() *SyncInfo {
 // exists.
 func (si *SyncInfo) IsSyncProgressSet(wallet sharedW.Asset) bool {
 	_, ok := si.progressInfo.Load(wallet)
-
 	return ok
 }
 
@@ -58,7 +57,6 @@ func (si *SyncInfo) IsSyncProgressSet(wallet sharedW.Asset) bool {
 // asset type.
 func (si *SyncInfo) GetSyncProgress(wallet sharedW.Asset) ProgressInfo {
 	data, _ := si.progressInfo.Load(wallet)
-
 	if data == nil {
 		return ProgressInfo{}
 	}
@@ -77,7 +75,6 @@ func (si *SyncInfo) SetSyncProgress(wallet sharedW.Asset, timeRemaining time.Dur
 	}
 
 	si.progressInfo.Store(wallet, progress)
-
 	return progress
 }
 
@@ -91,7 +88,6 @@ func (si *SyncInfo) DeleteSyncProgress(wallet sharedW.Asset) {
 // provided asset type exists.
 func (si *SyncInfo) IsRescanProgressSet(wallet sharedW.Asset) bool {
 	_, ok := si.rescanInfo.Load(wallet)
-
 	return ok
 }
 
@@ -99,7 +95,6 @@ func (si *SyncInfo) IsRescanProgressSet(wallet sharedW.Asset) bool {
 // asset type.
 func (si *SyncInfo) GetRescanProgress(wallet sharedW.Asset) *sharedW.HeadersRescanProgressReport {
 	data, _ := si.rescanInfo.Load(wallet)
-
 	return data.(*sharedW.HeadersRescanProgressReport)
 }
 

--- a/ui/utils/time_utils.go
+++ b/ui/utils/time_utils.go
@@ -1,0 +1,108 @@
+package utils
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ararog/timeago"
+	"github.com/crypto-power/cryptopower/ui/values"
+)
+
+const (
+	secondInMinute = 60
+	secondsInHour  = 60 * secondInMinute
+	secondsInDay   = 24 * secondsInHour
+)
+
+// File holds all time manipulation implementations required for a given page UI.
+
+// TimeAgo returns the elapsed time since now.
+func TimeAgo(timestamp int64) string {
+	timeAgo, _ := timeago.TimeAgoWithTime(time.Now(), time.Unix(timestamp, 0))
+	return timeAgo
+}
+
+// FormatDateOrTime formats the provided timestamp parameter as follows.
+// If the provided matches to time within today, the time difference between now
+// and then is returned.
+// If it matches to time within the previous one day, "yesterday" is returned.
+// Otherwise the formatted time and date is returned.
+func FormatDateOrTime(timestamp int64) string {
+	utcTime := time.Unix(timestamp, 0).UTC()
+	HoursDifference := time.Now().UTC().Sub(utcTime).Seconds()
+
+	if HoursDifference <= secondsInDay {
+		// Provided timestamp is within the same day(Today).
+		return TimeAgo(timestamp)
+	} else if HoursDifference <= 2*secondsInDay {
+		// Provided timestamp is within the previous day.
+		return values.String(values.StrYesterday)
+	}
+
+	t := strings.Split(utcTime.Format(time.UnixDate), " ")
+	t2 := t[2]
+	year := strconv.Itoa(utcTime.Year())
+	if t[2] == "" {
+		t2 = t[3]
+	}
+	return fmt.Sprintf("%s %s, %s", t[1], t2, year)
+}
+
+// TimeFormat formats the provided `secs` parameter into:
+//   - Day(s) if the seconds exceed or are equal to more than 1 day.
+//   - Hour(s) if the seconds exceed or are equal to more than 1 hour.
+//   - Minute(s) if the seconds exceed or are equal to more than 1 minute.
+//   - Otherwises returns the actual seconds passed.
+//
+// Parameter `long` sets the long format of time description formatted to otherwise
+// it sets the short format.
+func TimeFormat(secs int, long bool) string {
+	val := "s"
+	if long {
+		val = " " + values.String(values.StrSeconds)
+	}
+
+	if secs >= secondsInDay {
+		val = "d"
+		if long {
+			val = " " + values.String(values.StrDays)
+		}
+		days := secs / secondsInDay
+		return fmt.Sprintf("%d%s", days, val)
+	} else if secs >= secondsInHour {
+		val = "h"
+		if long {
+			val = " " + values.String(values.StrHours)
+		}
+		hours := secs / secondsInHour
+		return fmt.Sprintf("%d%s", hours, val)
+	} else if secs >= secondInMinute {
+		val = "m"
+		if long {
+			val = " " + values.String(values.StrMinutes)
+		}
+		mins := secs / secondInMinute
+		return fmt.Sprintf("%d%s", mins, val)
+	}
+
+	return fmt.Sprintf("%d %s", secs, val)
+}
+
+// SecondsToDays takes time in seconds and returns its string equivalent in the format ddhhmm.
+func SecondsToDays(totalTimeLeft int64) string {
+	q, r := divMod(totalTimeLeft, secondsInDay)
+	timeLeft := time.Duration(r) * time.Second
+	if q > 0 {
+		return fmt.Sprintf("%dd%s", q, timeLeft.String())
+	}
+	return timeLeft.String()
+}
+
+// divMod divides a numerator by a denominator and returns its quotient and remainder.
+func divMod(numerator, denominator int64) (quotient, remainder int64) {
+	quotient = numerator / denominator // integer division, decimals are truncated
+	remainder = numerator % denominator
+	return
+}

--- a/ui/utils/time_utils.go
+++ b/ui/utils/time_utils.go
@@ -31,12 +31,12 @@ func TimeAgo(timestamp int64) string {
 // Otherwise the formatted time and date is returned.
 func FormatDateOrTime(timestamp int64) string {
 	utcTime := time.Unix(timestamp, 0).UTC()
-	HoursDifference := time.Now().UTC().Sub(utcTime).Seconds()
+	timeDiff := int(time.Now().UTC().Sub(utcTime).Seconds())
 
-	if HoursDifference <= secondsInDay {
+	if timeDiff <= secondsInDay {
 		// Provided timestamp is within the same day(Today).
 		return TimeAgo(timestamp)
-	} else if HoursDifference <= 2*secondsInDay {
+	} else if timeDiff <= 2*secondsInDay {
 		// Provided timestamp is within the previous day.
 		return values.String(values.StrYesterday)
 	}

--- a/ui/utils/utils.go
+++ b/ui/utils/utils.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"decred.org/dcrdex/dex/encode"
 	"github.com/crypto-power/cryptopower/libwallet/utils"
@@ -52,20 +51,6 @@ func EditorsNotEmpty(editors ...*widget.Editor) bool {
 		}
 	}
 	return true
-}
-
-func FormatDateOrTime(timestamp int64) string {
-	utcTime := time.Unix(timestamp, 0).UTC()
-	if time.Now().UTC().Sub(utcTime).Hours() < 168 {
-		return utcTime.Weekday().String()
-	}
-
-	t := strings.Split(utcTime.Format(time.UnixDate), " ")
-	t2 := t[2]
-	if t[2] == "" {
-		t2 = t[3]
-	}
-	return fmt.Sprintf("%s %s", t[1], t2)
 }
 
 // breakBalance takes the balance string and returns it in two slices


### PR DESCRIPTION
Closes https://github.com/crypto-power/cryptopower/issues/472 #538 

This PR introduces the following changes:
- `IsSyncShuttingDown()` is moved to the shared wallet implementation. It helps in tracking the time when sync shutdown process is in progress.
- Two asset exported methods are introduced. `EnableSyncShuttingDown()` starts the sync shutdown tracking and `EndSyncShuttingDown()` ends the tracking.
- Prompts the shutdown protocol to wait until all the `cancelFuncs` functions are all run.
- Moves all the time formatting functionality with `ui/page` to `ui/utils/time_utils.go`.  Uses alias `pageutils` to better reference `"github.com/crypto-power/cryptopower/ui/utils"`.
- Implements sync utils management functionality that is found at `ui/utils/sync_utils.go`
- Adds Read and Write mutex protection to wallet sync report fields within `walletSyncInfo` page.
- Uses the headers download speed to compute the estimated completion time instead of the upstream provided field `RemainingTime` which is highly inaccurate.
- Made the sync toggle button more responsive to user button clicks. Before toggling the switch wasn't enough to update the sync progress UI. Now, the UI reacts immediately to the toggle button clicks.
- Passes the correct `HandleUserInteractions()` subpage methods to the parent page functionality for a better user interaction with the sync functionality.

<img width="779" alt="Screenshot 2024-07-04 at 00 56 22" src="https://github.com/crypto-power/cryptopower/assets/22055953/dcd34afb-75ea-42ec-8a8b-15d5deaa06c0">

