### PR TITLE
refactor: remove obsolete // +build tag

### DIFF
--- a/appos/os_android.go
+++ b/appos/os_android.go
@@ -1,5 +1,4 @@
 //go:build android
-// +build android
 
 package appos
 

--- a/appos/os_darwin.go
+++ b/appos/os_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package appos
 

--- a/appos/os_ios.go
+++ b/appos/os_ios.go
@@ -1,5 +1,4 @@
 //go:build ios
-// +build ios
 
 package appos
 

--- a/device/device_unsupported.go
+++ b/device/device_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !android && !ios
-// +build !android,!ios
 
 package device
 

--- a/libwallet/utils/disk_general.go
+++ b/libwallet/utils/disk_general.go
@@ -1,5 +1,4 @@
 //go:build linux || android || ios || darwin
-// +build linux android ios darwin
 
 package utils
 

--- a/libwallet/utils/disk_windows.go
+++ b/libwallet/utils/disk_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package utils
 


### PR DESCRIPTION
From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild