### PR TITLE
show send to wallet if there is at least one valid account

### DIFF
--- a/ui/page/send/recipient.go
+++ b/ui/page/send/recipient.go
@@ -130,7 +130,7 @@ func (rp *recipient) isShowSendToWallet() bool {
 				accountValids = append(accountValids, *acc)
 			}
 		}
-		return len(accountValids) > 1
+		return len(accountValids) > 0 // it should show the send to wallet if there is at least one valid account.
 	}
 
 	if len(wallets) > 1 {


### PR DESCRIPTION
This following changes:
- show "send to wallet" option if there is more than one valid account in a wallet or there are more than one wallet of the same asset type

<img width="955" alt="image" src="https://github.com/user-attachments/assets/ce5e4f98-7d42-4481-916a-8334b0d33ec7">
