### PR TITLE
Added a media query fix for when the device height is less than 600.

### DIFF
--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -398,6 +398,10 @@ func (sp *startPage) welcomePage(gtx C) D {
 
 func (sp *startPage) loadingSection(gtx C) D {
 	return sp.pageLayout(gtx, func(gtx C) D {
+
+		// Media query: check if device height is less than 600
+		isSmallScreen := gtx.Constraints.Max.Y < gtx.Dp(600)
+
 		return layout.Flex{Alignment: layout.Middle, Axis: layout.Vertical}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
 				return sp.logo.LayoutSize(gtx, values.MarginPadding150)
@@ -450,8 +454,14 @@ func (sp *startPage) loadingSection(gtx C) D {
 				if sp.loading {
 					return D{}
 				}
-				inset := layout.Inset{Top: values.MarginPadding100}
-				if sp.IsMobileView() {
+
+				topMargin := values.MarginPadding100
+				if isSmallScreen {
+					topMargin = values.MarginPadding10
+				}
+				inset := layout.Inset{Top: topMargin}
+
+				if sp.IsMobileView() && !isSmallScreen {
 					inset.Top += values.MarginPadding168
 				}
 				gtx.Constraints.Min.X = gtx.Dp(values.MarginPadding350)


### PR DESCRIPTION
closes #742 
fixed rendering issue on create wallet button for small devices 
<img width="430" height="689" alt="Screenshot from 2025-08-24 22-37-51" src="https://github.com/user-attachments/assets/991506d6-65d6-429b-82ca-864167f88e54" />
