### PR TITLE
Remember selected tab on the wallet page

### DIFF
--- a/ui/cryptomaterial/segmented_control.go
+++ b/ui/cryptomaterial/segmented_control.go
@@ -26,6 +26,9 @@ type SegmentedControl struct {
 	leftNavBtn,
 	rightNavBtn *Clickable
 
+	leftNavBtnVisible  bool
+	rightNavBtnVisible bool
+
 	Padding        layout.Inset
 	ContentPadding layout.Inset
 	Alignment      layout.Alignment
@@ -58,6 +61,8 @@ func (t *Theme) SegmentedControl(segmentTitles []string, segmentType SegmentType
 		segmentTitles:        segmentTitles,
 		leftNavBtn:           t.NewClickable(false),
 		rightNavBtn:          t.NewClickable(false),
+		leftNavBtnVisible:    false,
+		rightNavBtnVisible:   true,
 		isSwipeActionEnabled: true,
 		segmentType:          segmentType,
 		slideAction:          NewSlideAction(),
@@ -207,6 +212,12 @@ func (sc *SegmentedControl) splitTileLayout(gtx C) D {
 		Alignment:   layout.Middle,
 	}.Layout(gtx,
 		layout.Flexed(flexWidthLeft, func(gtx C) D {
+			if !sc.leftNavBtnVisible {
+				return D{
+					Size:     gtx.Constraints.Min,
+					Baseline: 0,
+				}
+			}
 			return sc.leftNavBtn.Layout(gtx, sc.theme.NewIcon(sc.theme.Icons.ChevronLeft).Layout24dp)
 		}),
 		layout.Flexed(flexWidthCenter, func(gtx C) D {
@@ -246,6 +257,12 @@ func (sc *SegmentedControl) splitTileLayout(gtx C) D {
 			})
 		}),
 		layout.Flexed(flexWidthRight, func(gtx C) D {
+			if !sc.rightNavBtnVisible {
+				return D{
+					Size:     gtx.Constraints.Min,
+					Baseline: 0,
+				}
+			}
 			return sc.rightNavBtn.Layout(gtx, sc.theme.NewIcon(sc.theme.Icons.ChevronRight).Layout24dp)
 		}),
 	)
@@ -338,6 +355,7 @@ func (sc *SegmentedControl) dynamicSplitTileLayout(gtx C) D {
 func (sc *SegmentedControl) handleEvents(gtx C) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
+	sc.updateArrowVisibility()
 	if segmentItemClicked, clickedSegmentIndex := sc.list.ItemClicked(); segmentItemClicked {
 		if sc.selectedIndex != clickedSegmentIndex {
 			sc.changed = true
@@ -355,6 +373,20 @@ func (sc *SegmentedControl) handleEvents(gtx C) {
 		sc.list.Position.OffsetLast = 0
 		sc.list.Position.BeforeEnd = false
 		sc.list.ScrollToEnd = true
+	}
+}
+
+func (sc *SegmentedControl) updateArrowVisibility() {
+	if sc.list.Position.First == 0 {
+		sc.leftNavBtnVisible = false
+	} else {
+		sc.leftNavBtnVisible = true
+	}
+
+	if sc.list.Position.First+sc.list.Position.Count >= len(sc.segmentTitles) {
+		sc.rightNavBtnVisible = false
+	} else {
+		sc.rightNavBtnVisible = true
 	}
 }
 

--- a/ui/page/root/wallet_selector_page.go
+++ b/ui/page/root/wallet_selector_page.go
@@ -20,6 +20,8 @@ import (
 
 const WalletSelectorPageID = "wallet_selector"
 
+var expandedAssetType string
+
 type (
 	C = layout.Context
 	D = layout.Dimensions
@@ -113,6 +115,8 @@ func (pg *WalletSelectorPage) OnNavigatedTo() {
 		pg.assetCollapsibles[asset] = pg.Load.Theme.Collapsible()
 		pg.addWalClickable[asset] = pg.Load.Theme.NewClickable(false)
 		pg.addWalClickable[asset].Radius = cryptomaterial.Radius(14)
+
+		pg.assetCollapsibles[asset].SetExpanded(expandedAssetType == asset.String())
 	}
 
 	go func() {
@@ -223,6 +227,13 @@ func (pg *WalletSelectorPage) HandleUserInteractions(gtx C) {
 // components unless they'll be recreated in the OnNavigatedTo() method.
 // Part of the load.Page interface.
 func (pg *WalletSelectorPage) OnNavigatedFrom() {
+	supportedAssets := pg.AssetsManager.AllAssetTypes()
+	expandedAssetType = ""
+	for _, asset := range supportedAssets {
+		if pg.assetCollapsibles[asset].IsExpanded() {
+			expandedAssetType = asset.String()
+		}
+	}
 	pg.stopSyncProgressListeners()
 }
 


### PR DESCRIPTION
Close #590 
Close #588 

- Updated the wallet detail page to remember the selected tab and navigate to it when the page is revisited
- Updated the Wallets page to track the expanded asset type and expand it on page revisit.
- Update the nav tab on the Wallet page to auto hide/show the left/right scroll button when it is ready in the left-most or right-most position

<img width="753" alt="image" src="https://github.com/user-attachments/assets/b6d9634a-4ec0-4b9e-8b6f-4d11a7fd531b">


<img width="757" alt="image" src="https://github.com/user-attachments/assets/fc55ead6-a31f-4810-86fb-553c36f1f149">


<img width="750" alt="image" src="https://github.com/user-attachments/assets/67a5e316-42a1-41f3-a9c0-1077afa34fc8">
