### PR TITLE
fix app freeze after turn off sync then click back button

### DIFF
--- a/libwallet/assets/btc/sync.go
+++ b/libwallet/assets/btc/sync.go
@@ -338,9 +338,6 @@ func (asset *Asset) loadChainService() (chainService *neutrino.ChainService, err
 
 // CancelSync stops the sync process.
 func (asset *Asset) CancelSync() {
-	asset.syncData.mu.RLock()
-	defer asset.syncData.mu.RUnlock()
-
 	log.Info("Canceling sync. May take a while for sync to fully cancel.")
 
 	// Cancel all the pending tcp connection at the node level.

--- a/libwallet/assets/ltc/sync.go
+++ b/libwallet/assets/ltc/sync.go
@@ -359,9 +359,6 @@ func (asset *Asset) loadChainService() (chainService *neutrino.ChainService, err
 
 // CancelSync stops the sync process.
 func (asset *Asset) CancelSync() {
-	asset.syncData.mu.RLock()
-	defer asset.syncData.mu.RUnlock()
-
 	log.Info("Canceling sync. May take a while for sync to fully cancel.")
 
 	// Cancel all the pending tcp connection at the node level.

--- a/ui/cryptomaterial/switch.go
+++ b/ui/cryptomaterial/switch.go
@@ -143,6 +143,9 @@ func (s *Switch) Layout(gtx layout.Context) layout.Dimensions {
 }
 
 func (s *Switch) Changed(gtx C) bool {
+	if s.disabled {
+		return false
+	}
 	return s.clk.Update(gtx)
 }
 


### PR DESCRIPTION
closed: #621 

this PR following changes:
- Fix app freeze after turn off sync then click back button. Remove unnecessary RWMutex.Rlock().
- Always return false in the Changed function to prevent the user change the switch when the switch is disabled