### PR TITLE
Implement BatchDB Interface in the BTC and LTC WalletData

### DIFF
--- a/libwallet/assets/wallet/walletdata/btc_db.go
+++ b/libwallet/assets/wallet/walletdata/btc_db.go
@@ -90,6 +90,19 @@ func (db *BTCDB) View(f func(tx walletdb.ReadTx) error, reset func()) error {
 	return nil
 }
 
+// Batch is similar to the package-level Update method, but it will attempt to
+// optismitcally combine the invocation of several transaction functions into a
+// single db write transaction.
+//
+// This function is part of the walletdb.Db interface implementation.
+func (db *BTCDB) Batch(f func(tx walletdb.ReadWriteTx) error) error {
+	return db.Bolt.Batch(func(btx *bbolt.Tx) error {
+		interfaceTx := &BTCTX{boltTx: btx}
+
+		return f(interfaceTx)
+	})
+}
+
 // Update opens a database read/write transaction and executes the
 // function f with the transaction passed as a parameter. After f exits,
 // if f did not error, the transaction is committed. Otherwise, if f did

--- a/libwallet/assets/wallet/walletdata/ltc_db.go
+++ b/libwallet/assets/wallet/walletdata/ltc_db.go
@@ -90,6 +90,19 @@ func (db *LTCDB) View(f func(tx walletdb.ReadTx) error, reset func()) error {
 	return nil
 }
 
+// Batch is similar to the package-level Update method, but it will attempt to
+// optismitcally combine the invocation of several transaction functions into a
+// single db write transaction.
+//
+// This function is part of the walletdb.Db interface implementation.
+func (db *LTCDB) Batch(f func(tx walletdb.ReadWriteTx) error) error {
+	return db.Bolt.Batch(func(btx *bbolt.Tx) error {
+		interfaceTx := &LTCTX{boltTx: btx}
+
+		return f(interfaceTx)
+	})
+}
+
 // Update opens a database read/write transaction and executes the
 // function f with the transaction passed as a parameter. After f exits,
 // if f did not error, the transaction is committed. Otherwise, if f did


### PR DESCRIPTION
Resolved the following error logs that occur during the wallet rescan:

```
2024-07-23 12:31:29.960 [ERR] B-NTR: Could not write filters to filterDB: need batch
2024-07-23 12:34:48.790 [ERR] B-NTR: Could not write filters to filterDB: need batch
2024-07-23 12:42:16.612 [ERR] B-NTR: Could not write filters to filterDB: need batch
2024-07-23 12:46:23.675 [ERR] B-NTR: Could not write filters to filterDB: need batch
2024-07-23 12:59:43.668 [ERR] B-NTR: Could not write filters to filterDB: need batch
```

Implementation of the [BatchDB interface](https://github.com/btcsuite/btcwallet/blob/db3a4a2543bdc7ebc1e992b2f7fd01e4abd257a3/walletdb/interface.go#L243-L250) was an optional requirement but neutrino v0.16.0 implements a [batchWriter functionality](https://github.com/lightninglabs/neutrino/blame/a50a92ab8271ea441ef3894fb669ca95be7fa40d/chanutils/batch_writer.go#L96-L100) that makes use of the batchDB interface resulting to the above error logs.