### PR TITLE
fix icon button too small on mobile, segment control tab not fit

### DIFF
--- a/ui/page/components/restore_page.go
+++ b/ui/page/components/restore_page.go
@@ -234,9 +234,11 @@ func (pg *Restore) HandleUserInteractions(gtx C) {
 	if pg.tabs.Changed() {
 		pg.tabIndex = pg.tabs.SelectedIndex()
 	}
-
-	if !pg.toggleSeedInput.IsChecked() && pg.toggleSeedInput.Changed(gtx) {
-		pg.seedRestorePage.setEditorFocus()
+	if pg.toggleSeedInput.Changed(gtx) {
+		if !pg.toggleSeedInput.IsChecked() {
+			pg.seedRestorePage.setEditorFocus()
+			pg.ParentWindow().Reload()
+		}
 	}
 
 	if pg.tabIndex == 0 {

--- a/ui/page/components/seed_restore_page.go
+++ b/ui/page/components/seed_restore_page.go
@@ -48,7 +48,8 @@ type SeedRestore struct {
 	isRestoring     bool
 	restoreComplete func(newWallet sharedW.Asset)
 
-	seedList *layout.List
+	seedList        *layout.List
+	scrollContainer *widget.List
 
 	validateSeed    cryptomaterial.Button
 	resetSeedFields cryptomaterial.Button
@@ -83,6 +84,7 @@ func NewSeedRestorePage(l *load.Load, walletName string, walletType libutils.Ass
 		Load:            l,
 		restoreComplete: onRestoreComplete,
 		seedList:        &layout.List{Axis: layout.Vertical},
+		scrollContainer: &widget.List{List: layout.List{Axis: layout.Vertical, Alignment: layout.Middle}},
 		suggestionLimit: 3,
 		openPopupIndex:  -1,
 		walletName:      walletName,
@@ -169,28 +171,27 @@ func (pg *SeedRestore) Layout(gtx C) D {
 }
 
 func (pg *SeedRestore) restore(gtx C) D {
-	return layout.Stack{Alignment: layout.S}.Layout(gtx,
-		layout.Expanded(func(gtx C) D {
-			return cryptomaterial.LinearLayout{
-				Orientation: layout.Vertical,
-				Width:       cryptomaterial.MatchParent,
-				Height:      cryptomaterial.WrapContent,
-				Background:  pg.Theme.Color.Surface,
-				Border:      cryptomaterial.Border{Radius: cryptomaterial.Radius(14)},
-				Padding:     layout.UniformInset(values.MarginPadding15),
-			}.Layout(gtx,
-				layout.Rigid(pg.seedEditorViewDesktop),
-				layout.Rigid(layout.Spacer{Height: values.MarginPadding5}.Layout),
-				layout.Rigid(pg.resetSeedFields.Layout),
-			)
-		}),
-		layout.Stacked(func(gtx C) D {
-			gtx.Constraints.Min.Y = gtx.Constraints.Max.Y
-			return layout.S.Layout(gtx, func(gtx C) D {
-				return layout.Inset{Left: values.MarginPadding1}.Layout(gtx, pg.restoreButtonSection)
-			})
-		}),
-	)
+	return pg.Theme.List(pg.scrollContainer).Layout(gtx, 1, func(gtx C, _ int) D {
+		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+			layout.Rigid(func(gtx C) D {
+				return cryptomaterial.LinearLayout{
+					Orientation: layout.Vertical,
+					Width:       cryptomaterial.MatchParent,
+					Height:      cryptomaterial.WrapContent,
+					Background:  pg.Theme.Color.Surface,
+					Border:      cryptomaterial.Border{Radius: cryptomaterial.Radius(14)},
+					Padding:     layout.UniformInset(values.MarginPadding15),
+				}.Layout(gtx,
+					layout.Rigid(pg.seedEditorViewDesktop),
+					layout.Rigid(layout.Spacer{Height: values.MarginPadding5}.Layout),
+					layout.Rigid(pg.resetSeedFields.Layout),
+				)
+			}),
+			layout.Rigid(func(gtx C) D {
+				return layout.Inset{Top: values.MarginPadding5, Bottom: values.MarginPadding5}.Layout(gtx, pg.restoreButtonSection)
+			}),
+		)
+	})
 }
 
 func (pg *SeedRestore) restoreButtonSection(gtx C) D {

--- a/ui/page/components/sub_page.go
+++ b/ui/page/components/sub_page.go
@@ -50,7 +50,7 @@ func GetBackButton(l *load.Load) cryptomaterial.IconButton {
 	backButton := l.Theme.NewIconButton(l.Theme.Icons.NavigationArrowBack, backClickable)
 	size := values.MarginPadding24
 	if l.IsMobileView() {
-		size = values.MarginPadding16
+		size = values.MarginPadding20
 	}
 	backButton.Size = size
 	backButton.Inset = layout.UniformInset(values.MarginPadding0)

--- a/ui/page/governance/governance_page.go
+++ b/ui/page/governance/governance_page.go
@@ -43,7 +43,7 @@ func NewGovernancePage(l *load.Load, detailData interface{}) *Page {
 		detailData:      detailData,
 	}
 
-	pg.tab = l.Theme.SegmentedControl(governanceTabTitles, cryptomaterial.SegmentTypeGroup)
+	pg.tab = l.Theme.SegmentedControl(governanceTabTitles, cryptomaterial.SegmentTypeGroupMax)
 
 	pg.tabCategoryList.IsHoverable = false
 

--- a/ui/page/seedbackup/backup_instructions.go
+++ b/ui/page/seedbackup/backup_instructions.go
@@ -120,6 +120,11 @@ func (pg *BackupInstructionsPage) OnNavigatedFrom() {}
 // to be eventually drawn on screen.
 // Part of the load.Page interface.
 func (pg *BackupInstructionsPage) Layout(gtx C) D {
+	for i := range pg.checkBoxes {
+		if pg.checkBoxes[i].CheckBox.Update(gtx) {
+			pg.ParentWindow().Reload()
+		}
+	}
 	sp := components.SubPage{
 		Load:       pg.Load,
 		Title:      values.String(values.StrKeepInMind),

--- a/ui/page/seedbackup/save_seed.go
+++ b/ui/page/seedbackup/save_seed.go
@@ -126,6 +126,7 @@ func (pg *SaveSeedPage) OnNavigatedTo() {
 			seed, err := pg.wallet.DecryptSeed(password)
 			if err != nil {
 				m.SetError(err.Error())
+				m.ParentWindow().Reload()
 				return false
 			}
 			m.Dismiss()

--- a/ui/page/seedbackup/verify_seed.go
+++ b/ui/page/seedbackup/verify_seed.go
@@ -195,6 +195,7 @@ func (pg *VerifySeedPage) verifySeed() {
 				}
 
 				m.SetError(err.Error())
+				m.ParentWindow().Reload()
 				return false
 			}
 
@@ -210,6 +211,10 @@ func (pg *VerifySeedPage) verifySeed() {
 // displayed.
 // Part of the load.Page interface.
 func (pg *VerifySeedPage) HandleUserInteractions(gtx C) {
+	if pg.toggleSeedInput.Changed(gtx) {
+		pg.ParentWindow().Reload()
+	}
+
 	for i, multiSeed := range pg.multiSeedList {
 		for j, clickable := range multiSeed.clickables {
 			if clickable.Clicked(gtx) {

--- a/ui/page/settings/about_page.go
+++ b/ui/page/settings/about_page.go
@@ -102,10 +102,10 @@ func (pg *AboutPage) pageHeaderLayout(gtx layout.Context) layout.Dimensions {
 					layout.Rigid(func(gtx C) D {
 						return layout.Inset{
 							Right: values.MarginPadding16,
-							Top:   values.MarginPaddingMinus2,
+							Top:   values.MarginPadding2,
 						}.Layout(gtx, pg.backButton.Layout)
 					}),
-					layout.Rigid(pg.Theme.Label(values.TextSize20, values.String(values.StrAbout)).Layout),
+					layout.Rigid(pg.Theme.Label(values.TextSizeTransform(pg.Load.IsMobileView(), values.TextSize20), values.String(values.StrAbout)).Layout),
 				)
 			})
 		}),

--- a/ui/page/settings/app_settings_page.go
+++ b/ui/page/settings/app_settings_page.go
@@ -172,6 +172,7 @@ func (pg *AppSettingsPage) pageHeaderLayout(gtx C) layout.Dimensions {
 				return layout.Flex{}.Layout(gtx,
 					layout.Rigid(func(gtx C) D {
 						return layout.Inset{
+							Top:   values.MarginPadding2,
 							Right: values.MarginPadding16,
 						}.Layout(gtx, pg.backButton.Layout)
 					}),

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -10,7 +10,6 @@ import (
 	"gioui.org/layout"
 	"gioui.org/text"
 	"gioui.org/unit"
-	"gioui.org/widget"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
@@ -101,7 +100,7 @@ func NewStartPage(ctx context.Context, l *load.Load, isShuttingDown ...bool) app
 		addWalletButton:     l.Theme.Button(values.String(values.StrAddWallet)),
 		nextButton:          l.Theme.Button(values.String(values.StrNext)),
 		skipButton:          l.Theme.OutlineButton(values.String(values.StrSkip)),
-		backButton:          getBackButton(l),
+		backButton:          components.GetBackButton(l),
 		networkSwitchButton: l.Theme.NewClickable(true),
 		introductionSlider:  l.Theme.Slider(),
 		logo:                l.Theme.Icons.AppIcon,
@@ -122,19 +121,6 @@ func NewStartPage(ctx context.Context, l *load.Load, isShuttingDown ...bool) app
 	sp.initPage()
 
 	return sp
-}
-
-func getBackButton(l *load.Load) cryptomaterial.IconButton {
-	backClickable := new(widget.Clickable)
-	backButton := l.Theme.NewIconButton(l.Theme.Icons.NavigationArrowBack, backClickable)
-	size := values.MarginPadding24
-	if l.IsMobileView() {
-		size = values.MarginPadding16
-	}
-	backButton.Size = size
-	backButton.Inset = layout.UniformInset(values.MarginPadding0)
-	l.Theme.AddBackClick(backClickable)
-	return backButton
 }
 
 // OnNavigatedTo is called when the page is about to be displayed and

--- a/ui/page/wallet/single_wallet_main_page.go
+++ b/ui/page/wallet/single_wallet_main_page.go
@@ -328,6 +328,10 @@ func (swmp *SingleWalletMasterPage) changeTab(tab string) {
 // displayed.
 // Part of the load.Page interface.
 func (swmp *SingleWalletMasterPage) HandleUserInteractions(gtx C) {
+	if swmp.checkBox.CheckBox.Update(gtx) {
+		swmp.ParentWindow().Reload()
+	}
+
 	if swmp.walletDropdown.Changed(gtx) {
 		swmp.OnNavigatedFrom()
 		swmp.CloseAllPages()


### PR DESCRIPTION
closed: #634 

This PR has changed:
- Increase icon button size on mobile
- Fix The segmented control tab is not fitting on the governance page
- Add scroll bar to Restore wallet page
- Fix some pages don't refresh after performing an action until tap somewhere on the screen

![Screenshot_1725855062](https://github.com/user-attachments/assets/b846c12c-732b-4dd0-bde4-fb573d626a59)
![Screenshot_1725855075](https://github.com/user-attachments/assets/22f5c63e-8738-445e-9640-cb4d14c0a2f8)
![Screenshot_1725855125](https://github.com/user-attachments/assets/a2e95c44-7527-4354-a5d9-41c0c76f747e)
