### PR TITLE
Allow users decide dexc first time initialization

### DIFF
--- a/dexc/core.go
+++ b/dexc/core.go
@@ -28,6 +28,10 @@ const (
 	// number in the settings map used to connect an existing Cryptopower wallet
 	// to the DEX client.
 	WalletAccountNumberConfigKey = "accountnumber"
+
+	// DBFileName is the database name for a dexc instance. Changing this
+	// without proper migration might lead to unexpected behaviors.
+	DBFileName = "dexc.db"
 )
 
 // DEXClient represents the Decred DEX client and embeds *core.Core.
@@ -168,7 +172,7 @@ func Start(ctx context.Context, root, lang, logDir, logLvl string, net libutils.
 		return nil, err
 	}
 
-	dbPath := filepath.Join(root, "dexc.db")
+	dbPath := filepath.Join(root, DBFileName)
 	cfg := &core.Config{
 		DBPath:             dbPath,
 		Net:                dexNet,

--- a/ui/page/root/migrate_page.go
+++ b/ui/page/root/migrate_page.go
@@ -80,11 +80,11 @@ func (mp *MigrationPage) HandleUserInteractions(gtx C) {
 		}
 
 		mp.AssetsManager = newmgr
-		mp.ParentWindow().ClearStackAndDisplay(NewHomePage(mp.ctx, mp.Load))
+		mp.ParentWindow().ClearStackAndDisplay(NewHomePage(mp.Load))
 	}
 
 	if mp.cancelButton.Clicked(gtx) {
-		mp.ParentWindow().ClearStackAndDisplay(NewHomePage(mp.ctx, mp.Load))
+		mp.ParentWindow().ClearStackAndDisplay(NewHomePage(mp.Load))
 	}
 
 	for i := range mp.inputPasswordButtons {

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -241,7 +241,7 @@ func (sp *startPage) openWalletsAndDisplayHomePage(password string) error {
 	if numberOfRAM < 4 && sp.AssetsManager.NeedMigrate {
 		sp.showRemoveWalletWarning()
 	} else {
-		sp.ParentNavigator().ClearStackAndDisplay(root.NewHomePage(sp.ctx, sp.Load))
+		sp.ParentNavigator().ClearStackAndDisplay(root.NewHomePage(sp.Load))
 	}
 	return nil
 }
@@ -266,7 +266,7 @@ func (sp *startPage) HandleUserInteractions(gtx C) {
 				newWallet.SaveUserConfigValue(sharedW.AutoSyncConfigKey, true)
 			}
 			sp.setLanguagePref(false)
-			sp.ParentNavigator().Display(root.NewHomePage(sp.ctx, sp.Load))
+			sp.ParentNavigator().Display(root.NewHomePage(sp.Load))
 		})
 		sp.ParentNavigator().Display(createWalletPage)
 	}
@@ -765,7 +765,7 @@ func (sp *startPage) showRemoveWalletWarning() {
 		PositiveButtonStyle(sp.Theme.Color.Surface, sp.Theme.Color.Danger)
 
 	warningModal.SetNegativeButtonCallback(func() {
-		sp.ParentNavigator().ClearStackAndDisplay(root.NewHomePage(sp.ctx, sp.Load))
+		sp.ParentNavigator().ClearStackAndDisplay(root.NewHomePage(sp.Load))
 	})
 
 	warningModal.SetPositiveButtonCallback(func(_ bool, _ *modal.InfoModal) bool {

--- a/ui/window.go
+++ b/ui/window.go
@@ -101,6 +101,9 @@ func CreateWindow(appInfo *load.AppInfo) (*Window, error) {
 	startPage := page.NewStartPage(win.ctx, win.load)
 	win.load.AppInfo.ReadyForDisplay(win.Window, startPage)
 
+	// Set DEX ctx to enable initializing dex from any page.
+	appInfo.AssetsManager.UpdateDEXCtx(win.ctx)
+
 	return win, nil
 }
 


### PR DESCRIPTION
> @dreacot: I noticed dex gets initialized immediately after the app is opened And not when the start trading button is clicked and the splash screen for dex doesn’t show because it’s initialized on the homepage.


Dex will still be initialized for existing dex users when they open the app but no longer for new users.