### PR TITLE
Change wallet name in wallet details page to a dropdown

### DIFF
--- a/ui/page/wallet/single_wallet_main_page.go
+++ b/ui/page/wallet/single_wallet_main_page.go
@@ -559,7 +559,7 @@ func (swmp *SingleWalletMasterPage) LayoutTopBar(gtx C) D {
 									Alignment:   alignment,
 								}.Layout(gtx,
 									layout.Rigid(func(gtx C) D {
-										return swmp.dropdownWallet(gtx)
+										return swmp.walletDropdownLayout(gtx)
 									}),
 									layout.Rigid(func(gtx C) D {
 										gtx.Constraints.Min.X = gtx.Constraints.Max.X
@@ -605,7 +605,7 @@ func (swmp *SingleWalletMasterPage) LayoutTopBar(gtx C) D {
 	)
 }
 
-func (swmp *SingleWalletMasterPage) dropdownWallet(gtx C) D {
+func (swmp *SingleWalletMasterPage) walletDropdownLayout(gtx C) D {
 	return layout.Flex{
 		Axis:      layout.Horizontal,
 		Alignment: layout.Middle,


### PR DESCRIPTION
Closes: #587 

This resolved:
- Change wallet name in wallet details page to a dropdown to quickly switch wallets

<img width="905" alt="image" src="https://github.com/user-attachments/assets/aa2f19f1-c2fd-4a5f-ad99-566c31ba2df0">
