### PR TITLE
Fixed the button was disabled in send page

### DIFF
--- a/ui/page/send/send_destination.go
+++ b/ui/page/send/send_destination.go
@@ -64,7 +64,7 @@ func (dst *destination) initDestinationWalletSelector(assetType libUtil.AssetTyp
 			}
 			if wallet.GetWalletID() == dst.sourceAccount.WalletID {
 				account, err := wallet.GetAccountsRaw()
-				if err != nil || len(account.Accounts) <= 2 {
+				if err != nil || len(account.Accounts) < 2 {
 					return false
 				}
 			}


### PR DESCRIPTION
This PR changed:
- Fixed an issue where the button was disabled when there was only one wallet of the same type