### PR TITLE
ui/page/accounts: list coins locked by ticket separately

### DIFF
--- a/ui/page/accounts/dcr_account_details_page.go
+++ b/ui/page/accounts/dcr_account_details_page.go
@@ -46,6 +46,7 @@ type AcctDetailsPage struct {
 	totalBalance     string
 	spendableBalance string
 	immatureBalance  string
+	lockeByTicket    string
 	votingAuthority  string
 	hdPath           string
 	keys             string
@@ -83,12 +84,12 @@ func NewDCRAcctDetailsPage(l *load.Load, wallet sharedW.Asset, account *sharedW.
 // the page is displayed.
 // Part of the load.Page interface.
 func (pg *AcctDetailsPage) OnNavigatedTo() {
-
 	bal := pg.account.Balance
-	pg.lockedBalance = pg.wallet.ToAmount(bal.Locked.ToInt() + bal.LockedByTickets.ToInt()).String()
+	pg.lockedBalance = bal.Locked.String()
 	pg.totalBalance = bal.Total.String()
 	pg.spendableBalance = bal.Spendable.String()
 	pg.immatureBalance = pg.wallet.ToAmount(bal.ImmatureReward.ToInt() + bal.ImmatureStakeGeneration.ToInt()).String()
+	pg.lockeByTicket = bal.LockedByTickets.String()
 	pg.votingAuthority = bal.VotingAuthority.String()
 
 	pg.hdPath = pg.AssetsManager.DCRHDPrefix() + strconv.Itoa(int(pg.account.Number)) + "'"
@@ -236,6 +237,9 @@ func (pg *AcctDetailsPage) accountBalanceLayout(gtx C) D {
 					}),
 					layout.Rigid(func(gtx C) D {
 						return pg.acctBalLayout(gtx, values.String(values.StrImmature), pg.immatureBalance, false)
+					}),
+					layout.Rigid(func(gtx C) D {
+						return pg.acctBalLayout(gtx, values.String(values.StrLockedByTickets), pg.lockeByTicket, false)
 					}),
 					layout.Rigid(func(gtx C) D {
 						return pg.acctBalLayout(gtx, values.String(values.StrVotingAuthority), pg.votingAuthority, false)


### PR DESCRIPTION
This PR adds a new locked coin type (Locked By Tickets) to the account details page, resolving an issue where a user might be confused about why their coins are locked.

IMO, we should hide zero bal fields on this page. esp anything `locked`.

<img width="752" alt="Screenshot 2024-09-03 at 1 58 15 PM" src="https://github.com/user-attachments/assets/02d49f9e-b05b-4927-99b1-ae1ca70f3128">
