### PR TITLE
Enable auto-sync for new wallet on fresh install

### DIFF
--- a/ui/page/components/restore_page.go
+++ b/ui/page/components/restore_page.go
@@ -35,7 +35,7 @@ type Restore struct {
 	// WindowNavigator if this page is displayed from the StartPage, otherwise
 	// the ParentNavigator is the MainPage.
 	*app.GenericPageModal
-	restoreComplete   func()
+	restoreComplete   func(newWallet sharedW.Asset)
 	tabs              *cryptomaterial.SegmentedControl
 	tabIndex          int
 	backButton        cryptomaterial.IconButton
@@ -49,7 +49,7 @@ type Restore struct {
 	seedTypeDropdown  *cryptomaterial.DropDown
 }
 
-func NewRestorePage(l *load.Load, walletName string, walletType libutils.AssetType, onRestoreComplete func()) *Restore {
+func NewRestorePage(l *load.Load, walletName string, walletType libutils.AssetType, onRestoreComplete func(newWallet sharedW.Asset)) *Restore {
 	pg := &Restore{
 		Load:             l,
 		GenericPageModal: app.NewGenericPageModal(CreateRestorePageID),
@@ -344,7 +344,7 @@ func (pg *Restore) restoreFromSeedEditor() {
 		ShowWalletInfoTip(true).
 		SetParent(pg).
 		SetPositiveButtonCallback(func(_, password string, m *modal.CreatePasswordModal) bool {
-			_, err := pg.AssetsManager.RestoreWallet(pg.walletType, pg.walletName, seedOrHex, password, sharedW.PassphraseTypePass, wordSeedType)
+			importedWallet, err := pg.AssetsManager.RestoreWallet(pg.walletType, pg.walletName, seedOrHex, password, sharedW.PassphraseTypePass, wordSeedType)
 			if err != nil {
 				errString := err.Error()
 				if err.Error() == libutils.ErrExist {
@@ -360,7 +360,7 @@ func (pg *Restore) restoreFromSeedEditor() {
 			m.Dismiss()
 			pg.ParentNavigator().CloseCurrentPage()
 			if pg.restoreComplete != nil {
-				pg.restoreComplete()
+				pg.restoreComplete(importedWallet)
 			}
 			clearEditor()
 			return true

--- a/ui/page/components/seed_restore_page.go
+++ b/ui/page/components/seed_restore_page.go
@@ -46,7 +46,7 @@ type SeedRestore struct {
 	// the ParentNavigator is the MainPage.
 	*app.GenericPageModal
 	isRestoring     bool
-	restoreComplete func()
+	restoreComplete func(newWallet sharedW.Asset)
 
 	seedList *layout.List
 
@@ -78,7 +78,7 @@ type SeedRestore struct {
 	getWordSeedType func() sharedW.WordSeedType
 }
 
-func NewSeedRestorePage(l *load.Load, walletName string, walletType libutils.AssetType, onRestoreComplete func(), getWordSeedType func() sharedW.WordSeedType) *SeedRestore {
+func NewSeedRestorePage(l *load.Load, walletName string, walletType libutils.AssetType, onRestoreComplete func(newWallet sharedW.Asset), getWordSeedType func() sharedW.WordSeedType) *SeedRestore {
 	pg := &SeedRestore{
 		Load:            l,
 		restoreComplete: onRestoreComplete,
@@ -532,7 +532,7 @@ func (pg *SeedRestore) HandleUserInteractions(gtx C) {
 			ShowWalletInfoTip(true).
 			SetParent(pg).
 			SetPositiveButtonCallback(func(_, password string, m *modal.CreatePasswordModal) bool {
-				_, err := pg.AssetsManager.RestoreWallet(pg.walletType, pg.walletName, pg.seedPhrase, password, sharedW.PassphraseTypePass, pg.getWordSeedType())
+				importedWallet, err := pg.AssetsManager.RestoreWallet(pg.walletType, pg.walletName, pg.seedPhrase, password, sharedW.PassphraseTypePass, pg.getWordSeedType())
 				if err != nil {
 					errString := err.Error()
 					if err.Error() == libutils.ErrExist {
@@ -549,7 +549,7 @@ func (pg *SeedRestore) HandleUserInteractions(gtx C) {
 				m.Dismiss()
 				pg.window.CloseCurrentPage()
 				if pg.restoreComplete != nil {
-					pg.restoreComplete()
+					pg.restoreComplete(importedWallet)
 				}
 				return true
 			})

--- a/ui/page/components/wallet_setup_page.go
+++ b/ui/page/components/wallet_setup_page.go
@@ -92,7 +92,7 @@ func NewCreateWallet(l *load.Load, walletCreationSuccessCallback func(newWallet 
 	}
 
 	if walletCreationSuccessCallback == nil {
-		pg.walletCreationSuccessCallback = func(newWallet sharedW.Asset) {
+		pg.walletCreationSuccessCallback = func(_ sharedW.Asset) {
 			pg.ParentNavigator().CloseCurrentPage()
 		}
 	}

--- a/ui/page/dcrdex/market.go
+++ b/ui/page/dcrdex/market.go
@@ -1732,7 +1732,7 @@ func (pg *DEXMarketPage) handleMissingMarketWallet() {
 		return
 	}
 
-	callbackFn := func() {
+	callbackFn := func(_ sharedW.Asset) {
 		pg.ParentNavigator().ClosePagesAfter(DEXMarketPageID)
 		showWalletModal()
 	}

--- a/ui/page/exchange/create_order_page.go
+++ b/ui/page/exchange/create_order_page.go
@@ -261,7 +261,7 @@ func (pg *CreateOrderPage) displayCreateWalletModal(isSourceWallet bool, asset l
 		SetCancelable(true).
 		SetContentAlignment(layout.Center, layout.W, layout.Center).
 		SetPositiveButtonCallback(func(_ bool, _ *modal.InfoModal) bool {
-			pg.ParentNavigator().Display(components.NewCreateWallet(pg.Load, func() {
+			pg.ParentNavigator().Display(components.NewCreateWallet(pg.Load, func(_ sharedW.Asset) {
 				pg.walletCreationSuccessFunc(isSourceWallet, asset)
 			}, asset))
 			return true
@@ -475,7 +475,7 @@ func (pg *CreateOrderPage) HandleUserInteractions(gtx C) {
 
 	if pg.createWalletBtn.Button.Clicked(gtx) {
 		assetToCreate := pg.AssetToCreate()
-		pg.ParentNavigator().Display(components.NewCreateWallet(pg.Load, func() {
+		pg.ParentNavigator().Display(components.NewCreateWallet(pg.Load, func(_ sharedW.Asset) {
 			pg.walletCreationSuccessFunc(false, assetToCreate)
 		}, assetToCreate))
 	}

--- a/ui/page/governance/proposal_details_page.go
+++ b/ui/page/governance/proposal_details_page.go
@@ -720,7 +720,7 @@ func (pg *ProposalDetails) displayCreateWalletModal(asset libutils.AssetType) {
 		SetCancelable(true).
 		SetContentAlignment(layout.Center, layout.W, layout.Center).
 		SetPositiveButtonCallback(func(_ bool, _ *modal.InfoModal) bool {
-			pg.ParentNavigator().Display(components.NewCreateWallet(pg.Load, func() {
+			pg.ParentNavigator().Display(components.NewCreateWallet(pg.Load, func(_ sharedW.Asset) {
 				pg.walletCreationSuccessFunc()
 			}, asset))
 			return true

--- a/ui/page/governance/treasury_page.go
+++ b/ui/page/governance/treasury_page.go
@@ -182,7 +182,7 @@ func (pg *TreasuryPage) HandleUserInteractions(gtx C) {
 	}
 
 	if pg.createWalletBtn.Button.Clicked(gtx) {
-		pg.ParentNavigator().Display(components.NewCreateWallet(pg.Load, func() {
+		pg.ParentNavigator().Display(components.NewCreateWallet(pg.Load, func(_ sharedW.Asset) {
 			pg.walletCreationSuccessFunc()
 		}, libutils.DCRWalletAsset))
 	}

--- a/ui/page/root/wallet_selector_page.go
+++ b/ui/page/root/wallet_selector_page.go
@@ -198,7 +198,7 @@ func (pg *WalletSelectorPage) HandleUserInteractions(gtx C) {
 		// Create a local copy of asset for each iteration
 		asset := asset
 		if clickable.Clicked(gtx) {
-			pg.ParentNavigator().Display(components.NewCreateWallet(pg.Load, func() {
+			pg.ParentNavigator().Display(components.NewCreateWallet(pg.Load, func(_ sharedW.Asset) {
 				pg.ParentNavigator().ClosePagesAfter(WalletSelectorPageID)
 				// enable sync for the newly created wallet
 				wallets, wExists := pg.walletsList[asset]

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -260,9 +260,8 @@ func (sp *startPage) HandleUserInteractions(gtx C) {
 	}
 
 	if sp.addWalletButton.Clicked(gtx) {
-		isFirstWallet := sp.AssetsManager.LoadedWalletsCount() == 0
 		createWalletPage := components.NewCreateWallet(sp.Load, func(newWallet sharedW.Asset) {
-			if newWallet != nil && isFirstWallet {
+			if newWallet != nil {
 				newWallet.SaveUserConfigValue(sharedW.AutoSyncConfigKey, true)
 			}
 			

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/text/language"
 
 	"github.com/crypto-power/cryptopower/app"
+	sharedW "github.com/crypto-power/cryptopower/libwallet/assets/wallet"
 	libutils "github.com/crypto-power/cryptopower/libwallet/utils"
 	"github.com/crypto-power/cryptopower/ui/cryptomaterial"
 	"github.com/crypto-power/cryptopower/ui/load"
@@ -259,7 +260,11 @@ func (sp *startPage) HandleUserInteractions(gtx C) {
 	}
 
 	if sp.addWalletButton.Clicked(gtx) {
-		createWalletPage := components.NewCreateWallet(sp.Load, func() {
+		createWalletPage := components.NewCreateWallet(sp.Load, func(newWallet sharedW.Asset) {
+			if newWallet != nil {
+				newWallet.SaveUserConfigValue(sharedW.AutoSyncConfigKey, true)
+			}
+			
 			sp.setLanguagePref(false)
 			sp.ParentNavigator().Display(root.NewHomePage(sp.ctx, sp.Load))
 		})

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -264,7 +264,6 @@ func (sp *startPage) HandleUserInteractions(gtx C) {
 			if newWallet != nil {
 				newWallet.SaveUserConfigValue(sharedW.AutoSyncConfigKey, true)
 			}
-			
 			sp.setLanguagePref(false)
 			sp.ParentNavigator().Display(root.NewHomePage(sp.ctx, sp.Load))
 		})

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -260,8 +260,9 @@ func (sp *startPage) HandleUserInteractions(gtx C) {
 	}
 
 	if sp.addWalletButton.Clicked(gtx) {
+		isFirstWallet := sp.AssetsManager.LoadedWalletsCount() == 0
 		createWalletPage := components.NewCreateWallet(sp.Load, func(newWallet sharedW.Asset) {
-			if newWallet != nil {
+			if newWallet != nil && isFirstWallet {
 				newWallet.SaveUserConfigValue(sharedW.AutoSyncConfigKey, true)
 			}
 			


### PR DESCRIPTION
Closes #595 

This PR enables auto-sync for wallets created from the onboarding screen if it is the first wallet.